### PR TITLE
add support for static file based API

### DIFF
--- a/open_event/views/admin/models_views/event.py
+++ b/open_event/views/admin/models_views/event.py
@@ -64,6 +64,13 @@ class EventView(ModelView):
                            event_id=event_id,
                            events=events)
 
+    @expose('/<event_id>/event')
+    def event(self, event_id):
+        events = Event.query.all()
+        return self.render('admin/base1.html',
+                           event_id=event_id,
+                           events=events)
+
     @expose('/<event_id>/track')
     def event_tracks(self, event_id):
         tracks = Track.query.filter_by(event_id=event_id)

--- a/open_event/views/views.py
+++ b/open_event/views/views.py
@@ -34,6 +34,11 @@ def get_events():
 def get_event_by_id(event_id):
     return jsonify(Event.query.get(event_id).serialize)
 
+@app.route('/get/api/v1/event/<event_id>/event', methods=['GET'])
+@cross_origin()
+def get_event_by_id(event_id):
+    return jsonify(Event.query.get(event_id).serialize)
+
 
 @app.route('/get/api/v1/event/<event_id>/sessions', methods=['GET'])
 @cross_origin()


### PR DESCRIPTION
So basically why I need this support for /event/event_id/event endpoint is because if someone uses a set of static json files (instead of a hosted python server), like I am doing in my testapi for the webapp here, https://github.com/fossasia/open-event-webapp/tree/master/testapi then we cannot save a file called /event/1 if a folder called /event/1 exists. 

This makes it easy to switch from testapi/static api to the hoster python server without changing the endpoint suffix

@rafalkowalski @leto please review and merge :) 