### PR TITLE
Search events by name

### DIFF
--- a/open_event/views/views.py
+++ b/open_event/views/views.py
@@ -42,6 +42,12 @@ def get_event_by_id(event_id):
     """Returns events by event id"""
     return jsonify({"events":[Event.query.get(event_id).serialize]})
 
+@app.route('/api/v1/event/search/name/<name_search>', methods=['GET'])
+@cross_origin()
+def search_events_by_name(name_search):
+    """Returns events matching a string"""
+    # is there a SQL injection here?
+    return jsonify({"events":[Event.name.ilike('%' + name_search + '%')]})
 
 @app.route('/api/v1/event/<event_id>/sessions', methods=['GET'])
 @cross_origin()

--- a/open_event/views/views.py
+++ b/open_event/views/views.py
@@ -45,9 +45,9 @@ def get_event_by_id(event_id):
 @app.route('/api/v1/event/search/name/<name_search>', methods=['GET'])
 @cross_origin()
 def search_events_by_name(name_search):
-    """Returns events matching a string"""
-    # is there a SQL injection here?
-    return jsonify({"events":[Event.name.ilike('%' + name_search + '%')]})
+    """Returns events which have a name matching a string"""
+    matching_events = Event.query.filter( Event.name.contains(name_search) )
+    return ObjectFormatter.get_json("events", matching_events, request)
 
 @app.route('/api/v1/event/<event_id>/sessions', methods=['GET'])
 @cross_origin()


### PR DESCRIPTION
This PR implements a simple GET API method which returns all events matching the given substring on this server. It is meant as an example for more complex search queries such as #147, #146 that GCI students can use as a basis.

To test:
1) Create two events which share a substring, such as JUNKFOO and JUNKBAR
2) Run `curl http://0.0.0.0:8001/api/v1/event/search/name/JUNK` and the two events should be returned