### PR TITLE
Validate form only on POST requests

### DIFF
--- a/open_event/views/admin/models_views/event.py
+++ b/open_event/views/admin/models_views/event.py
@@ -85,8 +85,8 @@ class EventView(ModelView):
         self.name = "Event | New"
         from ....forms.admin.event_form import EventForm
         self.form = EventForm()
-        if self.form.validate():
-            if request.method == "POST":
+        if request.method == "POST":
+            if self.form.validate():
                 try:
                     DataManager.create_event(self.form)
                 except Exception as error:


### PR DESCRIPTION
Remove unnecessary validation of the Event creation form on GET requests. This makes the "required field" messages to appear even though the user has not submitted the form.
Validate form only if it is a POST request.