### PR TITLE
Fix session proposal view

### DIFF
--- a/open_event/templates/admin/model/session/list.html
+++ b/open_event/templates/admin/model/session/list.html
@@ -24,7 +24,7 @@
                         Add New <i class="glyphicon glyphicon-plus" aria-hidden="true" style="margin-right:5px"></i>
                     </a>
                     {% else %}
-                    <a href="{{ get_url('event.event_session_new', event_id=event_id )}}" class="btn btn-info" style="margin:5px">
+                    <a href="{{ get_url('event.event_session_new_proposal', event_id=event_id )}}" class="btn btn-info" style="margin:5px">
                         Send proposal <i class="glyphicon glyphicon-envelope" aria-hidden="true" style="margin-right:5px"></i>
                     </a>
                     {%endif%}

--- a/open_event/views/admin/models_views/event.py
+++ b/open_event/views/admin/models_views/event.py
@@ -238,7 +238,7 @@ class EventView(ModelView):
                            cancel_url=url_for('.event_sessions', event_id=event_id))
 
     @expose('/<event_id>/session/new_proposal', methods=('GET', 'POST'))
-    def event_session_new(self, event_id):
+    def event_session_new_proposal(self, event_id):
         """New Session proposal view"""
         events = DataGetter.get_all_events()
         form = SessionForm()


### PR DESCRIPTION
In the views, URLs `/<event_id>/session/new_proposal` and `/<event_id>/session/new` have functions defined with the same name.

In the templates, since the function names are same there is a conflict and `/<event_id>/session/new` can never be retrieved.

- Rename the function used for creating new session proposals.
- Change template to reflect the same.

