### PR TITLE
Show event switcher dropdown menu only when logged in.

### DIFF
--- a/open_event/templates/admin/menu.html
+++ b/open_event/templates/admin/menu.html
@@ -28,7 +28,7 @@
 
               <li {% if "/api" in request.path  %} class="active"{% endif %}><a href="/admin/event/{{event_id}}/api">Api</a><li></li>
             {% endif %}
-
+            {% if current_user.is_authenticated %}
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:void(0)" aria-expanded="true">Switch event<b class="caret"></b></a>
               <ul class="dropdown-menu">
@@ -42,6 +42,7 @@
                 <li><a href="{{ get_url('event.index_view')}}"><i class="glyphicon glyphicon-th-list" aria-hidden="true" style="margin-right:5px"></i>List of events</a></li>
               </ul>
             </li>
+            {% endif %}
             <!-- end Main menu -->
           </ul>
           {% endblock %}


### PR DESCRIPTION
#### The problem
The event switcher menu is shown even when the user is Unauthenticated. And clicking on any event/link in the dropdown menu takes the user back to the login page. 

So, it's better if the menu is not shown when the user is not logged it. (all the functionality the menu provides, will anyway work only if the user is logged in)

#### What does this PR do?
- Shows the event switcher menu only when the user is logged in

#### How was this tested
- Manually in a browser