### PR TITLE
Use checkboxes to display MultipleFields

### DIFF
--- a/open_event/forms/admin/session_form.py
+++ b/open_event/forms/admin/session_form.py
@@ -1,6 +1,7 @@
 """Copyright 2015 Rafal Kowalski"""
 from flask_wtf import Form
 from wtforms import StringField, TextAreaField
+from wtforms.widgets import ListWidget, CheckboxInput
 from wtforms.ext.sqlalchemy.fields import QuerySelectMultipleField, QuerySelectField
 from wtforms.validators import DataRequired
 from flask_admin.form.fields import DateTimeField
@@ -27,5 +28,9 @@ class SessionForm(Form):
     level = QuerySelectField(label='Level', query_factory=DataGetter.get_levels, allow_blank=True)
     format = QuerySelectField(label='Format', query_factory=DataGetter.get_formats, allow_blank=True)
     language = QuerySelectField(label='Language', query_factory=DataGetter.get_languages, allow_blank=True)
-    speakers = QuerySelectMultipleField(query_factory=get_speakers, allow_blank=True)
+    speakers = QuerySelectMultipleField(
+            query_factory=get_speakers,
+            widget=ListWidget(prefix_label=False),
+            option_widget=CheckboxInput()
+    )
     microlocation = QuerySelectField(label='Microlocation', query_factory=DataGetter.get_microlocations_by_event_id, allow_blank=True)

--- a/open_event/forms/admin/speaker_form.py
+++ b/open_event/forms/admin/speaker_form.py
@@ -1,10 +1,10 @@
 """Copyright 2015 Rafal Kowalski"""
 from flask_wtf import Form
 from wtforms import StringField, TextAreaField, validators
+from wtforms.widgets import ListWidget, CheckboxInput
 from wtforms.ext.sqlalchemy.fields import QuerySelectMultipleField
 from open_event.models.session import Session
 from ...helpers.helpers import get_event_id
-from flask_wtf.file import FileField
 
 def get_sessions():
     """Returns Event's Sessions"""
@@ -25,4 +25,8 @@ class SpeakerForm(Form):
     organisation = StringField('Organisation', [validators.DataRequired()])
     position = StringField('Position')
     country = StringField('Country', [validators.DataRequired()])
-    sessions = QuerySelectMultipleField(query_factory=get_sessions, allow_blank=True)
+    sessions = QuerySelectMultipleField(
+            query_factory=get_sessions,
+            widget=ListWidget(prefix_label=False),
+            option_widget=CheckboxInput()
+    )

--- a/open_event/forms/admin/track_form.py
+++ b/open_event/forms/admin/track_form.py
@@ -2,6 +2,7 @@
 from flask_wtf import Form
 from wtforms import StringField
 from wtforms.validators import Length
+from wtforms.widgets import ListWidget, CheckboxInput
 from wtforms.ext.sqlalchemy.fields import QuerySelectMultipleField
 from ...helpers.data_getter import DataGetter
 
@@ -11,4 +12,8 @@ class TrackForm(Form):
     name = StringField('Name', [Length(min=6, max=35)])
     description = StringField('Description', [Length(min=4, max=1000)])
     track_image_url = StringField('Image')
-    sessions = QuerySelectMultipleField(query_factory=DataGetter.get_sessions_by_event_id, allow_blank=True)
+    sessions = QuerySelectMultipleField(
+            query_factory=DataGetter.get_sessions_by_event_id,
+            widget=ListWidget(prefix_label=False),
+            option_widget=CheckboxInput()
+    )

--- a/open_event/static/admin/css/open-event.css
+++ b/open_event/static/admin/css/open-event.css
@@ -15,3 +15,7 @@
     margin-left: 20%;
     margin-right: 20%
 }
+
+ul.form-control {
+  display: inline;
+}


### PR DESCRIPTION
Use Check-boxes to display `Sessions` or `Speakers` fields in Speaker, Session and Track forms.

[Screenshot (new field)](http://i.imgur.com/z15mu4E.png)

The current forms use drop-down select tag that are not fit for the purpose. Selecting more than one option requires the user to hold down the shift key. [Screenshot](https://i.imgur.com/Mo1mLWz.png)

- Remove `from flask_wtf.file import FileField` from `speaker_form.py`. It was imported but not used.
- Remove `allow_blank=True` option specified in `QuerySelectMultipleField`s. It does not accept any such option [docs](https://wtforms.readthedocs.org/en/2.0.2/ext.html?highlight=queryselectmultiplefield#wtforms.ext.sqlalchemy.fields.QuerySelectMultipleField).