### PR TITLE
Specify proper labels in Login and Register forms

### DIFF
--- a/open_event/forms/admin/auth/login_form.py
+++ b/open_event/forms/admin/auth/login_form.py
@@ -7,7 +7,7 @@ from sqlalchemy import or_
 
 class LoginForm(form.Form):
     """Login Form class"""
-    login = StringField(validators=[validators.required()])
+    login = StringField(u'Username or Email', validators=[validators.required()])
     password = PasswordField(validators=[validators.required()])
 
     def __init__(self, form):

--- a/open_event/forms/admin/auth/registration_form.py
+++ b/open_event/forms/admin/auth/registration_form.py
@@ -5,7 +5,7 @@ from ....models.user import User
 
 
 class RegistrationForm(form.Form):
-    login = StringField(validators=[validators.required()])
+    login = StringField(u'Username', validators=[validators.required()])
     email = StringField(validators=[validators.email()])
     password = PasswordField(validators=[validators.required()])
 


### PR DESCRIPTION
The current Register form uses 'Login' as the field label for Username. The Login form uses 'login' as field label for Username/Email.