### PR TITLE
Use `Select2Widget` to display Select fields

### DIFF
--- a/open_event/forms/admin/session_form.py
+++ b/open_event/forms/admin/session_form.py
@@ -1,7 +1,7 @@
 """Copyright 2015 Rafal Kowalski"""
 from flask_wtf import Form
+from flask_admin.form.widgets import Select2Widget
 from wtforms import StringField, TextAreaField
-from wtforms.widgets import ListWidget, CheckboxInput
 from wtforms.ext.sqlalchemy.fields import QuerySelectMultipleField, QuerySelectField
 from wtforms.validators import DataRequired
 from flask_admin.form.fields import DateTimeField
@@ -30,7 +30,6 @@ class SessionForm(Form):
     language = QuerySelectField(label='Language', query_factory=DataGetter.get_languages, allow_blank=True)
     speakers = QuerySelectMultipleField(
             query_factory=get_speakers,
-            widget=ListWidget(prefix_label=False),
-            option_widget=CheckboxInput()
+            widget=Select2Widget(multiple=True)
     )
     microlocation = QuerySelectField(label='Microlocation', query_factory=DataGetter.get_microlocations_by_event_id, allow_blank=True)

--- a/open_event/forms/admin/speaker_form.py
+++ b/open_event/forms/admin/speaker_form.py
@@ -1,7 +1,7 @@
 """Copyright 2015 Rafal Kowalski"""
 from flask_wtf import Form
+from flask_admin.form.widgets import Select2Widget
 from wtforms import StringField, TextAreaField, validators
-from wtforms.widgets import ListWidget, CheckboxInput
 from wtforms.ext.sqlalchemy.fields import QuerySelectMultipleField
 from open_event.models.session import Session
 from ...helpers.helpers import get_event_id
@@ -27,6 +27,5 @@ class SpeakerForm(Form):
     country = StringField('Country', [validators.DataRequired()])
     sessions = QuerySelectMultipleField(
             query_factory=get_sessions,
-            widget=ListWidget(prefix_label=False),
-            option_widget=CheckboxInput()
+            widget=Select2Widget(multiple=True)
     )

--- a/open_event/forms/admin/track_form.py
+++ b/open_event/forms/admin/track_form.py
@@ -1,8 +1,8 @@
 """Copyright 2015 Rafal Kowalski"""
 from flask_wtf import Form
+from flask_admin.form.widgets import Select2Widget
 from wtforms import StringField
 from wtforms.validators import Length
-from wtforms.widgets import ListWidget, CheckboxInput
 from wtforms.ext.sqlalchemy.fields import QuerySelectMultipleField
 from ...helpers.data_getter import DataGetter
 
@@ -14,6 +14,5 @@ class TrackForm(Form):
     track_image_url = StringField('Image')
     sessions = QuerySelectMultipleField(
             query_factory=DataGetter.get_sessions_by_event_id,
-            widget=ListWidget(prefix_label=False),
-            option_widget=CheckboxInput()
+            widget=Select2Widget(multiple=True)
     )

--- a/open_event/static/admin/css/open-event.css
+++ b/open_event/static/admin/css/open-event.css
@@ -15,7 +15,3 @@
     margin-left: 20%;
     margin-right: 20%
 }
-
-ul.form-control {
-  display: inline;
-}


### PR DESCRIPTION
Use `Select2Widget` with `multiple=True` to display select fields in Session, Speaker and Track forms.

Delete changes that were added to `open-event.css` in https://github.com/fossasia/open-event-orga-server/pull/229.

Closed in favor of https://github.com/fossasia/open-event-orga-server/pull/250.