### PR TITLE
Rewrite failing tests

### DIFF
--- a/open_event/helpers/data.py
+++ b/open_event/helpers/data.py
@@ -382,7 +382,7 @@ class DataManager(object):
         password = form.password.data
         user.password = generate_password_hash(password, salt)
         hash = random.getrandbits(128)
-        user.reset_password = hash
+        user.reset_password = str(hash)
 
         user.salt = salt
         user.role = 'speaker'

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ Flask-Migrate==1.6.0
 Flask-Login==0.3.2
 flask-scrypt
 xlrd
+mock==2.0.0

--- a/tests/test_event_track.py
+++ b/tests/test_event_track.py
@@ -38,7 +38,7 @@ class TestEvent(unittest.TestCase):
                                       name='track1',
                                       description='trackdescription'),
                                   follow_redirects=True)
-            self.assertEqual(len(Track.query.all()), 2)
+            self.assertEqual(len(Track.query.all()), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -16,7 +16,8 @@ class TestDataManager(unittest.TestCase):
     def setUp(self):
         self.app = Setup.create_app()
         with app.test_request_context():
-            db.session.add(ObjectMother.get_event())
+            event = ObjectMother.get_event()
+            db.session.add(event)
             db.session.commit()
 
     def tearDown(self):

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -32,13 +32,8 @@ class TestValidation(unittest.TestCase):
         with app.test_request_context():
             self.event_form['start_time'].data = MagicMock(return_value=datetime(2015, 8, 4, 12, 30, 45))
             self.event_form['end_time'].data = MagicMock(return_value=datetime(2015, 1, 4, 12, 30, 45))
-            self.assertRaises(ValidationError, CustomDateEventValidate().__call__(form=self.event_form, field=None))
-
-    def test_event_start_time_smaller_than_end_time(self):
-        with app.test_request_context():
-            self.event_form['start_time'].data = MagicMock(return_value=datetime(2015, 8, 4, 12, 30, 45))
-            self.event_form['end_time'].data = MagicMock(return_value=datetime(2015, 9, 4, 12, 30, 45))
-            self.assertRaises(ValidationError, CustomDateEventValidate().__call__(form=self.event_form, field=None))
+            with self.assertRaises(ValidationError):
+                CustomDateEventValidate().__call__(form=self.event_form, field=None)
 
     def test_session_start_time_and_end_time_contains_in_event_date(self):
         with app.test_request_context():
@@ -52,7 +47,8 @@ class TestValidation(unittest.TestCase):
             self.session_form['start_time'].data = datetime(2015, 8, 4, 12, 30, 45)
             self.session_form['end_time'].data = datetime(2014, 9, 4, 12, 30, 45)
             request.url = 'http://0.0.0.0:5000/admin/event/1'
-            self.assertRaises(ValidationError, CustomDateSessionValidate().__call__(form=self.session_form, field=None))
+            with self.assertRaises(ValidationError):
+                CustomDateSessionValidate().__call__(form=self.session_form, field=None)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Specify `mock2.0.0` to be a requirement in `requirements.txt`. It is being used in validation tests (`test_validations.py`).
- Typecast `hash` to string during user creation in `helpers/data.py`. `User.reset_password` inside models has been defined a string.
- Track count (`len(Track.query.all())`) inside `text_event_track.py` would be `1`.
- Use `assertRaises()` correctly.
- Remove `test_event_start_time_smaller_than_end_time` test from `test_validations.py`. No validation error is raised for start time smaller than end time.