### PR TITLE
Fix 404 errors for Flask-Admin static assets

### DIFF
--- a/open_event/templates/admin/base1.html
+++ b/open_event/templates/admin/base1.html
@@ -44,9 +44,9 @@
     {% endblock %}
 
     {% block tail_js %}
-    <script src="{{ admin_static.url(filename='vendor/jquery-2.1.1.min.js') }}" type="text/javascript"></script>
+    <script src="{{ admin_static.url(filename='vendor/jquery.min.js') }}" type="text/javascript"></script>
     <script src="{{ admin_static.url(filename='bootstrap/bootstrap3/js/bootstrap.min.js') }}" type="text/javascript"></script>
-    <script src="{{ admin_static.url(filename='vendor/moment-2.8.4.min.js') }}" type="text/javascript"></script>
+    <script src="{{ admin_static.url(filename='vendor/moment.min.js') }}" type="text/javascript"></script>
     <script src="{{ admin_static.url(filename='vendor/select2/select2.min.js') }}" type="text/javascript"></script>
     <script src="{{ url_for('static', filename='admin/lib/jquery-migrate/jquery-migrate.min.js') }}" type="text/javascript"></script>
     <script src="{{ url_for('static', filename='admin/lib/bootstrap-material-design/dist/js/material.min.js')}}"></script>

--- a/open_event/templates/admin/lib.html
+++ b/open_event/templates/admin/lib.html
@@ -191,5 +191,5 @@
   {% if editable_columns %}
   <script src="{{ admin_static.url(filename='vendor/x-editable/js/bootstrap3-editable-1.5.1.min.js') }}"></script>
   {% endif %}
-  <script src="{{ admin_static.url(filename='admin/js/form-1.0.0.js') }}"></script>
+  <script src="{{ admin_static.url(filename='admin/js/form.js') }}"></script>
 {% endmacro %}


### PR DESCRIPTION
After Flask-Admin upgrade from 1.1.0 to 1.4.0: `vendor/jquery-2.1.1.min.js` is now at `vendor/jquery.min.js`, `vendor/moment-2.8.4.min.js` at `vendor/moment.min.js` and `admin/js/form-1.0.0.js` at `admin/js/form.js`.