### PR TITLE
Fixes event deletion

### DIFF
--- a/open_event/helpers/data.py
+++ b/open_event/helpers/data.py
@@ -461,6 +461,11 @@ class DataManager(object):
     @staticmethod
     def delete_event(e_id):
         EventsUsers.query.filter_by(event_id=e_id).delete()
+        Sponsor.query.filter_by(id=e_id).delete()
+        Speaker.query.filter_by(id=e_id).delete()
+        Microlocation.query.filter_by(id=e_id).delete()
+        Track.query.filter_by(id=e_id).delete()
+        Session.query.filter_by(id=e_id).delete()
         Event.query.filter_by(id=e_id).delete()
         db.session.commit()
 


### PR DESCRIPTION
Events could not be deleted if sponsor,microlocation,tracks or sessions were created because they were not being deleted from their respective tables before the event was deleted.
