### PR TITLE
Minor `DebugToolbarExtension` fix

### DIFF
--- a/open_event/__init__.py
+++ b/open_event/__init__.py
@@ -22,13 +22,11 @@ from open_event.views.admin.admin import AdminView
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 app = Flask(__name__)
-toolbar = DebugToolbarExtension(app)
 
 def create_app():
     auto = Autodoc(app)
     cal = Calendar()
     event = Event()
-   
 
     from open_event.views.views import app as routes
     app.register_blueprint(routes)
@@ -47,9 +45,7 @@ def create_app():
     app.config['STATIC_URL'] = '/static/'
     app.config['STATIC_ROOT'] = 'staticfiles'
     app.config['STATICFILES_DIRS'] = (os.path.join(BASE_DIR, 'static'),)
-    app.config['DEBUG_TB_ENABLED']=True
     app.config['SQLALCHEMY_RECORD_QUERIES'] = True
-    app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = False
     app.logger.addHandler(logging.StreamHandler(sys.stdout))
     app.logger.setLevel(logging.INFO)
     # logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
@@ -57,6 +53,12 @@ def create_app():
     admin_view = AdminView("Open Event")
     admin_view.init(app)
     admin_view.init_login(app)
+
+    # Flask-DebugToolbar Configuration
+    # Set DEBUG_TB_ENABLED as False in Production
+    app.config['DEBUG_TB_ENABLED'] = True
+    app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = False
+    DebugToolbarExtension(app)
 
     return app, manager, db
 
@@ -77,4 +79,3 @@ def request_wants_json():
         request.accept_mimetypes['text/html']
 
 current_app, manager, database = create_app()
-toolbar.init_app(current_app)


### PR DESCRIPTION
- Remove re-initialization (`toolbar.init_app(current_app)`) of debug toolbar. It is already initialized during `DebugToolbarExtension(app)`
- Group toolbar config and add comments

@leto Please take a look. It just brings minor changes and does not require tests.