### PR TITLE
Update track API

### DIFF
--- a/open_event/models/track.py
+++ b/open_event/models/track.py
@@ -12,7 +12,8 @@ class Track(db.Model):
     sessions = db.relationship('Session', backref='track', lazy='dynamic')
     event_id = db.Column(db.Integer, db.ForeignKey('events.id'))
 
-    def __init__(self, name=None, description=None, event_id=None, session=None, track_image_url=None):
+    def __init__(self, name=None, description=None, event_id=None,
+                 session=None, track_image_url=None):
         self.name = name
         self.description = description
         self.event_id = event_id
@@ -28,7 +29,12 @@ class Track(db.Model):
     @property
     def serialize(self):
         """Return object data in easily serializeable format"""
-        return {'id': self.id,
-                'name': self.name,
-                'description': self.description,
-                'track_image_url': self.track_image_url}
+        sessions = [{'id': session.id, 'title': session.title}
+                    for session in self.sessions]
+        return {
+            'id': self.id,
+            'name': self.name,
+            'description': self.description,
+            'sessions': sessions,
+            'track_image_url': self.track_image_url,
+        }


### PR DESCRIPTION
Add `sessions` key to the API. It is a list of sessions each having an `id` and a `title`.

@leto The Coverall coverage and CircleCI build are failing because they're not configured. I've opened an issue [here](https://github.com/fossasia/open-event-orga-server/issues/284).