### PR TITLE
Fix unicode handling at models

### DIFF
--- a/open_event/models/event.py
+++ b/open_event/models/event.py
@@ -60,8 +60,7 @@ class Event(db.Model):
                  email=None,
                  color=None,
                  slogan=None,
-                 url=None,
-                 ):
+                 url=None):
         self.name = name
         self.logo = logo
         self.email = email
@@ -79,22 +78,25 @@ class Event(db.Model):
         return '<Event %r>' % self.name
 
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         return self.name
 
     @property
     def serialize(self):
         """Return object data in easily serializeable format"""
-        return {'id': self.id,
-                           'name': self.name,
-                           'logo': self.logo,
-                           'begin':
-                               DateFormatter().format_date(self.start_time),
-                           'end':
-                               DateFormatter().format_date(self.end_time),
-                           'latitude': self.latitude,
-                           'longitude': self.longitude,
-                           'location_name': self.location_name,
-                           'email': self.email,
-                           'color': self.color.get_hex() if self.color else '',
-                           'slogan': self.slogan,
-                           'url': self.url}
+        return {
+            'id': self.id,
+            'name': self.name,
+            'logo': self.logo,
+            'begin': DateFormatter().format_date(self.start_time),
+            'end': DateFormatter().format_date(self.end_time),
+            'latitude': self.latitude,
+            'longitude': self.longitude,
+            'location_name': self.location_name,
+            'email': self.email,
+            'color': self.color.get_hex() if self.color else '',
+            'slogan': self.slogan,
+            'url': self.url
+        }

--- a/open_event/models/file.py
+++ b/open_event/models/file.py
@@ -10,7 +10,7 @@ class File(db.Model):
     name = db.Column(db.String,
                      nullable=False)
     path = db.Column(db.String,
-                         nullable=False)
+                     nullable=False)
     owner_id = db.Column(db.Integer,
                          db.ForeignKey('user.id'))
 
@@ -26,4 +26,7 @@ class File(db.Model):
         return '<File %r>' % self.name
 
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         return self.name

--- a/open_event/models/microlocation.py
+++ b/open_event/models/microlocation.py
@@ -36,14 +36,19 @@ class Microlocation(db.Model):
         return '<Microlocation %r>' % self.name
 
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         return self.name
 
     @property
     def serialize(self):
         """Return object data in easily serializeable format"""
-        return {'id': self.id,
-                'name': self.name,
-                'latitude': self.latitude,
-                'longitude': self.longitude,
-                'floor': self.floor,
-                'room': self.room}
+        return {
+            'id': self.id,
+            'name': self.name,
+            'latitude': self.latitude,
+            'longitude': self.longitude,
+            'floor': self.floor,
+            'room': self.room
+        }

--- a/open_event/models/session.py
+++ b/open_event/models/session.py
@@ -1,16 +1,12 @@
 """Copyright 2015 Rafal Kowalski"""
 from . import db
-from .track import Track
 from open_event.helpers.date_formatter import DateFormatter
 
-
 speakers_sessions = db.Table('speakers_sessions',
-                    db.Column('speaker_id',
-                              db.Integer,
-                              db.ForeignKey('speaker.id')),
-                    db.Column('session_id',
-                              db.Integer,
-                              db.ForeignKey('session.id')))
+                             db.Column('speaker_id', db.Integer,
+                                       db.ForeignKey('speaker.id')),
+                             db.Column('session_id', db.Integer,
+                                       db.ForeignKey('session.id')))
 
 
 class Level(db.Model):
@@ -43,7 +39,11 @@ class Level(db.Model):
         return '<Level %r>' % (self.name)
 
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         return self.name
+
 
 class Format(db.Model):
     """Format model class"""
@@ -75,7 +75,11 @@ class Format(db.Model):
         return '<Format %r>' % (self.name)
 
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         return self.name
+
 
 class Language(db.Model):
     """Language model class"""
@@ -111,8 +115,10 @@ class Language(db.Model):
         return '<Language %r>' % (self.name)
 
     def __str__(self):
-        return self.name
+        return unicode(self).encode('utf-8')
 
+    def __unicode__(self):
+        return self.name
 
 
 class Session(db.Model):
@@ -130,16 +136,15 @@ class Session(db.Model):
     track_id = db.Column(db.Integer, db.ForeignKey('tracks.id'))
     speakers = db.relationship('Speaker',
                                secondary=speakers_sessions,
-                               backref=db.backref('sessions',
-                                                  lazy='dynamic'))
+                               backref=db.backref('sessions', lazy='dynamic'))
     level_id = db.Column(db.Integer,
                          db.ForeignKey('level.id'))
     format_id = db.Column(db.Integer,
-                         db.ForeignKey('format.id'))
+                          db.ForeignKey('format.id'))
     language_id = db.Column(db.Integer,
-                         db.ForeignKey('language.id'))
+                            db.ForeignKey('language.id'))
     microlocation_id = db.Column(db.Integer,
-                         db.ForeignKey('microlocation.id'))
+                                 db.ForeignKey('microlocation.id'))
 
     event_id = db.Column(db.Integer,
                          db.ForeignKey('events.id'))
@@ -176,24 +181,40 @@ class Session(db.Model):
     @property
     def serialize(self):
         """Return object data in easily serializeable format"""
-        return {'id': self.id,
-                'title': self.title,
-                'subtitle': self.subtitle,
-                'abstract': self.abstract,
-                'description': self.description,
-                'begin': DateFormatter().format_date(self.start_time),
-                'end': DateFormatter().format_date(self.end_time),
-                'format': {'id': self.format.name, 'label_en': self.format.label_en} if self.format else None,
-                'track': self.track.id if self.track else None,
-                'speakers': [{'id': speaker.id, 'name': speaker.name} for speaker in self.speakers],
-                'level': {'id': self.level.name, 'label_en': self.level.label_en} if self.level else None,
-                'lang': {'id': self.language.name, 'label_en': self.language.label_en, 'label_de': self.language.label_de} if self.language else None,
-                'microlocation': self.microlocation.id if self.microlocation else None}
+        return {
+            'id': self.id,
+            'title': self.title,
+            'subtitle': self.subtitle,
+            'abstract': self.abstract,
+            'description': self.description,
+            'begin': DateFormatter().format_date(self.start_time),
+            'end': DateFormatter().format_date(self.end_time),
+            'format': {
+                'id': self.format.name,
+                'label_en': self.format.label_en
+            } if self.format else None,
+            'track': self.track.id if self.track else None,
+            'speakers': [
+                {'id': speaker.id, 'name': speaker.name}
+                for speaker in self.speakers
+            ],
+            'level': {
+                'id': self.level.name,
+                'label_en': self.level.label_en
+            } if self.level else None,
+            'lang': {
+                'id': self.language.name,
+                'label_en': self.language.label_en,
+                'label_de': self.language.label_de
+            } if self.language else None,
+            'microlocation': self.microlocation.id if self.microlocation else None
+        }
 
     def __repr__(self):
         return '<Session %r>' % self.title
 
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         return self.title
-
-

--- a/open_event/models/speaker.py
+++ b/open_event/models/speaker.py
@@ -52,25 +52,31 @@ class Speaker(db.Model):
         return '<Speaker %r>' % self.name
 
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         return self.name
 
     @property
     def serialize(self):
         """Return object data in easily serializeable format"""
 
-        session_data = [ { 'title': session.title, 'id': session.id } for session in self.sessions ]
+        session_data = [{'title': session.title, 'id': session.id}
+                        for session in self.sessions]
 
-        return {'id': self.id,
-                'name': self.name,
-                'photo': self.photo,
-                'biography': self.biography,
-                'email': self.email,
-                'web': self.web,
-                'twitter': self.twitter,
-                'facebook': self.facebook,
-                'github': self.github,
-                'linkedin': self.linkedin,
-                'organisation': self.organisation,
-                'position': self.position,
-                'country': self.country,
-                'sessions': session_data  }
+        return {
+            'id': self.id,
+            'name': self.name,
+            'photo': self.photo,
+            'biography': self.biography,
+            'email': self.email,
+            'web': self.web,
+            'twitter': self.twitter,
+            'facebook': self.facebook,
+            'github': self.github,
+            'linkedin': self.linkedin,
+            'organisation': self.organisation,
+            'position': self.position,
+            'country': self.country,
+            'sessions': session_data
+        }

--- a/open_event/models/sponsor.py
+++ b/open_event/models/sponsor.py
@@ -21,12 +21,17 @@ class Sponsor(db.Model):
         return '<Sponsor %r>' % self.name
 
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         return self.name
 
     @property
     def serialize(self):
         """Return object data in easily serializeable format"""
-        return {'id': self.id,
-                'name': self.name,
-                'url': self.url,
-                'logo': self.logo}
+        return {
+            'id': self.id,
+            'name': self.name,
+            'url': self.url,
+            'logo': self.logo
+        }

--- a/open_event/models/track.py
+++ b/open_event/models/track.py
@@ -24,6 +24,9 @@ class Track(db.Model):
         return '<Track %r>' % self.name
 
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         return self.name
 
     @property

--- a/open_event/models/version.py
+++ b/open_event/models/version.py
@@ -33,12 +33,6 @@ class Version(db.Model):
     def __repr__(self):
         return '<Version %r>' % self.id
 
-    def __str__(self):
-        return unicode(self).encode('utf-8')
-
-    def __unicode__(self):
-        return self.id
-
     @property
     def serialize(self):
         """Return object data in easily serializeable format"""

--- a/open_event/models/version.py
+++ b/open_event/models/version.py
@@ -34,17 +34,23 @@ class Version(db.Model):
         return '<Version %r>' % self.id
 
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         return self.id
 
     @property
     def serialize(self):
         """Return object data in easily serializeable format"""
-        return {"version":
-                    [{'id': self.id,
-                      'event_id': self.event_id,
-                      'event_ver': self.event_ver,
-                      'session_ver': self.session_ver,
-                      'speakers_ver': self.speakers_ver,
-                      'tracks_ver': self.tracks_ver,
-                      'sponsors_ver': self.sponsors_ver,
-                      'microlocations_ver': self.microlocations_ver}]}
+        return {
+            'version': [
+                {'id': self.id,
+                 'event_id': self.event_id,
+                 'event_ver': self.event_ver,
+                 'session_ver': self.session_ver,
+                 'speakers_ver': self.speakers_ver,
+                 'tracks_ver': self.tracks_ver,
+                 'sponsors_ver': self.sponsors_ver,
+                 'microlocations_ver': self.microlocations_ver}
+            ]
+        }

--- a/tests/test_model_unicode.py
+++ b/tests/test_model_unicode.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+import unittest
+
+from tests.setup_database import Setup
+from tests.utils import OpenEventTestCase
+
+from open_event import current_app as app
+from open_event.helpers.data import save_to_db
+from open_event.models.event import Event
+from open_event.models.session import Session, Level, Format, Language
+from open_event.models.speaker import Speaker
+from open_event.models.sponsor import Sponsor
+from open_event.models.microlocation import Microlocation
+
+UNICODE_STRING = u'☺'
+
+
+class TestModelUnicode(OpenEventTestCase):
+    """
+    Tests for unicode handling in models
+    """
+    def setUp(self):
+        self.app = Setup.create_app()
+        with app.test_request_context():
+            event = Event(name=UNICODE_STRING,
+                          start_time=datetime(2013, 8, 4, 12, 30, 45),
+                          end_time=datetime(2016, 9, 4, 12, 30, 45))
+            event.owner = 1
+
+            microlocation = Microlocation(name=UNICODE_STRING)
+            level = Level(name=UNICODE_STRING, event_id=1)
+            session_format = Format(name=UNICODE_STRING, label_en='label',
+                                    event_id=1)
+            language = Language(name=UNICODE_STRING, event_id=1)
+            session = Session(title=UNICODE_STRING, description='descp',
+                              start_time=datetime(2014, 8, 4, 12, 30, 45),
+                              end_time=datetime(2015, 9, 4, 12, 30, 45))
+            speaker = Speaker(name=UNICODE_STRING, email='email@eg.com',
+                              organisation='org', country='japan')
+            sponsor = Sponsor(name=UNICODE_STRING)
+
+            save_to_db(event, "Event saved")
+            save_to_db(microlocation, 'Microlocation saved')
+            save_to_db(level, 'Level saved')
+            save_to_db(session_format, 'Format saved')
+            save_to_db(language, 'Language saved')
+            save_to_db(session, 'Session saved')
+            save_to_db(speaker, 'Speaker saved')
+            save_to_db(sponsor, 'Sponsor saved')
+
+    def test_event_name(self):
+        """Unicode handling for Event model"""
+        with app.test_request_context():
+            try:
+                str(Event.query.get(1))
+            except UnicodeEncodeError:
+                self.fail('UnicodeEncodeError for event')
+
+    def test_microlocation_name(self):
+        """Unicode handling for Microlocation model"""
+        with app.test_request_context():
+            try:
+                str(Microlocation.query.get(1))
+            except UnicodeEncodeError:
+                self.fail('UnicodeEncodeError for microlocation')
+
+    def test_level_name(self):
+        """Unicode handling for Level model"""
+        with app.test_request_context():
+            try:
+                str(Level.query.get(1))
+            except UnicodeEncodeError:
+                self.fail('UnicodeEncodeError for level')
+
+    def test_format_name(self):
+        """Unicode handling for Format model"""
+        with app.test_request_context():
+            try:
+                str(Format.query.get(1))
+            except UnicodeEncodeError:
+                self.fail('UnicodeEncodeError for format')
+
+    def test_language_name(self):
+        """Unicode handling for Language model"""
+        with app.test_request_context():
+            try:
+                str(Language.query.get(1))
+            except UnicodeEncodeError:
+                self.fail('UnicodeEncodeError for language')
+
+    def test_session_title(self):
+        """Unicode handling for Session model"""
+        with app.test_request_context():
+            try:
+                str(Session.query.get(1))
+            except UnicodeEncodeError:
+                self.fail('UnicodeEncodeError for session')
+
+    def test_sponsor_name(self):
+        """Unicode handling for Sponsor model"""
+        with app.test_request_context():
+            try:
+                str(Sponsor.query.get(1))
+            except UnicodeEncodeError:
+                self.fail('UnicodeEncodeError for sponsor')
+
+    def test_speaker_name(self):
+        """Unicode handling for Speaker model"""
+        with app.test_request_context():
+            try:
+                str(Speaker.query.get(1))
+            except UnicodeEncodeError:
+                self.fail('UnicodeEncodeError for speaker')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/fossasia/open-event-orga-server/issues/313 and solves linting issues for all models.

I did not know what type of tests to add. I had never seen tests for `__unicode__()` and `__str__()` methods. So I just added tests that check `str(model)` for `UnicodeEncodeError` like it was being raised in the issue I described.