### PR TITLE
Remove SQLALCHEMY_TRACK_MODIFICATIONS warning

### DIFF
--- a/open_event/__init__.py
+++ b/open_event/__init__.py
@@ -15,7 +15,6 @@ from flask import request
 from icalendar import Calendar, Event
 from flask_debugtoolbar import DebugToolbarExtension
 
-import open_event.models.event_listeners
 from open_event.models import db
 from open_event.views.admin.admin import AdminView
 
@@ -33,13 +32,13 @@ def create_app():
     app.register_blueprint(routes)
     migrate = Migrate(app, db)
 
+    app.config.from_object('config.ProductionConfig')
     db.init_app(app)
     manager = Manager(app)
     manager.add_command('db', MigrateCommand)
 
     cors = CORS(app)
     app.secret_key = 'super secret key'
-    app.config.from_object('config.ProductionConfig')
     # app.config.from_object('config.LocalSQLITEConfig')
     app.config['UPLOADS_FOLDER'] = os.path.realpath('.') + '/static/'
     app.config['FILE_SYSTEM_STORAGE_FILE_VIEW'] = 'static'


### PR DESCRIPTION
Patch for https://github.com/fossasia/open-event-orga-server/issues/314

You can actually see this in the travis build. Here's an older build with the warning: https://travis-ci.org/fossasia/open-event-orga-server/builds/129056237#L713

And the build down below doesn't have it. [Link](https://travis-ci.org/fossasia/open-event-orga-server/builds/130246834)