### PR TITLE
Segregate requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: "pip install -r requirements/tests.txt"
 # command to run tests
 script: nosetests --with-coverage
 # upload coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ USER root
 
 RUN export DATABASE_URL=postgresql://open_event_user:start@localhost:5432/test
 #install dependencies
-RUN pip install -r requirements.txt
+RUN pip install -r requirements/prod.txt
 #create db
 RUN python create_db.py
 #set environment

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Now you are inside a synced up copy of the project directory. if you do `ls`, th
 * Before running the app , install the requirements from 
 requirements.txt .
 ```
-pip install -r requirements.txt
+pip install -r requirements/dev.txt
 ```
 * Time to run the app, if the DB migrations went well, then doing this will be okay
 ```

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ export DATABASE_URL=postgresql://$APP_DB_USER:$APP_DB_PASS@localhost:5432/$APP_D
 cd /vagrant
 #Flask
 echo "Installing requirements"
-pip install -r requirements.txt
+pip install -r requirements/dev.txt
 
 python create_db.py
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,22 +21,3 @@ xlrd
 mock
 SQLAlchemy-Utils
 cryptography==1.3.2
-
-# these prevent SSL warnings in urllib3
-pyopenssl
-ndg-httpsclient
-pyasn1
-
-# dev
-livereload==2.4.1
-nose==1.3.7
-coverage==4.0.3
-pylint==1.5.5
-pep8==1.7.0
-glob2==0.4.1
-coveralls==1.1.0
-codeclimate-test-reporter==0.1.1
-
-# deploy
-gunicorn==19.5.0
-Fabric==1.11.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,13 @@
+-r common.txt
+
+nose==1.3.7
+livereload==2.4.1
+glob2==0.4.1
+
+pylint==1.5.5
+pep8==1.7.0
+
+# these prevent SSL warnings in urllib3
+pyopenssl
+ndg-httpsclient
+pyasn1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,4 @@
+-r common.txt
+
+gunicorn==19.5.0
+Fabric==1.11.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,0 +1,5 @@
+-r dev.txt
+
+coverage==4.0.3
+coveralls==1.1.0
+codeclimate-test-reporter==0.1.1


### PR DESCRIPTION
Fix for https://github.com/fossasia/open-event-orga-server/issues/318

Updates README, travis.yml, Dockerfile and install.sh. Specifying requirements file for each.

`travis.yml`: requirements/tests.txt
`install.sh`: requirements/dev.txt
`Dockerfile`: requirements/prod.txt