### PR TITLE
return 404 status in API where applicable, prevent api view crashes on invalid input

### DIFF
--- a/open_event/helpers/data_getter.py
+++ b/open_event/helpers/data_getter.py
@@ -187,14 +187,14 @@ class DataGetter:
     @staticmethod
     def get_event(event_id):
         """Get event by id, None if it doesn't exist"""
-        return Event.query.filter_by(id=event_id).first()
+        return Event.query.get(event_id)
 
     @staticmethod
     def get_session(session_id):
         """Get session by id"""
-        return Session.query.filter_by(id=session_id).first()
+        return Session.query.get(session_id)
 
     @staticmethod
     def get_speaker(speaker_id):
         """Get speaker by id"""
-        return Speaker.query.filter_by(id=speaker_id).first()
+        return Speaker.query.get(speaker_id)

--- a/open_event/helpers/data_getter.py
+++ b/open_event/helpers/data_getter.py
@@ -183,3 +183,18 @@ class DataGetter:
     @staticmethod
     def get_object(db_model, object_id):
         return db_model.query.get(object_id)
+
+    @staticmethod
+    def get_event(event_id):
+        """Check if event with the id exists"""
+        return Event.query.filter_by(id=event_id).first()
+
+    @staticmethod
+    def get_session(session_id):
+        """Check if session with the id exists"""
+        return Session.query.filter_by(id=session_id).first()
+
+    @staticmethod
+    def get_speaker(speaker_id):
+        """Get speaker with id"""
+        return Speaker.query.filter_by(id=speaker_id).first()

--- a/open_event/helpers/data_getter.py
+++ b/open_event/helpers/data_getter.py
@@ -186,15 +186,15 @@ class DataGetter:
 
     @staticmethod
     def get_event(event_id):
-        """Check if event with the id exists"""
+        """Get event by id, None if it doesn't exist"""
         return Event.query.filter_by(id=event_id).first()
 
     @staticmethod
     def get_session(session_id):
-        """Check if session with the id exists"""
+        """Get session by id"""
         return Session.query.filter_by(id=session_id).first()
 
     @staticmethod
     def get_speaker(speaker_id):
-        """Get speaker with id"""
+        """Get speaker by id"""
         return Speaker.query.filter_by(id=speaker_id).first()

--- a/open_event/helpers/object_formatter.py
+++ b/open_event/helpers/object_formatter.py
@@ -21,6 +21,8 @@ class ObjectFormatter(object):
                     for table_object in
                     objects]})
         else:
+            if count <= ((page-1) * PER_PAGE):  # no results possible
+                return jsonify({})
             pagination = objects.paginate(page, PER_PAGE)
             return jsonify({
                 name: [

--- a/open_event/views/views.py
+++ b/open_event/views/views.py
@@ -45,7 +45,10 @@ def get_events():
 @cross_origin()
 def get_events_per_page(page):
     """Returns 20 events per page"""
-    return ObjectFormatter.get_json("events", Event.query, request, page)
+    return api_response(
+        data=ObjectFormatter.get_json("events", Event.query, request, page),
+        check_data=True
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>', methods=['GET'])
@@ -107,7 +110,8 @@ def get_sessions_per_page(event_id, page):
     return api_response(
         data=ObjectFormatter.get_json("sessions", sessions, request, page),
         status_code=event_status_code(event_id),
-        error='Event'
+        error='Event',
+        check_data=True
     )
 
 
@@ -133,7 +137,8 @@ def get_tracks_per_page(event_id, page):
     return api_response(
         data=ObjectFormatter.get_json("tracks", tracks, request, page),
         status_code=event_status_code(event_id),
-        error='Event'
+        error='Event',
+        check_data=True
     )
 
 
@@ -173,7 +178,8 @@ def get_speakers_per_page(event_id, page):
     return api_response(
         data=ObjectFormatter.get_json("speakers", speakers, request, page),
         status_code=event_status_code(event_id),
-        error='Event'
+        error='Event',
+        check_data=True
     )
 
 
@@ -199,7 +205,8 @@ def get_sponsors_per_page(event_id, page):
     return api_response(
         data=ObjectFormatter.get_json("sponsors", sponsors, request, page),
         status_code=event_status_code(event_id),
-        error='Event'
+        error='Event',
+        check_data=True
     )
 
 
@@ -225,7 +232,8 @@ def get_levels_per_page(event_id, page):
     return api_response(
         data=ObjectFormatter.get_json("levels", levels, request, page),
         status_code=event_status_code(event_id),
-        error='Event'
+        error='Event',
+        check_data=True
     )
 
 
@@ -251,7 +259,8 @@ def get_formatsper_page(event_id, page):
     return api_response(
         data=ObjectFormatter.get_json("formats", formats, request, page),
         status_code=event_status_code(event_id),
-        error='Event'
+        error='Event',
+        check_data=True
     )
 
 
@@ -276,7 +285,8 @@ def get_languages_per_page(event_id, page):
     return api_response(
         data=ObjectFormatter.get_json("languages", languages, request, page),
         status_code=event_status_code(event_id),
-        error='Event'
+        error='Event',
+        check_data=True
     )
 
 
@@ -302,7 +312,8 @@ def get_microlocations_per_page(event_id, page):
     return api_response(
         data=ObjectFormatter.get_json("microlocations", microlocations, request, page),
         status_code=event_status_code(event_id),
-        error='Event'
+        error='Event',
+        check_data=True
     )
 
 

--- a/open_event/views/views.py
+++ b/open_event/views/views.py
@@ -12,7 +12,7 @@ from ..models.session import Session, Level, Format, Language
 from ..models.version import Version
 from ..helpers.object_formatter import ObjectFormatter
 from ..helpers.data_getter import DataGetter
-from views_helpers import event_status_code
+from views_helpers import event_status_code, api_response
 from flask import Blueprint
 from flask.ext.autodoc import Autodoc
 from icalendar import Calendar
@@ -56,7 +56,10 @@ def get_event_by_id(event_id):
     event = DataGetter.get_event(event_id)
     if event:
         return jsonify({"events": event.serialize})
-    return jsonify({"events": {}}), 404
+    return api_response(
+        status_code=404,
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/search/name/<name_search>', methods=['GET'])
@@ -74,8 +77,11 @@ def search_events_by_name(name_search):
 def get_sessions(event_id):
     """Returns all event's sessions"""
     sessions = Session.query.filter_by(event_id=event_id, is_accepted=True)
-    return ObjectFormatter.get_json("sessions", sessions, request), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("sessions", sessions, request),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/sessions/<int:session_id>', methods=['GET'])
@@ -86,7 +92,10 @@ def get_session_by_id(session_id):
     session = DataGetter.get_session(session_id)
     if session:
         return jsonify(session.serialize)
-    return jsonify({}), 404
+    return api_response(
+        status_code=404,
+        error='Session'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/sessions/page/<int:page>', methods=['GET'])
@@ -95,8 +104,11 @@ def get_session_by_id(session_id):
 def get_sessions_per_page(event_id, page):
     """Returns 20 event's sessions"""
     sessions = Session.query.filter_by(event_id=event_id, is_accepted=True)
-    return ObjectFormatter.get_json("sessions", sessions, request, page), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("sessions", sessions, request, page),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/tracks', methods=['GET'])
@@ -105,8 +117,11 @@ def get_sessions_per_page(event_id, page):
 def get_tracks(event_id):
     """Returns all event's tracks"""
     tracks = Track.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("tracks", tracks, request), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("tracks", tracks, request),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/tracks/page/<int:page>', methods=['GET'])
@@ -115,8 +130,11 @@ def get_tracks(event_id):
 def get_tracks_per_page(event_id, page):
     """Returns 20 event's tracks"""
     tracks = Track.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("tracks", tracks, request, page), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("tracks", tracks, request, page),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/speakers', methods=['GET'])
@@ -125,8 +143,11 @@ def get_tracks_per_page(event_id, page):
 def get_speakers(event_id):
     """Returns all event's speakers"""
     speakers = Speaker.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("speakers", speakers, request), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("speakers", speakers, request),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/speakers/<int:speaker_id>', methods=['GET'])
@@ -137,7 +158,10 @@ def get_speaker_by_id(speaker_id):
     speaker = DataGetter.get_speaker(speaker_id)
     if speaker:
         return jsonify(speaker.serialize)
-    return jsonify({}), 404
+    return api_response(
+        status_code=404,
+        error='Speaker'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/speakers/page/<int:page>', methods=['GET'])
@@ -146,8 +170,11 @@ def get_speaker_by_id(speaker_id):
 def get_speakers_per_page(event_id, page):
     """Returns 20 event's speakers"""
     speakers = Speaker.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("speakers", speakers, request, page), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("speakers", speakers, request, page),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/sponsors', methods=['GET'])
@@ -156,8 +183,11 @@ def get_speakers_per_page(event_id, page):
 def get_sponsors(event_id):
     """Returns all event's sponsors"""
     sponsors = Sponsor.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("sponsors", sponsors, request), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("sponsors", sponsors, request),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/sponsors/page/<int:page>', methods=['GET'])
@@ -166,8 +196,11 @@ def get_sponsors(event_id):
 def get_sponsors_per_page(event_id, page):
     """Returns 20 event's sponsors"""
     sponsors = Sponsor.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("sponsors", sponsors, request, page), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("sponsors", sponsors, request, page),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/levels', methods=['GET'])
@@ -176,8 +209,11 @@ def get_sponsors_per_page(event_id, page):
 def get_levels(event_id):
     """Returns all event's levels"""
     levels = Level.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("levels", levels, request), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("levels", levels, request),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/levels/page/<int:page>', methods=['GET'])
@@ -186,8 +222,11 @@ def get_levels(event_id):
 def get_levels_per_page(event_id, page):
     """Returns 20 event's levels"""
     levels = Level.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("levels", levels, request, page), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("levels", levels, request, page),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/formats', methods=['GET'])
@@ -196,8 +235,11 @@ def get_levels_per_page(event_id, page):
 def get_formats(event_id):
     """Returns all event's formats"""
     formats = Format.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("formats", formats, request), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("formats", formats, request),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/formats/page/<int:page>', methods=['GET'])
@@ -206,8 +248,11 @@ def get_formats(event_id):
 def get_formatsper_page(event_id, page):
     """Returns 20 event's formats"""
     formats = Format.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("formats", formats, request, page), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("formats", formats, request, page),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/languages', methods=['GET'])
@@ -215,8 +260,11 @@ def get_formatsper_page(event_id, page):
 def get_languages(event_id):
     """Returns all event's languages"""
     languages = Language.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("languages", languages, request), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("languages", languages, request),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/languages/page/<int:page>', methods=['GET'])
@@ -225,8 +273,11 @@ def get_languages(event_id):
 def get_languages_per_page(event_id, page):
     """Returns 20 event's languages"""
     languages = Language.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("languages", languages, request, page), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("languages", languages, request, page),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/microlocations', methods=['GET'])
@@ -235,8 +286,11 @@ def get_languages_per_page(event_id, page):
 def get_microlocations(event_id):
     """Returns all event's microlocations"""
     microlocations = Microlocation.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("microlocations", microlocations, request), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("microlocations", microlocations, request),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/microlocations/page/<int:page>', methods=['GET'])
@@ -245,8 +299,11 @@ def get_microlocations(event_id):
 def get_microlocations_per_page(event_id, page):
     """Returns 20 event's microlocations"""
     microlocations = Microlocation.query.filter_by(event_id=event_id)
-    return ObjectFormatter.get_json("microlocations", microlocations, request, page), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("microlocations", microlocations, request, page),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/version', methods=['GET'])
@@ -257,7 +314,10 @@ def get_versions():
     version = Version.query.order_by(Version.id.desc()).first()
     if version:
         return jsonify(version.serialize)
-    return jsonify({"version": []}), 404
+    return api_response(
+        status_code=404,
+        error='Version'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/version', methods=['GET'])
@@ -268,7 +328,10 @@ def get_event_version(event_id):
     version = Version.query.filter_by(event_id=event_id).order_by(Version.id.desc()).first()
     if version:
         return jsonify(version.serialize)
-    return jsonify({"version": []}), 404
+    return api_response(
+        status_code=404,
+        error='Version'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/sessions/title/<string:session_title>', methods=['GET'])
@@ -280,8 +343,11 @@ def get_sessions_at_event(event_id, session_title):
     contain session_title string in their title
     """
     sessions = Session.query.filter(Session.event_id == event_id, Session.title.contains(session_title))
-    return ObjectFormatter.get_json("sessions", sessions, request), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("sessions", sessions, request),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/speakers/name/<string:speaker_name>', methods=['GET'])
@@ -293,8 +359,11 @@ def get_speakers_at_event(event_id, speaker_name):
     contain speaker_name string in their name
     """
     speakers = Speaker.query.filter(Speaker.event_id == event_id, Speaker.name.contains(speaker_name))
-    return ObjectFormatter.get_json("speakers", speakers, request), \
-        event_status_code(event_id)
+    return api_response(
+        data=ObjectFormatter.get_json("speakers", speakers, request),
+        status_code=event_status_code(event_id),
+        error='Event'
+    )
 
 
 @app.route('/api/v1/event/<int:event_id>/export/ical', methods=['GET'])
@@ -306,7 +375,7 @@ def generate_icalendar_event(event_id):
     event = icalendar.Event()
     matching_event = Event.query.get(event_id)
     if matching_event is None:
-        return "Sorry, the event does not exist", 404
+        return api_response(status_code=404, error='Event')
     event.add('summary', matching_event.name)
     event.add('geo', (matching_event.latitude, matching_event.longitude))
     event.add('location', matching_event.location_name)
@@ -329,8 +398,10 @@ def generate_icalendar_track(event_id, track_id):
     cal = Calendar()
     track = icalendar.Event()
     matching_track = Track.query.get(track_id)
-    if matching_track is None or matching_track.event_id != event_id:
-        return "Sorry, the track does not exist", 404
+    if matching_track is None:
+        return api_response(status_code=404, error='Track')
+    if matching_track.event_id != event_id:
+        return api_response(status_code=404, error='Event')
     track.add('summary', matching_track.name)
     track.add('description', matching_track.description)
     track.add('url', matching_track.track_image_url)

--- a/open_event/views/views_helpers.py
+++ b/open_event/views/views_helpers.py
@@ -1,5 +1,6 @@
 from ..helpers.data_getter import DataGetter
 from flask import jsonify
+import json
 
 
 def error_404_message(item):
@@ -10,12 +11,21 @@ def error_404_message(item):
 def api_response(
         data=None,
         status_code=200,
-        error='Item'):
+        error='Item',
+        check_data=False,
+        error_data='Page'):
     """
     Api response helper
     if status_code is 200, return data
     else return error message with {status_code}
     """
+    # check if data is empty
+    if check_data:
+        if len(json.loads(data.data)) == 0 and status_code == 200:
+            # don't overwrite existing error
+            status_code = 404
+            error = error_data
+    # return response
     if status_code == 200:
         return data, 200
     elif status_code == 404:

--- a/open_event/views/views_helpers.py
+++ b/open_event/views/views_helpers.py
@@ -1,0 +1,9 @@
+from ..helpers.data_getter import DataGetter
+
+
+def event_status_code(event_id):
+    """
+    Helper function to return status code 200 if event exists
+    else 404
+    """
+    return 200 if DataGetter.get_event(event_id) else 404

--- a/open_event/views/views_helpers.py
+++ b/open_event/views/views_helpers.py
@@ -1,4 +1,27 @@
 from ..helpers.data_getter import DataGetter
+from flask import jsonify
+
+
+def error_404_message(item):
+    """Make error message for non-existence of {item}"""
+    return '%s does not exist' % item
+
+
+def api_response(
+        data=None,
+        status_code=200,
+        error='Item'):
+    """
+    Api response helper
+    if status_code is 200, return data
+    else return error message with {status_code}
+    """
+    if status_code == 200:
+        return data, 200
+    elif status_code == 404:
+        return jsonify({"message": error_404_message(error)}), 404
+    else:  # for future extensibility
+        return jsonify({"message": error}), status_code
 
 
 def event_status_code(event_id):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,12 +8,11 @@ from open_event import current_app as app
 from open_event.helpers.data import save_to_db
 from tests.object_mother import ObjectMother
 
+
 class TestApi(OpenEventTestCase):
 
     def test_api_tracks(self):
-        with self.assertRaises(Exception) as context:
-            self.app.get('/api/v1/event/1')
-        self.assertTrue(AttributeError, context.exception)
+        self.assertEqual(self.app.get('/api/v1/event/1').status_code, 404)
         event = ObjectMother.get_event()
         track = ObjectMother.get_track()
         with app.test_request_context():


### PR DESCRIPTION
* Fixes #320 
Return 404 status code with appropriate message when event/speaker/session/page doesn't exist 
* Fixes #321 
API views crash due to non-existant entity - Some API views like the one to get a single speaker would crash if speaker id didn't exist. This has been fixed
* Refactored code at places

All the updates have been done in accordance with the recent discussions on API.

**Note** - This PR contains #352 

PS - codecov/patch fails for this as the whole API code is *untested* [currently](https://codecov.io/gh/fossasia/open-event-orga-server/src/91d6611e6fb659a0d1722831b1d3cd936270f27c/open_event/views/views.py). My aim today was to write tests for them but this issue needed to be worked upon first before writing tests.