### PR TITLE
Fix Dragging error in Schedule UI and add auto scroll

### DIFF
--- a/open_event/static/css/admin/scheduling.css
+++ b/open_event/static/css/admin/scheduling.css
@@ -23,6 +23,7 @@
     top: 120px;
     padding: 5px;
     color: white;
+    z-index: 2;
 }
 
 .scheduled > .time {

--- a/open_event/static/js/admin/event/scheduling.js
+++ b/open_event/static/js/admin/event/scheduling.js
@@ -30,7 +30,15 @@
                 // enable inertial throwing
                 inertia: false,
                 // enable autoScroll
-                autoScroll: false,
+                autoScroll: {
+                    container: $(".track-container")[0],
+                    margin: 50,
+                    distance: 5,
+                    interval: 10
+                },
+                restrict: {
+                    restriction: '.draggable-holder'
+                },
                 // call this function on every dragmove event
                 onmove: function (event) {
                     var $sessionElement = $(event.target),

--- a/open_event/templates/gentelella/admin/event/details/scheduling.html
+++ b/open_event/templates/gentelella/admin/event/details/scheduling.html
@@ -72,7 +72,7 @@
                             <div class="timeunit">17:00</div>
                         </td>
                         <td class="rooms x1">
-                            <div class="track-container clearfix" style="width: 750px; height: 816px;">
+                            <div class="track-container clearfix draggable-holder" style="width: 750px; height: 816px;">
 
                                 <div class="track" data-day="1" data-track="1">
                                     <div class="text-center track-header">Android Track <span


### PR DESCRIPTION
This fixes #381 . Dragging error is fixed and the timeline will now auto scroll while dragging.