### PR TITLE
give distinct names to related api models, fixed #383

### DIFF
--- a/open_event/api/languages.py
+++ b/open_event/api/languages.py
@@ -6,7 +6,7 @@ from .helpers import get_object_list, get_object_or_404, get_object_in_event
 
 api = Namespace('languages', description='languages', path='/')
 
-LANGUAGE = api.model('language', {
+LANGUAGE = api.model('Language', {
     'id': fields.Integer(required=True),
     'name': fields.String,
     'label_en': fields.String,

--- a/open_event/api/levels.py
+++ b/open_event/api/levels.py
@@ -6,7 +6,7 @@ from .helpers import get_object_list, get_object_or_404, get_object_in_event
 
 api = Namespace('levels', description='levels', path='/')
 
-LEVEL = api.model('level', {
+LEVEL = api.model('Level', {
     'id': fields.Integer(required=True),
     'name': fields.String,
     'label_en': fields.String,

--- a/open_event/api/microlocations.py
+++ b/open_event/api/microlocations.py
@@ -6,7 +6,7 @@ from .helpers import get_object_list, get_object_or_404, get_object_in_event
 
 api = Namespace('microlocations', description='microlocations', path='/')
 
-MICROLOCATION = api.model('microlocation', {
+MICROLOCATION = api.model('Microlocation', {
     'id': fields.Integer(required=True),
     'name': fields.String,
     'latitude': fields.Float,

--- a/open_event/api/sessions.py
+++ b/open_event/api/sessions.py
@@ -6,28 +6,28 @@ from .helpers import get_object_list, get_object_or_404, get_object_in_event
 
 api = Namespace('sessions', description='Sessions', path='/')
 
-TRACK = api.model('Track', {
+SESSION_TRACK = api.model('SessionTrack', {
     'id': fields.Integer(required=True),
     'name': fields.String,
 })
 
-SPEAKER = api.model('Speaker', {
+SESSION_SPEAKER = api.model('SessionSpeaker', {
     'id': fields.Integer(required=True),
     'name': fields.String,
 })
 
-LEVEL = api.model('Level', {
+SESSION_LEVEL = api.model('SessionLevel', {
     'id': fields.Integer(required=True),
     'label_en': fields.String,
 })
 
-LANGUAGE = api.model('Language', {
+SESSION_LANGUAGE = api.model('SessionLanguage', {
     'id': fields.Integer(required=True),
     'label_en': fields.String,
     'label_de': fields.String,
 })
 
-MICROLOCATION = api.model('Microlocation', {
+SESSION_MICROLOCATION = api.model('SessionMicrolocation', {
     'id': fields.Integer(required=True),
     'name': fields.String,
 })
@@ -40,11 +40,11 @@ SESSION = api.model('Session', {
     'description': fields.String,
     'start_time': fields.DateTime,
     'end_time': fields.DateTime,
-    'track': fields.Nested(TRACK),
-    'speakers': fields.List(fields.Nested(SPEAKER)),
-    'level': fields.Nested(LEVEL),
-    'language': fields.Nested(LANGUAGE),
-    'microlocation': fields.Nested(MICROLOCATION),
+    'track': fields.Nested(SESSION_TRACK),
+    'speakers': fields.List(fields.Nested(SESSION_SPEAKER)),
+    'level': fields.Nested(SESSION_LEVEL),
+    'language': fields.Nested(SESSION_LANGUAGE),
+    'microlocation': fields.Nested(SESSION_MICROLOCATION),
 })
 
 

--- a/open_event/api/speakers.py
+++ b/open_event/api/speakers.py
@@ -6,7 +6,7 @@ from .helpers import get_object_list, get_object_or_404, get_object_in_event
 
 api = Namespace('speakers', description='Speakers', path='/')
 
-SESSION = api.model('Session', {
+SPEAKER_SESSION = api.model('SpeakerSession', {
     'id': fields.Integer,
     'title': fields.String,
 })
@@ -25,7 +25,7 @@ SPEAKER = api.model('Speaker', {
     'organisation': fields.String,
     'position': fields.String,
     'country': fields.String,
-    'sessions': fields.List(fields.Nested(SESSION)),
+    'sessions': fields.List(fields.Nested(SPEAKER_SESSION)),
 })
 
 

--- a/open_event/api/sponsors.py
+++ b/open_event/api/sponsors.py
@@ -6,7 +6,7 @@ from .helpers import get_object_list, get_object_or_404, get_object_in_event
 
 api = Namespace('sponsors', description='sponsors', path='/')
 
-SPONSOR = api.model('sponsor', {
+SPONSOR = api.model('Sponsor', {
     'id': fields.Integer(required=True),
     'name': fields.String,
     'url': fields.String,

--- a/open_event/api/tracks.py
+++ b/open_event/api/tracks.py
@@ -6,7 +6,7 @@ from .helpers import get_object_list, get_object_or_404, get_object_in_event
 
 api = Namespace('tracks', description='Tracks', path='/')
 
-SESSION = api.model('Session', {
+TRACK_SESSION = api.model('TrackSession', {
     'id': fields.Integer(required=True),
     'title': fields.String,
 })
@@ -16,7 +16,7 @@ TRACK = api.model('Track', {
     'name': fields.String,
     'description': fields.String,
     'track_image_url': fields.String,
-    'sessions': fields.List(fields.Nested(SESSION)),
+    'sessions': fields.List(fields.Nested(TRACK_SESSION)),
 })
 
 


### PR DESCRIPTION
Since flask-restplus auto documents every model created, so the related model named 'session' created in speaker.py was shadowing the real session model. This was the reason for #383 .
To fix this, I have given proper names to the related models. 

@shivamMg @juslee please review