### PR TITLE
Cleanup of the base Gentelella template file.

### DIFF
--- a/open_event/templates/gentelella/admin/base.html
+++ b/open_event/templates/gentelella/admin/base.html
@@ -14,17 +14,11 @@
     {% endblock %}
     {% block head_css %}
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-
-        <!-- Optional theme -->
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css" integrity="sha384-fLW2N01lMqjakBkx3l/M9EahuwpSfeNvV63J5ezn3uZzapT0u7EYsXMjQV+0En5r" crossorigin="anonymous">
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
-        <!-- Latest compiled and minified JavaScript -->
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
-
-
         <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}" />
-        <script type="text/javascript" src="{{ url_for('static', filename='js/custom.js') }}"></script>
-        <script type="text/javascript" src="{{ url_for('static', filename='js/admin.js') }}"></script>
+    {% endblock %}
+
+    {% block head_js %}
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
     {% endblock %}
 </head>
 <body class="nav-md">
@@ -42,5 +36,11 @@
             </div>
         </div>
     </div>
+
+    {% block tail_js %}
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+        <script type="text/javascript" src="{{ url_for('static', filename='js/custom.js') }}"></script>
+        <script type="text/javascript" src="{{ url_for('static', filename='js/admin.js') }}"></script>
+    {% endblock %}
 </body>
 </html>

--- a/open_event/templates/gentelella/admin/event/details/details.html
+++ b/open_event/templates/gentelella/admin/event/details/details.html
@@ -1,7 +1,7 @@
 {% extends 'gentelella/admin/base.html' %}
 {% block head_css %}
-{{ super() }}
-<link href="{{ url_for('static', filename='css/admin/scheduling.css') }}" rel="stylesheet">
+    {{ super() }}
+    <link href="{{ url_for('static', filename='css/admin/scheduling.css') }}" rel="stylesheet">
 {% endblock %}
 
 {% block body %}
@@ -111,13 +111,16 @@
     </div>
 </div>
 
-
-<script src="{{ url_for('static', filename='admin/lib/interact/dist/interact.min.js') }}"></script>
-<script src="{{ url_for('static', filename='admin/lib/moment/min/moment.min.js') }}"></script>
-<script src="{{ url_for('static', filename='js/jquery/randomColor.min.js') }}"></script>
-
-<script type="text/javascript" src="{{ url_for('static', filename='js/jquery/jquery.smartWizard.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/details.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/scheduling.js') }}"></script>
-
 {% endblock %}
+
+{% block tail_js %}
+    {{ super() }}
+    <script src="{{ url_for('static', filename='admin/lib/interact/dist/interact.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='admin/lib/moment/min/moment.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/jquery/randomColor.min.js') }}"></script>
+
+    <script type="text/javascript" src="{{ url_for('static', filename='js/jquery/jquery.smartWizard.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/details.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/scheduling.js') }}"></script>
+{% endblock %}
+

--- a/open_event/templates/gentelella/admin/event/index.html
+++ b/open_event/templates/gentelella/admin/event/index.html
@@ -1,10 +1,5 @@
 {% extends 'gentelella/admin/base.html' %}
-{% block head %}
-{{ super() }}
-{% endblock %}
 {% block body %}
-
-
 <div class="page-title">
     <div class="title_left">
         <h3>Events</h3>

--- a/open_event/templates/gentelella/admin/event/new/new.html
+++ b/open_event/templates/gentelella/admin/event/new/new.html
@@ -70,9 +70,12 @@
 </div>
 
 
-<script type="text/javascript" src="{{ url_for('static', filename='js/jquery/jquery.smartWizard.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/lib/moment.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/lib/daterangepicker.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/new.js') }}"></script><script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAHdXg0Y_zk-wCNpslbBqcezLdHniaEwkI&callback=initMap" async defer></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/jscolor.js') }}"></script>
+{% endblock %}
+{% block tail_js %}
+    {{ super() }}
+    <script type="text/javascript" src="{{ url_for('static', filename='js/jquery/jquery.smartWizard.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/lib/moment.min.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/lib/daterangepicker.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/new.js') }}"></script><script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAHdXg0Y_zk-wCNpslbBqcezLdHniaEwkI&callback=initMap" async defer></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/jscolor.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
This PR cleans up the template file at 
`open_event/templates/gentelella/admin/base.html` 

The changes done are:
1. `bootstrap.min.js`, `js/custom.js`, `js/admin.js` have been moved to the end of the body for better performance while page loads.
2. two new blocks have been created `head_js` (for scripts inside the head) and `tail_js`(for scripts at the end of the body).
3. Script declarations in `open_event/templates/gentelella/admin/event/details/details.html` and `open_event/templates/gentelella/admin/event/new/new.html` have been moved into the new `tail_js` block.

Resolves #399.

@rafalkowalski please review and merge if everything's good. 