### PR TITLE
Allow session elements to be removed from the timeline

### DIFF
--- a/open_event/static/css/admin/scheduling.css
+++ b/open_event/static/css/admin/scheduling.css
@@ -31,12 +31,24 @@
     cursor: all-scroll !important;
 }
 
+.unscheduled > .remove-btn {
+    display: none;
+}
+
 .scheduled {
     position: absolute !important;
     top: 120px;
     color: white;
     z-index: 2;
     border: none;
+    padding-right: 10px;
+}
+
+.scheduled > .remove-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    cursor: pointer;
 }
 
 .timeline-table td {

--- a/open_event/static/js/admin/event/scheduling.js
+++ b/open_event/static/js/admin/event/scheduling.js
@@ -261,7 +261,7 @@ function initializeInteractables() {
                 updateColor($sessionElement);
             } else {
                 $sessionElement.appendTo($(".sessions-holder"));
-                $sessionElement.addClass('unscheduled').removeClass('scheduled').tooltip("hide").attr("data-original-title", "");
+                $sessionElement.addClass("unscheduled").removeClass("scheduled").tooltip("hide").attr("data-original-title", "");
                 $sessionElement.css({
                     "-webkit-transform": "",
                     "transform": "",
@@ -273,7 +273,7 @@ function initializeInteractables() {
         ondropdeactivate: function (event) {
             var $trackDropZone = $(event.target);
             var $sessionElement = $(event.relatedTarget);
-            $trackDropZone.removeClass('drop-now').removeClass('drop-active');
+            $trackDropZone.removeClass("drop-now").removeClass("drop-active");
             if (!$sessionElement.hasClass("scheduled")) {
                 $sessionElement.css({
                     "-webkit-transform": "",
@@ -449,6 +449,17 @@ $(document).on("click", ".date-change-btn", function () {
     $(this).addClass("active");
     loadTracksToTimeline($(this).text());
     $(this).siblings().removeClass("active");
+});
+
+$(document).on("click", ".session.scheduled > .remove-btn", function () {
+    var $sessionElement = $(this).parent();
+    $sessionElement.appendTo($(".sessions-holder"));
+    $sessionElement.addClass("unscheduled").removeClass("scheduled").tooltip("hide").attr("data-original-title", "");
+    $sessionElement.css({
+        "-webkit-transform": "",
+        "transform": "",
+        "background-color": ""
+    }).removeData("x").removeData("y");
 });
 
 $(document).ready(function () {

--- a/open_event/static/js/admin/event/scheduling.js
+++ b/open_event/static/js/admin/event/scheduling.js
@@ -160,7 +160,7 @@ function initializeInteractables() {
 
     $tracks = $(".track");
 
-    interact('.session')
+    interact(".session")
         .draggable({
             // enable inertial throwing
             inertia: false,
@@ -172,7 +172,7 @@ function initializeInteractables() {
                 interval: 10
             },
             restrict: {
-                restriction: '.draggable-holder'
+                restriction: ".draggable-holder"
             },
             // call this function on every dragmove event
             onmove: function (event) {
@@ -181,8 +181,8 @@ function initializeInteractables() {
                     y = (parseFloat($sessionElement.data('y')) || 0) + event.dy;
 
                 if (restrictionCheck(x, $sessionElement) || $sessionElement.hasClass("unscheduled")) {
-                    $sessionElement.css("-webkit-transform", 'translate(' + x + 'px, ' + y + 'px)');
-                    $sessionElement.css("transform", 'translate(' + x + 'px, ' + y + 'px)');
+                    $sessionElement.css("-webkit-transform", "translate(" + x + "px, " + y + "px)");
+                    $sessionElement.css("transform", "translate(" + x + "px, " + y + "px)");
 
                     $sessionElement.data('x', x);
                     $sessionElement.data('y', y);
@@ -203,21 +203,21 @@ function initializeInteractables() {
         });
 
 
-    interact('.session')
+    interact(".session")
         .resizable({
             preserveAspectRatio: false,
             enabled: true,
             edges: {left: false, right: false, bottom: true, top: false}
         })
-        .on('resizemove', function (event) {
+        .on("resizemove", function (event) {
             if ($(event.target).hasClass("scheduled")) {
                 var target = event.target,
-                    x = (parseFloat(target.getAttribute('data-x')) || 0),
-                    y = (parseFloat(target.getAttribute('data-y')) || 0);
+                    x = (parseFloat(target.getAttribute("data-x")) || 0),
+                    y = (parseFloat(target.getAttribute("data-y")) || 0);
 
                 // update the element's style
-                target.style.width = roundOffToMultiple(event.rect.width) + 'px';
-                target.style.height = roundOffToMultiple(event.rect.height) + 'px';
+                target.style.width = roundOffToMultiple(event.rect.width) + "px";
+                target.style.height = roundOffToMultiple(event.rect.height) + "px";
 
                 $(event.target).ellipsis();
 
@@ -225,26 +225,26 @@ function initializeInteractables() {
             }
         });
 
-    interact('.track-inner').dropzone({
+    interact(".track-inner").dropzone({
         // only accept elements matching this CSS selector
-        accept: '.session',
+        accept: ".session",
         // Require a 75% element overlap for a drop to be possible
         overlap: 0.50,
 
         ondropactivate: function (event) {
-            $(event.target).addClass('drop-active');
+            $(event.target).addClass("drop-active");
         },
         ondragenter: function (event) {
-            $(event.target).addClass('drop-now');
+            $(event.target).addClass("drop-now");
         },
         ondragleave: function (event) {
-            $(event.target).removeClass('drop-now');
+            $(event.target).removeClass("drop-now");
         },
         ondrop: function (event) {
             var $sessionElement = $(event.relatedTarget);
             var $trackDropZone = $(event.target);
-            $sessionElement.removeClass('unscheduled').addClass('scheduled');
-            $trackDropZone.removeClass('drop-active').removeClass('drop-now');
+            $sessionElement.removeClass("unscheduled").addClass("scheduled");
+            $trackDropZone.removeClass("drop-active").removeClass("drop-now");
 
             $sessionElement.css({
                 "-webkit-transform": "",
@@ -434,7 +434,7 @@ function loadTracksToTimeline(day) {
 
     });
     fixOverlaps();
-    $('[data-toggle="tooltip"]').tooltip();
+    $("[data-toggle=tooltip]").tooltip();
 }
 
 function loadData(eventId, callback) {

--- a/open_event/static/js/jquery/jquery.ellipsis.js
+++ b/open_event/static/js/jquery/jquery.ellipsis.js
@@ -1,5 +1,5 @@
 // Borrowed from http://stackoverflow.com/a/1022672/1562480
-(function ($) {
+(function ellipsisInit($) {
     $.fn.ellipsis = function () {
         return this.each(function () {
             var el = $(this);
@@ -8,13 +8,13 @@
             el.text(text);
 
             var multiline = true;
-            
+
             var t = $(this.cloneNode(true))
                     .hide()
-                    .css('position', 'absolute')
-                    .css('overflow', 'visible')
-                    .width(multiline ? el.width() : 'auto')
-                    .height(multiline ? 'auto' : el.height())
+                    .css("position", "absolute")
+                    .css("overflow", "visible")
+                    .width(multiline ? el.width() : "auto")
+                    .height(multiline ? "auto" : el.height())
                 ;
 
             el.after(t);

--- a/open_event/static/js/jquery/jquery.ellipsis.js
+++ b/open_event/static/js/jquery/jquery.ellipsis.js
@@ -5,7 +5,7 @@
             var el = $(this);
 
             var text = el.attr("data-original-text");
-            el.text(text);
+            el.find(".text").text(text);
 
             var multiline = true;
 
@@ -33,9 +33,10 @@
             while (text.length > 0 && func()) {
                 text = text.substr(0, text.length - 1);
                 t.text(text + "...");
+
             }
 
-            el.text(t.text());
+            el.find(".text").text(t.text());
             t.remove();
         });
     };

--- a/open_event/templates/gentelella/admin/event/details/details.html
+++ b/open_event/templates/gentelella/admin/event/details/details.html
@@ -112,6 +112,5 @@
     <script type="text/javascript" src="{{ url_for('static', filename='js/jquery/jquery.smartWizard.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/details.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/scheduling.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/jscolor.js') }}"></script>
 {% endblock %}
 

--- a/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
+++ b/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
@@ -123,8 +123,11 @@
 </script>
 
 <script id="session-template" type="text/x-template">
-    <div class="session title" data-toggle="tooltip" data-animation="false" data-placement="top" title="">
+    <div class="session" data-toggle="tooltip" data-animation="false" data-placement="top" title="">
+        <div class="text">
 
+        </div>
+        <i class="remove-btn glyphicon glyphicon-remove"></i>
     </div>
 </script>
 <form id="add-track-form" onsubmit="return add_track()">
@@ -147,7 +150,7 @@
 
                         <label>Color:</label>&nbsp;&nbsp;
                         <div class="input-group colorpicker-component" id="color">
-                            <input type="text" value="#e01ab5" class="form-control" name="color"/>
+                            <input type="text" value="#e01ab5" class="form-control" name="color" title="track-color"/>
                             <span class="input-group-addon"><i></i></span>
                           </div>
 
@@ -186,7 +189,7 @@
         var posting = $.ajax({
                 type: "POST",
                 url: "{{ url_for('track.create_view', event_id=event.id) }}",
-                data: payload,
+                data: payload
         });
 
         posting.done(function(result){
@@ -195,5 +198,5 @@
         });
 
         return false;
-    };
+    }
 </script>


### PR DESCRIPTION
This PR adds a remove button to all scheduled sessions. On pressing the button, the session gets removed from the time line and is added to the list of unscheduled sessions. 

Resolves #436.

@SaptakS @juslee @rafalkowalski this is ready to be merged into `gsoc2016`. Please review.