### PR TITLE
POST API

### DIFF
--- a/open_event/api/__init__.py
+++ b/open_event/api/__init__.py
@@ -14,7 +14,7 @@ from .languages import api as language_api
 api_v2 = Blueprint('api', __name__, url_prefix='/api/v2')
 
 api = Api(api_v2, version='2.0', title='Organizer Server APIs',
-    description='Open Event Organizer APIs',
+    description='Open Event Organizer APIs'
 )
 
 api.add_namespace(event_api)

--- a/open_event/api/events.py
+++ b/open_event/api/events.py
@@ -1,8 +1,11 @@
 from flask.ext.restplus import Resource, Namespace, fields
+from flask import g
 
-from open_event.models.event import Event as EventModel
-from .helpers import get_object_list, get_object_or_404, get_paginated_list
+from open_event.models.event import Event as EventModel, EventsUsers
+from .helpers import get_object_list, get_object_or_404, get_paginated_list,\
+    requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase
+from open_event.helpers.data import save_to_db, update_version
 
 api = Namespace('events', description='Events')
 
@@ -25,6 +28,9 @@ EVENT_PAGINATED = api.clone('EventPaginated', PAGINATED_MODEL, {
     'results': fields.List(fields.Nested(EVENT))
 })
 
+EVENT_POST = api.clone('EventPost', EVENT)
+del EVENT_POST['id']
+
 
 @api.route('/<int:event_id>')
 @api.param('event_id')
@@ -44,6 +50,27 @@ class EventList(Resource):
     def get(self):
         """List all events"""
         return get_object_list(EventModel)
+
+    @requires_auth
+    @api.doc('create_event')
+    @api.marshal_with(EVENT)
+    @api.expect(EVENT_POST, validate=True)
+    def post(self):
+        """Create an event"""
+        new_event = EventModel(**self.api.payload)
+        a = EventsUsers()
+        a.user = g.user
+        a.editor = True
+        a.admin = True
+        new_event.users.append(a)
+        save_to_db(new_event, "Event saved")
+        update_version(
+            event_id=new_event.id,
+            is_created=True,
+            column_to_increment="event_ver"
+        )
+        # return the new event created
+        return get_object_or_404(EventModel, new_event.id)
 
 
 @api.route('/page')

--- a/open_event/api/helpers.py
+++ b/open_event/api/helpers.py
@@ -129,6 +129,16 @@ def get_paginated_list(klass, url, args={}, **kwargs):
     return obj
 
 
+def save_db_model(new_model, model_name, event_id=None):
+    """
+    Save a new/modified model to database
+    """
+    save_to_db(new_model, "Model %s saved" % model_name)
+    if not event_id:
+        update_version(event_id, False, "session_ver")
+    return new_model
+
+
 def create_service_model(model, event_id, data):
     """
     Create a new service model (microlocations, sessions, speakers etc)

--- a/open_event/api/helpers.py
+++ b/open_event/api/helpers.py
@@ -157,7 +157,6 @@ def requires_auth(f):
             # used in swagger UI
             if login.current_user.is_authenticated:
                 g.user = login.current_user
-                print login.current_user.login
                 return f(*args, **kwargs)
             else:
                 _error_abort(401, 'Authentication credentials not found')

--- a/open_event/api/helpers.py
+++ b/open_event/api/helpers.py
@@ -150,15 +150,18 @@ def requires_auth(f):
     """
     @wraps(f)
     def decorated(*args, **kwargs):
-        # check for active session
-        # used in swagger UI
-        if login.current_user is not None:
-            g.user = login.current_user
-            return f(*args, **kwargs)
         # check for auth headers
         auth = request.authorization
         if not auth:
-            _error_abort(401, 'Authentication headers missing')
+            # check for active session
+            # used in swagger UI
+            if login.current_user.is_authenticated:
+                g.user = login.current_user
+                print login.current_user.login
+                return f(*args, **kwargs)
+            else:
+                _error_abort(401, 'Authentication credentials not found')
+        # validate credentials
         user = UserModel.query.filter_by(login=auth.username).first()
         auth_ok = False
         if user is not None:

--- a/open_event/api/levels.py
+++ b/open_event/api/levels.py
@@ -1,10 +1,8 @@
 from flask.ext.restplus import Resource, Namespace, fields
 
 from open_event.models.session import Level as LevelModel
-from open_event.models.event import Event as EventModel
-from .helpers import get_object_list, get_object_or_404, get_object_in_event,\
-    get_paginated_list
-from utils import PAGINATED_MODEL, PaginatedResourceBase
+from .helpers import get_paginated_list, requires_auth
+from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO
 
 api = Namespace('levels', description='levels', path='/')
 
@@ -18,6 +16,16 @@ LEVEL_PAGINATED = api.clone('LevelPaginated', PAGINATED_MODEL, {
     'results': fields.List(fields.Nested(LEVEL))
 })
 
+LEVEL_POST = api.clone('LevelPost', LEVEL)
+del LEVEL_POST['id']
+
+
+# Create DAO
+class LevelDAO(ServiceDAO):
+    pass
+
+DAO = LevelDAO(model=LevelModel)
+
 
 @api.route('/events/<int:event_id>/levels/<int:level_id>')
 @api.response(404, 'Level not found')
@@ -27,7 +35,7 @@ class Level(Resource):
     @api.marshal_with(LEVEL)
     def get(self, event_id, level_id):
         """Fetch a level given its id"""
-        return get_object_in_event(LevelModel, level_id, event_id)
+        return DAO.get(event_id, level_id)
 
 
 @api.route('/events/<int:event_id>/levels')
@@ -37,10 +45,15 @@ class LevelList(Resource):
     @api.marshal_list_with(LEVEL)
     def get(self, event_id):
         """List all levels"""
-        # Check if an event with `event_id` exists
-        get_object_or_404(EventModel, event_id)
+        return DAO.list(event_id)
 
-        return get_object_list(LevelModel, event_id=event_id)
+    @requires_auth
+    @api.doc('create_level')
+    @api.marshal_with(LEVEL)
+    @api.expect(LEVEL_POST, validate=True)
+    def post(self, event_id):
+        """Create a level"""
+        return DAO.create(event_id, self.api.payload)
 
 
 @api.route('/events/<int:event_id>/levels/page')

--- a/open_event/api/microlocations.py
+++ b/open_event/api/microlocations.py
@@ -1,10 +1,8 @@
 from flask.ext.restplus import Resource, Namespace, fields
 
 from open_event.models.microlocation import Microlocation as MicrolocationModel
-from open_event.models.event import Event as EventModel
-from .helpers import get_object_list, get_object_or_404, get_object_in_event,\
-    get_paginated_list
-from utils import PAGINATED_MODEL, PaginatedResourceBase
+from .helpers import get_paginated_list, requires_auth
+from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO
 
 api = Namespace('microlocations', description='microlocations', path='/')
 
@@ -21,6 +19,16 @@ MICROLOCATION_PAGINATED = api.clone('MicrolocationPaginated', PAGINATED_MODEL, {
     'results': fields.List(fields.Nested(MICROLOCATION))
 })
 
+MICROLOCATION_POST = api.clone('MicrolocationPost', MICROLOCATION)
+del MICROLOCATION_POST['id']
+
+
+# Create DAO
+class MicrolocationDAO(ServiceDAO):
+    pass
+
+DAO = MicrolocationDAO(model=MicrolocationModel)
+
 
 @api.route('/events/<int:event_id>/microlocations/<int:microlocation_id>')
 @api.response(404, 'Microlocation not found')
@@ -30,8 +38,7 @@ class Microlocation(Resource):
     @api.marshal_with(MICROLOCATION)
     def get(self, event_id, microlocation_id):
         """Fetch a microlocation given its id"""
-        return get_object_in_event(MicrolocationModel, microlocation_id,
-                                   event_id)
+        return DAO.get(event_id, microlocation_id)
 
 
 @api.route('/events/<int:event_id>/microlocations')
@@ -41,10 +48,15 @@ class MicrolocationList(Resource):
     @api.marshal_list_with(MICROLOCATION)
     def get(self, event_id):
         """List all microlocations"""
-        # Check if an event with `event_id` exists
-        get_object_or_404(EventModel, event_id)
+        return DAO.list(event_id)
 
-        return get_object_list(MicrolocationModel, event_id=event_id)
+    @requires_auth
+    @api.doc('create_microlocation')
+    @api.marshal_with(MICROLOCATION)
+    @api.expect(MICROLOCATION_POST, validate=True)
+    def post(self, event_id):
+        """Create a microlocation"""
+        return DAO.create(event_id, self.api.payload)
 
 
 @api.route('/events/<int:event_id>/microlocations/page')

--- a/open_event/api/sessions.py
+++ b/open_event/api/sessions.py
@@ -67,6 +67,7 @@ SESSION_PAGINATED = api.clone('SessionPaginated', PAGINATED_MODEL, {
 
 SESSION_POST = api.clone('SessionPost', SESSION, {
     'track_id': fields.Integer,
+    'speaker_ids': fields.List(fields.Integer),
     'level_id': fields.Integer,
     'language_id': fields.Integer,
     'format_id': fields.Integer,
@@ -74,6 +75,7 @@ SESSION_POST = api.clone('SessionPost', SESSION, {
 })
 del SESSION_POST['id']
 del SESSION_POST['track']
+del SESSION_POST['speakers']
 del SESSION_POST['level']
 del SESSION_POST['language']
 del SESSION_POST['microlocation']
@@ -89,8 +91,8 @@ class SessionDAO(ServiceDAO):
         data['format'] = FormatModel.query.get(data['format_id'])
         data['microlocation'] = MicrolocationModel.query.get(data['microlocation_id'])
         data['event_id'] = event_id
-        speakers = data['speakers']
-        del data['speakers']
+        speakers = data['speaker_ids']
+        del data['speaker_ids']
         del data['track_id']
         del data['level_id']
         del data['language_id']
@@ -98,7 +100,7 @@ class SessionDAO(ServiceDAO):
         del data['microlocation_id']
         session = SessionModel(**data)
         session.speakers = InstrumentedList(
-            SpeakerModel.query.get(_['id']) for _ in speakers
+            SpeakerModel.query.get(_) for _ in speakers
         )
         new_session = save_db_model(session, SessionModel.__name__, event_id)
         return self.get(event_id, new_session.id)

--- a/open_event/api/sessions.py
+++ b/open_event/api/sessions.py
@@ -2,7 +2,8 @@ from flask.ext.restplus import Resource, Namespace, fields
 from sqlalchemy.orm.collections import InstrumentedList
 
 from open_event.models.session import Session as SessionModel, \
-    Language as LanguageModel, Level as LevelModel
+    Language as LanguageModel, Level as LevelModel, \
+    Format as FormatModel
 from open_event.models.track import Track as TrackModel
 from open_event.models.microlocation import Microlocation as MicrolocationModel
 from open_event.models.speaker import Speaker as SpeakerModel
@@ -68,6 +69,7 @@ SESSION_POST = api.clone('SessionPost', SESSION, {
     'track_id': fields.Integer,
     'level_id': fields.Integer,
     'language_id': fields.Integer,
+    'format_id': fields.Integer,
     'microlocation_id': fields.Integer
 })
 del SESSION_POST['id']
@@ -75,6 +77,7 @@ del SESSION_POST['track']
 del SESSION_POST['level']
 del SESSION_POST['language']
 del SESSION_POST['microlocation']
+del SESSION_POST['format']
 
 
 # Create DAO
@@ -83,6 +86,7 @@ class SessionDAO(ServiceDAO):
         data['track'] = TrackModel.query.get(data['track_id'])
         data['level'] = LevelModel.query.get(data['level_id'])
         data['language'] = LanguageModel.query.get(data['language_id'])
+        data['format'] = FormatModel.query.get(data['format_id'])
         data['microlocation'] = MicrolocationModel.query.get(data['microlocation_id'])
         data['event_id'] = event_id
         speakers = data['speakers']
@@ -90,6 +94,7 @@ class SessionDAO(ServiceDAO):
         del data['track_id']
         del data['level_id']
         del data['language_id']
+        del data['format_id']
         del data['microlocation_id']
         session = SessionModel(**data)
         session.speakers = InstrumentedList(

--- a/open_event/api/sessions.py
+++ b/open_event/api/sessions.py
@@ -34,6 +34,11 @@ SESSION_LANGUAGE = api.model('SessionLanguage', {
     'label_de': fields.String,
 })
 
+SESSION_FORMAT = api.model('SessionFormat', {
+    'id': fields.Integer(required=True),
+    'name': fields.String
+})
+
 SESSION_MICROLOCATION = api.model('SessionMicrolocation', {
     'id': fields.Integer(required=True),
     'name': fields.String,
@@ -51,6 +56,7 @@ SESSION = api.model('Session', {
     'speakers': fields.List(fields.Nested(SESSION_SPEAKER)),
     'level': fields.Nested(SESSION_LEVEL),
     'language': fields.Nested(SESSION_LANGUAGE),
+    'format': fields.Nested(SESSION_FORMAT),
     'microlocation': fields.Nested(SESSION_MICROLOCATION),
 })
 

--- a/open_event/api/speakers.py
+++ b/open_event/api/speakers.py
@@ -1,10 +1,8 @@
 from flask.ext.restplus import Resource, Namespace, fields
 
 from open_event.models.speaker import Speaker as SpeakerModel
-from open_event.models.event import Event as EventModel
-from .helpers import get_object_list, get_object_or_404, get_object_in_event,\
-    get_paginated_list
-from utils import PAGINATED_MODEL, PaginatedResourceBase
+from .helpers import get_paginated_list, requires_auth
+from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO
 
 api = Namespace('speakers', description='Speakers', path='/')
 
@@ -34,6 +32,17 @@ SPEAKER_PAGINATED = api.clone('SpeakerPaginated', PAGINATED_MODEL, {
     'results': fields.List(fields.Nested(SPEAKER))
 })
 
+SPEAKER_POST = api.clone('SpeakerPost', SPEAKER)
+del SPEAKER_POST['id']
+del SPEAKER_POST['sessions']  # don't allow adding sessions
+
+
+# Create DAO
+class SpeakerDAO(ServiceDAO):
+    pass
+
+DAO = SpeakerDAO(model=SpeakerModel)
+
 
 @api.route('/events/<int:event_id>/speakers/<int:speaker_id>')
 @api.response(404, 'Speaker not found')
@@ -43,7 +52,7 @@ class Speaker(Resource):
     @api.marshal_with(SPEAKER)
     def get(self, event_id, speaker_id):
         """Fetch a speaker given its id"""
-        return get_object_in_event(SpeakerModel, speaker_id, event_id)
+        return DAO.get(event_id, speaker_id)
 
 
 @api.route('/events/<int:event_id>/speakers')
@@ -53,10 +62,15 @@ class SpeakerList(Resource):
     @api.marshal_list_with(SPEAKER)
     def get(self, event_id):
         """List all speakers"""
-        # Check if an event with `event_id` exists
-        get_object_or_404(EventModel, event_id)
+        return DAO.list(event_id)
 
-        return get_object_list(SpeakerModel, event_id=event_id)
+    @requires_auth
+    @api.doc('create_speaker')
+    @api.marshal_with(SPEAKER)
+    @api.expect(SPEAKER_POST, validate=True)
+    def post(self, event_id):
+        """Create a speaker"""
+        return DAO.create(event_id, self.api.payload)
 
 
 @api.route('/events/<int:event_id>/speakers/page')

--- a/open_event/api/sponsors.py
+++ b/open_event/api/sponsors.py
@@ -1,10 +1,8 @@
 from flask.ext.restplus import Resource, Namespace, fields
 
 from open_event.models.sponsor import Sponsor as SponsorModel
-from open_event.models.event import Event as EventModel
-from .helpers import get_object_list, get_object_or_404, get_object_in_event,\
-    get_paginated_list
-from utils import PAGINATED_MODEL, PaginatedResourceBase
+from .helpers import get_paginated_list, requires_auth
+from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO
 
 api = Namespace('sponsors', description='sponsors', path='/')
 
@@ -19,6 +17,16 @@ SPONSOR_PAGINATED = api.clone('SponsorPaginated', PAGINATED_MODEL, {
     'results': fields.List(fields.Nested(SPONSOR))
 })
 
+SPONSOR_POST = api.clone('SponsorPost', SPONSOR)
+del SPONSOR_POST['id']
+
+
+# Create DAO
+class SponsorDAO(ServiceDAO):
+    pass
+
+DAO = SponsorDAO(model=SponsorModel)
+
 
 @api.route('/events/<int:event_id>/sponsors/<int:sponsor_id>')
 @api.response(404, 'Sponsor not found')
@@ -28,7 +36,7 @@ class Sponsor(Resource):
     @api.marshal_with(SPONSOR)
     def get(self, event_id, sponsor_id):
         """Fetch a sponsor given its id"""
-        return get_object_in_event(SponsorModel, sponsor_id, event_id)
+        return DAO.get(event_id, sponsor_id)
 
 
 @api.route('/events/<int:event_id>/sponsors')
@@ -38,10 +46,15 @@ class SponsorList(Resource):
     @api.marshal_list_with(SPONSOR)
     def get(self, event_id):
         """List all sponsors"""
-        # Check if an event with `event_id` exists
-        get_object_or_404(EventModel, event_id)
+        return DAO.list(event_id)
 
-        return get_object_list(SponsorModel, event_id=event_id)
+    @requires_auth
+    @api.doc('create_sponsor')
+    @api.marshal_with(SPONSOR)
+    @api.expect(SPONSOR_POST, validate=True)
+    def post(self, event_id):
+        """Create a sponsor"""
+        return DAO.create(event_id, self.api.payload)
 
 
 @api.route('/events/<int:event_id>/sponsors/page')

--- a/open_event/api/tracks.py
+++ b/open_event/api/tracks.py
@@ -1,10 +1,8 @@
 from flask.ext.restplus import Resource, Namespace, fields
 
 from open_event.models.track import Track as TrackModel
-from open_event.models.event import Event as EventModel
-from .helpers import get_object_list, get_object_or_404, get_object_in_event,\
-    get_paginated_list
-from utils import PAGINATED_MODEL, PaginatedResourceBase
+from .helpers import get_paginated_list, requires_auth
+from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO
 
 api = Namespace('tracks', description='Tracks', path='/')
 
@@ -25,6 +23,17 @@ TRACK_PAGINATED = api.clone('TrackPaginated', PAGINATED_MODEL, {
     'results': fields.List(fields.Nested(TRACK))
 })
 
+TRACK_POST = api.clone('TrackPost', TRACK)
+del TRACK_POST['id']
+del TRACK_POST['sessions']
+
+
+# Create DAO
+class TrackDAO(ServiceDAO):
+    pass
+
+DAO = TrackDAO(model=TrackModel)
+
 
 @api.route('/events/<int:event_id>/tracks/<int:track_id>')
 @api.response(404, 'Track not found')
@@ -34,7 +43,7 @@ class Track(Resource):
     @api.marshal_with(TRACK)
     def get(self, event_id, track_id):
         """Fetch a track given its id"""
-        return get_object_in_event(TrackModel, track_id, event_id)
+        return DAO.get(event_id, track_id)
 
 
 @api.route('/events/<int:event_id>/tracks')
@@ -43,10 +52,15 @@ class TrackList(Resource):
     @api.marshal_list_with(TRACK)
     def get(self, event_id):
         """List all tracks"""
-        # Check if an event with `event_id` exists
-        get_object_or_404(EventModel, event_id)
+        return DAO.list(event_id)
 
-        return get_object_list(TrackModel, event_id=event_id)
+    @requires_auth
+    @api.doc('create_track')
+    @api.marshal_with(TRACK)
+    @api.expect(TRACK_POST, validate=True)
+    def post(self, event_id):
+        """Create a track"""
+        return DAO.create(event_id, self.api.payload)
 
 
 @api.route('/events/<int:event_id>/tracks/page')

--- a/open_event/api/utils.py
+++ b/open_event/api/utils.py
@@ -1,4 +1,7 @@
 from flask_restplus import Model, fields, reqparse
+from .helpers import get_object_list, get_object_or_404, get_object_in_event, \
+    create_service_model
+from open_event.models.event import Event as EventModel
 
 
 # Base Api Model for a paginated response
@@ -20,3 +23,31 @@ class PaginatedResourceBase():
     parser = reqparse.RequestParser()
     parser.add_argument('start', type=int, default=1)
     parser.add_argument('limit', type=int, default=20)
+
+
+# DAO for Service Models
+class ServiceDAO:
+    """
+    Data Access Object for service models like microlocations,
+    speakers and so.
+    """
+    def __init__(self, model):
+        self.model = model
+
+    def get(self, event_id, sid):
+        return get_object_in_event(self.model, sid, event_id)
+
+    def list(self, event_id):
+        # Check if an event with `event_id` exists
+        get_object_or_404(EventModel, event_id)
+        return get_object_list(self.model, event_id=event_id)
+
+    def create(self, event_id, data):
+        item = create_service_model(self.model, event_id, data)
+        return self.get(event_id, item.id)
+
+    def update(self):
+        pass
+
+    def delete(self):
+        pass

--- a/tests/api/test_post_api.py
+++ b/tests/api/test_post_api.py
@@ -48,7 +48,7 @@ class TestPostApi(OpenEventTestCase):
             headers={'content-type': 'application/json'}
         )
         self.assertEqual(200, response.status_code, msg=response.data)
-        self.assertIn('Test' + str(name).title(), msg=response.data)
+        self.assertIn('Test' + str(name).title(), response.data)
         return response
 
     def test_track_api(self):

--- a/tests/api/test_post_api.py
+++ b/tests/api/test_post_api.py
@@ -33,13 +33,17 @@ class TestPostApi(OpenEventTestCase):
         1. Without login, try to do a POST request and catch 401 error
         2. Login and match 200 response code and correct response data
         """
-        path = get_path(1, name + 's')
+        path = get_path() if name == 'event' else get_path(1, name + 's')
         response = self.app.post(
             path,
             data=json.dumps(data),
             headers={'content-type': 'application/json'}
         )
         self.assertEqual(401, response.status_code, msg=response.data)
+        # TODO: has some issues with datetime and sqlite
+        # so return in event and session
+        if name in ['event', 'session']:
+            return
         # login and send the request again
         self.login_user()
         response = self.app.post(
@@ -50,6 +54,9 @@ class TestPostApi(OpenEventTestCase):
         self.assertEqual(200, response.status_code, msg=response.data)
         self.assertIn('Test' + str(name).title(), response.data)
         return response
+
+    def test_event_api(self):
+        self._test_model('event', POST_EVENT_DATA)
 
     def test_track_api(self):
         self._test_model('track', POST_TRACK_DATA)
@@ -67,8 +74,8 @@ class TestPostApi(OpenEventTestCase):
         self._test_model('language', POST_LANGUAGE_DATA)
 
     # TODO: has some issues with datetime and sqlite
-    # def test_session_api(self):
-    #     self._test_model('session', POST_SESSION_DATA)
+    def test_session_api(self):
+        self._test_model('session', POST_SESSION_DATA)
 
     def test_speaker_api(self):
         self._test_model('speaker', POST_SPEAKER_DATA)

--- a/tests/api/test_post_api.py
+++ b/tests/api/test_post_api.py
@@ -1,0 +1,81 @@
+import unittest
+import json
+
+from tests.setup_database import Setup
+from tests.utils import OpenEventTestCase
+from tests.auth_helper import login, register
+from tests.api.utils import create_event, get_path
+from tests.api.utils_post_data import *
+
+from open_event import current_app as app
+
+
+class TestPostApi(OpenEventTestCase):
+    """
+    Test POST APIs against 401 (unauthorized) and
+    200 (successful) status codes
+    """
+    def setUp(self):
+        self.app = Setup.create_app()
+        with app.test_request_context():
+            create_event()
+
+    def login_user(self):
+        """
+        register a user and login
+        """
+        register(self.app, 'test', 'test@gmail.com', 'test')
+        login(self.app, 'test', 'test')
+
+    def _test_model(self, name, data):
+        """
+        Tests -
+        1. Without login, try to do a POST request and catch 401 error
+        2. Login and match 200 response code and correct response data
+        """
+        path = get_path(1, name + 's')
+        response = self.app.post(
+            path,
+            data=json.dumps(data),
+            headers={'content-type': 'application/json'}
+        )
+        self.assertEqual(401, response.status_code, msg=response.data)
+        # login and send the request again
+        self.login_user()
+        response = self.app.post(
+            path,
+            data=json.dumps(data),
+            headers={'content-type': 'application/json'}
+        )
+        self.assertEqual(200, response.status_code, msg=response.data)
+        self.assertIn('Test' + str(name).title(), msg=response.data)
+        return response
+
+    def test_track_api(self):
+        self._test_model('track', POST_TRACK_DATA)
+
+    def test_microlocation_api(self):
+        self._test_model('microlocation', POST_MICROLOCATION_DATA)
+
+    def test_level_api(self):
+        self._test_model('level', POST_LEVEL_DATA)
+
+    def test_format_api(self):
+        self._test_model('format', POST_FORMAT_DATA)
+
+    def test_language_api(self):
+        self._test_model('language', POST_LANGUAGE_DATA)
+
+    # TODO: has some issues with datetime and sqlite
+    # def test_session_api(self):
+    #     self._test_model('session', POST_SESSION_DATA)
+
+    def test_speaker_api(self):
+        self._test_model('speaker', POST_SPEAKER_DATA)
+
+    def test_sponsor_api(self):
+        self._test_model('sponsor', POST_SPONSOR_DATA)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/api/utils_post_data.py
+++ b/tests/api/utils_post_data.py
@@ -1,0 +1,69 @@
+"""
+This file contains sample POST data
+"""
+
+POST_FORMAT_DATA = {
+    "label_en": "TestFormat",
+    "name": "TestFormat"
+}
+
+POST_LANGUAGE_DATA = {
+    "label_de": "TestLanguage",
+    "label_en": "TestLanguage",
+    "name": "TestLanguage"
+}
+
+POST_LEVEL_DATA = {
+    "label_en": "TestLevel",
+    "name": "TestLevel"
+}
+
+POST_MICROLOCATION_DATA = {
+    "floor": 1,
+    "latitude": 1,
+    "longitude": 1,
+    "name": "TestMicrolocation",
+    "room": "TestRoom"
+}
+
+POST_SESSION_DATA = {
+    "abstract": "TestSession",
+    "description": "TestSession",
+    "end_time": "2016-05-30T08:47:37.410Z",
+    "format_id": 1,
+    "language_id": 1,
+    "level_id": 1,
+    "microlocation_id": 1,
+    "speaker_ids": [1],
+    "start_time": "2016-05-25T08:47:37.410Z",
+    "subtitle": "TestSession",
+    "title": "TestSession",
+    "track_id": 1
+}
+
+POST_SPEAKER_DATA = {
+    "biography": "TestSpeaker",
+    "country": "TestSpeaker",
+    "email": "a@b.com",
+    "facebook": "http://facebook.com/user",
+    "github": "http://github.com/user",
+    "linkedin": "http://in.linkedin.com/user",
+    "name": "TestSpeaker",
+    "organisation": "TestSession",
+    "photo": "http://imgur.com/skds.png",
+    "position": "TestSession",
+    "twitter": "http://twitter.com/user",
+    "web": "http://website.com"
+}
+
+POST_SPONSOR_DATA = {
+    "logo": "http://imgur.com/image.png",
+    "name": "TestSponsor",
+    "url": "http://sponsor.com"
+}
+
+POST_TRACK_DATA = {
+    "description": "TestTrack",
+    "name": "TestTrack",
+    "track_image_url": "http://imgur.com/image.png"
+}

--- a/tests/api/utils_post_data.py
+++ b/tests/api/utils_post_data.py
@@ -2,6 +2,20 @@
 This file contains sample POST data
 """
 
+POST_EVENT_DATA = {
+    "color": "red",
+    "email": "email@gmail.com",
+    "end_time": "2016-05-30T12:12:43.891Z",
+    "latitude": 0,
+    "location_name": "TestEvent",
+    "logo": "http://imgur.com/image.png",
+    "longitude": 0,
+    "name": "TestEvent",
+    "slogan": "TestEvent",
+    "start_time": "2016-05-25T12:12:43.891Z",
+    "url": "http://website.com"
+}
+
 POST_FORMAT_DATA = {
     "label_en": "TestFormat",
     "name": "TestFormat"


### PR DESCRIPTION
Fixes #442 and #462
Includes PR #456 

Currently no ACL has been implemented in this patch although login is required to be able to update data on server. Using Python requests - 
```python
from requests import post 
url = 'http://localhost:5000/api/v2/events'
print post(url + '/1/formats', json={'label_en': 'eng', 'name': 'eng'}, auth=('username', 'password')).json()
```
In swagger UI, you need to be signed in to open event before you can make POST requests. :sunglasses: 

#### A question

@juslee @leto @shivamMg 

For POST request to create a new session, I am representing related models only by their ids. like `level_id` instead of full level object (below)
```json
"level": {
    "id": 1,
    "label_en": "string"
  },
```

The current schema to send a POST req to create session is as follows. As you can see, I am using `level_id`, `track_id` and so..
```json
{
  "abstract": "string",
  "description": "string",
  "end_time": "2016-05-29T12:44:03.743Z",
  "language_id": 0,
  "level_id": 0,
  "microlocation_id": 0,
  "speakers": [
    {
       "id": 0,
       "name": "string"
    }
  ],
  "start_time": "2016-05-29T12:44:03.743Z",
  "subtitle": "string",
  "title": "string",
  "track_id": 0
}
```

Is using IDs better since when creating a session, if you want to attach a level, you need to have the id of level before hand ?
Should I change `speakers` to `speaker_ids`, a list of speaker id's ?

**UPDATE** - I have changed `speakers` to `speaker_ids` now. 