### PR TITLE
'Fix Overlaps' functionality's inefficiency has been resolved

### DIFF
--- a/open_event/static/js/jquery/jquery.codezero.js
+++ b/open_event/static/js/jquery/jquery.codezero.js
@@ -142,5 +142,7 @@ function logDebug(message, ref) {
     }
 }
 
-
+function isUndefinedOrNull(variable) {
+    return (_.isUndefined(variable) || _.isNull(variable));
+}
 


### PR DESCRIPTION
The Fix overlaps functionality seemed to have become slower than before causing an approximate of `3` seconds of UI blocking. 

The problem was due to some events that were broadcasted unnecessarily during session rearrangement. 

Resolves #481 .

@juslee @SaptakS @rafalkowalski this is ready for merging into `gsoc2016`. Please review and merge. 