### PR TITLE
Prevent sessions from being dropped onto another session

### DIFF
--- a/open_event/static/css/admin/scheduling.css
+++ b/open_event/static/css/admin/scheduling.css
@@ -19,7 +19,7 @@
     height: 48px;
     overflow: hidden;
     width: 216px;
-	white-space: normal;
+    white-space: normal;
     padding: 5px;
     font-size: 11px;
     display: flex;
@@ -174,4 +174,66 @@
 
 .track-inner.drop-now {
     background-color: rgba(220, 220, 220, 0.35);
+}
+
+#sessions-list {
+
+}
+
+/**
+ * SNACKBAR CSS STYLES
+ * ===================
+ */
+.paper-snackbar {
+    transition-property: opacity, bottom, left, right, width, margin, border-radius;
+    transition-duration: 0.5s;
+    transition-timing-function: ease;
+    font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, serif;
+    font-weight: 300;
+    font-size: 14px;
+    min-height: 14px;
+    background-color: #323232;
+    position: fixed;
+    z-index: 99999999;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: white;
+    line-height: 22px;
+    padding: 18px 24px;
+    bottom: 0;
+    opacity: 0;
+
+}
+
+@media (min-width: 640px) {
+    .paper-snackbar {
+
+        min-width: 288px;
+        max-width: 568px;
+        display: inline-flex;
+        border-radius: 2px;
+        margin: 24px;
+        bottom: -100px;
+
+    }
+}
+
+@media (max-width: 640px) {
+    .paper-snackbar {
+        left: 0;
+        right: 0;
+    }
+}
+
+.paper-snackbar .action {
+    background: inherit;
+    display: inline-block;
+    border: none;
+    font-size: inherit;
+    text-transform: uppercase;
+    color: #ffeb3b;
+    margin: 0 0 0 24px;
+    padding: 0;
+    min-width: min-content;
 }

--- a/open_event/static/js/admin/event/scheduling.js
+++ b/open_event/static/js/admin/event/scheduling.js
@@ -74,11 +74,11 @@ var unscheduledStore = [];
  * @type {jQuery|HTMLElement}
  */
 var $tracks = $(".track");
-var $unscheduledSessionsList = $(".sessions-list");
-var $tracksHolder = $(".track-container");
+var $unscheduledSessionsList = $("#sessions-list");
+var $tracksHolder = $("#track-container");
 var $unscheduledSessionsHolder = $unscheduledSessionsList;
-var $noSessionsInfoBox = $(".no-sessions-info");
-var $dayButtonsHolder = $(".date-change-btn-holder");
+var $noSessionsInfoBox = $("#no-sessions-info");
+var $dayButtonsHolder = $("#date-change-btn-holder");
 
 /**
  * TEMPLATE STRINGS
@@ -442,7 +442,7 @@ function generateTimeUnits() {
  */
 function initializeInteractables() {
 
-    $tracks = $(".track");
+    $tracks = $tracksHolder.find(".track");
 
     interact(".session")
         .draggable({
@@ -674,7 +674,7 @@ function loadTracksToTimeline(day) {
         }
     });
 
-    $tracks = $(".track");
+    $tracks = $tracksHolder.find(".track");
     $("[data-toggle=tooltip]").tooltip("hide");
 }
 

--- a/open_event/static/js/jquery/jquery.codezero.js
+++ b/open_event/static/js/jquery/jquery.codezero.js
@@ -73,7 +73,7 @@ function roundOffToMultiple(val, multiple) {
  * @returns {boolean}
  */
 function horizontallyBound($parentDiv, $childDiv, offsetAdd) {
-    if(!offsetAdd) {
+    if (!offsetAdd) {
         offsetAdd = 0;
     }
     var pageWidth = $parentDiv.width();
@@ -142,7 +142,80 @@ function logDebug(message, ref) {
     }
 }
 
+/**
+ * Detect if a variable is undefined or null
+ * @param {*} variable The variable
+ * @returns {boolean} The result of the check
+ */
 function isUndefinedOrNull(variable) {
     return (_.isUndefined(variable) || _.isNull(variable));
 }
 
+/**
+ * Create a material design snackbar to display simple notifications
+ */
+var createSnackbar = (function () {
+    var previous = null;
+
+    return function (message, actionText, action, delay) {
+        if (previous) {
+            previous.dismiss();
+        }
+
+        if (typeof actionText === 'undefined' || actionText == null) {
+            actionText = "Dismiss";
+        }
+
+        if (typeof delay === 'undefined' || delay == null) {
+            delay = 5000;
+        }
+        var snackbar = document.createElement('div');
+        snackbar.className = 'paper-snackbar';
+        snackbar.dismiss = function () {
+            this.style.opacity = 0;
+        };
+        var text = document.createTextNode(message);
+        snackbar.appendChild(text);
+        if (actionText) {
+            var hasAction = true;
+            if (!action) {
+                action = snackbar.dismiss.bind(snackbar);
+                hasAction = false;
+            }
+            var actionButton = document.createElement('button');
+            actionButton.className = 'action';
+            actionButton.innerHTML = actionText;
+            if (hasAction) {
+                actionButton.addEventListener('click', function () {
+                    action();
+                    snackbar.dismiss.bind(snackbar);
+                });
+            } else {
+                actionButton.addEventListener('click', action);
+            }
+
+            snackbar.appendChild(actionButton);
+        }
+        setTimeout(function () {
+            if (previous === this) {
+                previous.dismiss();
+            }
+        }.bind(snackbar), delay);
+
+        snackbar.addEventListener('transitionend', function (event, elapsed) {
+            if (event.propertyName === 'opacity' && this.style.opacity == 0) {
+                this.parentElement.removeChild(this);
+                if (previous === this) {
+                    previous = null;
+                }
+            }
+        }.bind(snackbar));
+
+        previous = snackbar;
+        document.body.appendChild(snackbar);
+        getComputedStyle(snackbar).bottom;
+        snackbar.style.bottom = '0px';
+        snackbar.style.left = '0px';
+        snackbar.style.opacity = 1;
+    };
+})();

--- a/open_event/templates/gentelella/admin/base.html
+++ b/open_event/templates/gentelella/admin/base.html
@@ -26,7 +26,7 @@
         <div class="main_container">
             {{ sidebar.render_sidebar() }}
             {{ menu.render_menu() }}
-            <div class="right_col" role="main" style="min-height: 3574px;">
+            <div class="right_col" role="main">
                  {% include '/gentelella/admin/notifications.html' %}
                  <div class="">
 

--- a/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
+++ b/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
@@ -13,7 +13,7 @@
     </div>
 
     <div class="row scheduler-holder" style="display: none;">
-        <div class="col-xs-3 sessions-holder" style="">
+        <div class="col-xs-3 sessions-holder">
             <h4>Sessions</h4><br>
             <div class="input-group">
                 <span class="input-group-addon" id="search-addon"><i class="glyphicon glyphicon-search"></i></span>
@@ -21,17 +21,17 @@
                        aria-describedby="search-addon">
             </div>
             <br>
-            <div class="sessions-list">
+            <div id="sessions-list" class="sessions-list">
 
             </div>
-            <span class="text-muted no-sessions-info" style="font-size: 24px; font-weight: 100;">
+            <span id="no-sessions-info" class="text-muted no-sessions-info" style="font-size: 24px; font-weight: 100;">
                 No Unscheduled sessions.
             </span>
         </div>
         <div class="col-xs-9">
 
             <div class="btn-toolbar" role="toolbar">
-                <div class="btn-group date-change-btn-holder" role="group">
+                <div id="date-change-btn-holder" class="btn-group date-change-btn-holder" role="group">
 
                 </div>
                 <div class="btn-group" role="group">
@@ -50,7 +50,7 @@
                             <div class="timeunit"></div>
                         </td>
                         <td class="tracks x1">
-                            <div class="track-container clearfix draggable-holder"
+                            <div id="track-container" class="track-container clearfix draggable-holder"
                                  style="width: 750px; height: 1311px;">
                             </div>
                         </td>


### PR DESCRIPTION
Sessions were allowed to be dropped into other sessions. This has been prevented by having a collision check on each drop. The user is notified via a simple SnackBar. 

Resolves #482.

Other changes (not related to #482) that have been made in this PR are:
- Context has been provided to class selectors for a better performance
- ID selectors have been used wherever possible
- lodash's implementation `_.each` has been used instead of the slower jQuery's implementation `$.each` for looping through jQuery objects.


@juslee @SaptakS @rafalkowalski this is ready for merging into `gsoc2016`. Please review and merge. 