### PR TITLE
Session display added

### DIFF
--- a/open_event/helpers/data_getter.py
+++ b/open_event/helpers/data_getter.py
@@ -49,6 +49,13 @@ class DataGetter:
         return Session.query.filter_by(event_id=get_event_id())
 
     @staticmethod
+    def get_sessions_by_event_id(event_id):
+        """
+        :return: All Sessions with correct event_id
+        """
+        return Session.query.filter_by(event_id=event_id)
+
+    @staticmethod
     def get_tracks(event_id):
         """
         :param event_id: Event id

--- a/open_event/helpers/helpers.py
+++ b/open_event/helpers/helpers.py
@@ -36,9 +36,9 @@ def send_email_invitation(email, username, event_name, link):
     payload = {'to': email,
                'from': 'open-event@googlegroups.com',
                'subject': "Invitation to Submit Papers for " + event_name,
-               "html": ("Hi %s<br/>" + \
-                        "You are invited to submit papers for event: %s" + \
-                        "<br/> Visit this link to fill up details: %s" % (username, event_name, link))}
+               "html": ("Hi %s<br/>" % str(username) + \
+                        "You are invited to submit papers for event: %s" % str(event_name) + \
+                        "<br/> Visit this link to fill up details: %s" % link)}
     requests.post("https://api.sendgrid.com/api/mail.send.json",
                   data=payload,
                   headers=HEADERS)

--- a/open_event/templates/gentelella/admin/event/details/steps/call_for_papers.html
+++ b/open_event/templates/gentelella/admin/event/details/steps/call_for_papers.html
@@ -5,7 +5,7 @@
         </label>
 
         <button class="btn btn-success " type="button" data-toggle="modal" data-target="#invite-speaker-modal">Invite Person</button>
-        <button class="btn btn-warning ">Accept/Reject Session</button>
+        <a href="{{ url_for('session.display_view', event_id=event.id) }}"><button class="btn btn-warning ">Accept/Reject Session</button></a>
     </div>
     <div class="row">
         <div class="col-md-offset-10">

--- a/open_event/templates/gentelella/admin/session/display.html
+++ b/open_event/templates/gentelella/admin/session/display.html
@@ -1,0 +1,69 @@
+{% extends 'gentelella/admin/base.html' %}
+{% block body %}
+<div class="page-title">
+    <div class="title_left">
+        <h3>Sessions</h3>
+    </div>
+</div>
+
+<div class="clearfix"></div>
+<div class="row">
+    <div class="col-md-12 col-sm-12 col-xs-12">
+        <div class="x_panel">
+            <button class="btn btn-default" onclick="show_all();">All</button>
+            <button class="btn btn-default" onclick="show_pending();">Pending</button>
+            <button class="btn btn-default" onclick="show_accepted();">Accepted</button>
+            <button class="btn btn-default" onclick="show_rejected();">Rejected</button>
+
+         <div class="x_content">
+                <table class="table table-striped">
+                    <thead>
+                    <tr>
+                        <th>Title</th>
+                        <th>Description</th>
+                        <th>Abstract</th>
+                        <th>Start Date</th>
+                        <th>End Date</th>
+                        <th>State</th>
+
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for session in sessions %}
+                    <tr class="session {{session.state}}">
+                        <td>{{session.title}}</td>
+                        <td>{{session.description}}</td>
+                        <td>{{session.abstract}}</td>
+                        <td>{{session.start_time}}</td>
+                        <td>{{session.end_time}}</td>
+                        <td>{{session.state}}</td>
+                    </tr>
+                    {%endfor%}
+                    </tbody>
+                </table>
+            </div>
+
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    function show_all() {
+        $('.session').show();
+    }
+
+    function show_pending() {
+        $('.session').hide();
+        $('.session.pending').show();
+    }
+
+    function show_accepted() {
+        $('.session').hide();
+        $('.session.accepted').show();
+    }
+
+    function show_rejected() {
+        $('.session').hide();
+        $('.session.rejected').show();
+    }
+</script>
+{% endblock %}

--- a/open_event/views/admin/models_views/session.py
+++ b/open_event/views/admin/models_views/session.py
@@ -13,5 +13,11 @@ class SessionView(ModelView):
         if invite and invite.hash == hash:
             if request.method == 'POST':
                 DataManager.add_session_to_event(request.form, event_id)
-                return redirect(url_for('event.details_view', event_id=event_id))
+                return redirect(url_for('session.display_view', event_id=event_id))
             return self.render('/gentelella/admin/session/new.html')
+
+    @expose('/display/')
+    def display_view(self, event_id):
+        sessions = DataGetter.get_sessions_by_event_id(event_id)
+        return self.render('/gentelella/admin/session/display.html',
+                           sessions=sessions)


### PR DESCRIPTION
Fixes https://github.com/fossasia/open-event-orga-server/issues/495

Features included:
- [x] Shows table with all sessions for a particular event
- [x] Filtering to see all, pending, accepted or rejected
- [x] The page can be accessed from the "call for papers" stage by clicking "Accept/Reject Session" button

![screenshot from 2016-06-02 16 53 36](https://cloud.githubusercontent.com/assets/9530293/15743828/d0acd732-28e5-11e6-9e2d-ac22f51aa991.png)
