### PR TITLE
Load event ID dynamically for the timeline

### DIFF
--- a/open_event/static/js/admin/event/scheduling.js
+++ b/open_event/static/js/admin/event/scheduling.js
@@ -73,6 +73,7 @@ var unscheduledStore = [];
  *
  * @type {jQuery|HTMLElement}
  */
+var $timeline = $("#timeline");
 var $tracks = $(".track");
 var $unscheduledSessionsList = $("#sessions-list");
 var $tracksHolder = $("#track-container");
@@ -760,6 +761,7 @@ $(document)
  * Initialize the Scheduler UI on document ready
  */
 $(document).ready(function () {
+    var eventId = $timeline.data("event-id").trim();
     generateTimeUnits();
-    initializeTimeline(18);
+    initializeTimeline(eventId);
 });

--- a/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
+++ b/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
@@ -41,7 +41,7 @@
                     </button>
                 </div>
             </div>
-            <div class="timeline"
+            <div class="timeline" id="timeline" data-event-id="{{ event.id }}"
                  style="margin-top: 10px; margin-left: 10px; height: 600px; overflow-x: hidden; overflow-y: scroll; width: 100%;">
                 <table class="timeline-table table">
                     <tbody>


### PR DESCRIPTION
Use the current event's event ID for loading the sessions in the timeline.

@SaptakS @rafalkowalski Please review and merge into `development`