### PR TITLE
Sort unscheduled sessions alphabetically

### DIFF
--- a/open_event/static/js/admin/event/scheduling.js
+++ b/open_event/static/js/admin/event/scheduling.js
@@ -732,6 +732,8 @@ $("#sessions-search").valueChange(function (value) {
         });
     }
 
+    filtered = _.sortBy(filtered, "title");
+    
     $unscheduledSessionsHolder.html("");
 
     if (filtered.length == 0) {

--- a/open_event/static/js/jquery/jquery.codezero.js
+++ b/open_event/static/js/jquery/jquery.codezero.js
@@ -17,8 +17,40 @@ jQuery.fn.extend({
                 }
             });
         });
+    },
+    appendAt: function ($element, index) {
+        return this.each(function () {
+            var elem = $(this);
+            if (index === 0) {
+                elem.prepend($element);
+                return;
+            } else if (index === -1) {
+                elem.append($element);
+                return;
+            }
+            elem.find("div:nth-child(" + (index) + ")").after($element);
+        });
+    }
+
+});
+
+/**
+ * Extend Lodash and add some additional functionality
+ */
+_.mixin({
+    /**
+     * Push data into an array while maintaining sort order
+     * @param array
+     * @param value
+     * @param [iteratee=_.identity]
+     */
+    sortedPush: function (array, value, iteratee) {
+        var sortedIndex = _.sortedIndex(array, value, iteratee);
+        array.splice(sortedIndex, 0, value);
+        return sortedIndex;
     }
 });
+
 
 /**
  * Cache the results of a RegExp match.

--- a/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
+++ b/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
@@ -42,7 +42,7 @@
                 </div>
             </div>
             <div class="timeline" id="timeline" data-event-id="{{ event.id }}"
-                 style="margin-top: 10px; margin-left: 10px; height: 600px; overflow-x: hidden; overflow-y: scroll; width: 100%;">
+                 style="margin-top: 10px; margin-left: 10px; width: 100%;">
                 <table class="timeline-table table">
                     <tbody>
                     <tr>


### PR DESCRIPTION
The list of unscheduled sessions have been sorted alphabetically based on the session title so that it's easier for the organizer to find a session.

I am referring to the list of unscheduled sessions that will be shown here :

![capture](https://cloud.githubusercontent.com/assets/2404372/15805823/93c512d4-2b52-11e6-9c49-841aa10ed77d.PNG)

Also, the scrollbar inside the page has been removed and the page height has increased accordingly.

Resolves #511.

@SaptakS @rafalkowalski please review and merge into `development`