### PR TITLE
Added JWT based authentication

### DIFF
--- a/open_event/__init__.py
+++ b/open_event/__init__.py
@@ -58,7 +58,7 @@ def create_app():
     # set up jwt
     app.config['JWT_AUTH_USERNAME_KEY'] = 'email'
     app.config['JWT_EXPIRATION_DELTA'] = timedelta(seconds=84400)
-    app.config['JWT_AUTH_URL_RULE'] = '/admin/jwtauth'  # not used anyway
+    app.config['JWT_AUTH_URL_RULE'] = None
     jwt = JWT(app, jwt_authenticate, jwt_identity)
 
     admin_view = AdminView("Open Event")

--- a/open_event/__init__.py
+++ b/open_event/__init__.py
@@ -57,7 +57,7 @@ def create_app():
 
     # set up jwt
     app.config['JWT_AUTH_USERNAME_KEY'] = 'email'
-    app.config['JWT_EXPIRATION_DELTA'] = timedelta(seconds=84400)
+    app.config['JWT_EXPIRATION_DELTA'] = timedelta(seconds=24*60*60)
     app.config['JWT_AUTH_URL_RULE'] = None
     jwt = JWT(app, jwt_authenticate, jwt_identity)
 

--- a/open_event/api/__init__.py
+++ b/open_event/api/__init__.py
@@ -10,6 +10,7 @@ from .microlocations import api as microlocation_api
 from .levels import api as level_api
 from .formats import api as format_api
 from .languages import api as language_api
+from .login import api as login_api
 
 api_v2 = Blueprint('api', __name__, url_prefix='/api/v2')
 
@@ -26,3 +27,4 @@ api.add_namespace(microlocation_api)
 api.add_namespace(level_api)
 api.add_namespace(format_api)
 api.add_namespace(language_api)
+api.add_namespace(login_api)

--- a/open_event/api/formats.py
+++ b/open_event/api/formats.py
@@ -5,7 +5,7 @@ from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
     PAGE_PARAMS, POST_RESPONSES
 
-api = Namespace('formats', description='formats', path='/')
+api = Namespace('formats', description='Formats', path='/')
 
 # Create models
 FORMAT = api.model('Format', {

--- a/open_event/api/helpers.py
+++ b/open_event/api/helpers.py
@@ -215,7 +215,6 @@ def auth_jwt():
     A helper function that throws JWTError if JWT is not set
     """
     g.user = current_identity
-    pass
 
 
 def auth_basic():

--- a/open_event/api/helpers.py
+++ b/open_event/api/helpers.py
@@ -3,6 +3,7 @@ from flask import request, g
 from flask.ext.restplus import abort
 from flask.ext import login
 from flask.ext.scrypt import check_password_hash
+from flask_jwt import jwt_required, JWTError, current_identity
 
 from open_event.models.event import Event as EventModel
 from custom_fields import CustomField
@@ -170,31 +171,69 @@ def requires_auth(f):
     """
     Custom decorator to restrict non-login access to views
     g.user holds the successfully authenticated user
-    Can be extended in future to allow other types of logins
-    Source: http://stackoverflow.com/q/32290511/2295672
+    Allows JWT token based access and Basic auth access
+    Falls back to active session if both are not present
     """
     @wraps(f)
     def decorated(*args, **kwargs):
-        # check for auth headers
-        auth = request.authorization
-        if not auth:
-            # check for active session
-            # used in swagger UI
+        message = 'Authentication credentials not found'
+        success = False
+        # JWT Auth
+        try:
+            auth_jwt()
+            success = True
+        except JWTError as e:
+            if e.headers is not None and 'WWW-Authenticate' not in e.headers:
+                # JWT header was set but something wrong happened
+                message = e.error + ': ' + e.description
+
+        # Basic Auth
+        if not success:
+            results = auth_basic()
+            if not results[0]:
+                if results[1]:
+                    message = results[1]
+            else:
+                success = True
+
+        # if none worked, check for active session
+        # used in swagger UI
+        if not success:
             if login.current_user.is_authenticated:
                 g.user = login.current_user
-                return f(*args, **kwargs)
-            else:
-                _error_abort(401, 'Authentication credentials not found')
-        # validate credentials
-        user = UserModel.query.filter_by(email=auth.username).first()
-        auth_ok = False
-        if user is not None:
-            auth_ok = check_password_hash(
-                auth.password.encode('utf-8'),
-                user.password.encode('utf-8'),
-                user.salt)
-        if not auth_ok:
-            return _error_abort(401, 'Authentication failed. Wrong username or password')
-        g.user = user
-        return f(*args, **kwargs)
+                success = True
+        if success:
+            return f(*args, **kwargs)
+        else:
+            _error_abort(401, message)
     return decorated
+
+
+@jwt_required()
+def auth_jwt():
+    """
+    A helper function that throws JWTError if JWT is not set
+    """
+    g.user = current_identity
+    pass
+
+
+def auth_basic():
+    """
+    Check for basic auth in header. Return a tuple as result
+    The second value of tuple is set only when user tried basic_auth
+    """
+    auth = request.authorization  # only works in Basic auth
+    if not auth:
+        return (False, '')
+    user = UserModel.query.filter_by(email=auth.username).first()
+    auth_ok = False
+    if user is not None:
+        auth_ok = check_password_hash(
+            auth.password.encode('utf-8'),
+            user.password.encode('utf-8'),
+            user.salt)
+    if not auth_ok:
+        return (False, 'Authentication failed. Wrong username or password')
+    g.user = user
+    return (True, '')

--- a/open_event/api/languages.py
+++ b/open_event/api/languages.py
@@ -5,7 +5,7 @@ from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
     PAGE_PARAMS, POST_RESPONSES
 
-api = Namespace('languages', description='languages', path='/')
+api = Namespace('languages', description='Languages', path='/')
 
 LANGUAGE = api.model('Language', {
     'id': fields.Integer(required=True),

--- a/open_event/api/levels.py
+++ b/open_event/api/levels.py
@@ -5,7 +5,7 @@ from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
     PAGE_PARAMS, POST_RESPONSES
 
-api = Namespace('levels', description='levels', path='/')
+api = Namespace('levels', description='Levels', path='/')
 
 LEVEL = api.model('Level', {
     'id': fields.Integer(required=True),

--- a/open_event/api/login.py
+++ b/open_event/api/login.py
@@ -1,0 +1,31 @@
+import json
+from flask.ext.restplus import Resource, Namespace, fields
+from custom_fields import EmailField
+from helpers import _error_abort
+from flask_jwt import JWTError
+
+api = Namespace('login', description='Login')
+
+LOGIN = api.model('Login', {
+    'email': EmailField(required=True),
+    'password': fields.String(required=True)
+})
+
+TOKEN = api.model('Token', {
+    'access_token': fields.String
+})
+
+
+@api.route('')
+class Login(Resource):
+    @api.doc('get_token')
+    @api.expect(LOGIN, validate=True)
+    @api.marshal_with(TOKEN)
+    @api.response(401, 'Authentication Failed')
+    def post(self):
+        from .. import jwt
+        try:
+            response = jwt.auth_request_callback()
+            return json.loads(response.data)
+        except JWTError as e:
+            _error_abort(401, '%s: %s' % (e.error, e.description))

--- a/open_event/api/microlocations.py
+++ b/open_event/api/microlocations.py
@@ -5,7 +5,7 @@ from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
     PAGE_PARAMS, POST_RESPONSES
 
-api = Namespace('microlocations', description='microlocations', path='/')
+api = Namespace('microlocations', description='Microlocations', path='/')
 
 MICROLOCATION = api.model('Microlocation', {
     'id': fields.Integer(required=True),

--- a/open_event/api/sponsors.py
+++ b/open_event/api/sponsors.py
@@ -6,7 +6,7 @@ from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
     PAGE_PARAMS, POST_RESPONSES
 
-api = Namespace('sponsors', description='sponsors', path='/')
+api = Namespace('sponsors', description='Sponsors', path='/')
 
 SPONSOR = api.model('Sponsor', {
     'id': fields.Integer(required=True),

--- a/open_event/helpers/jwt.py
+++ b/open_event/helpers/jwt.py
@@ -1,0 +1,21 @@
+from flask.ext.scrypt import check_password_hash
+from open_event.models.user import User
+
+
+def jwt_authenticate(email, password):
+    user = User.query.filter_by(email=email).first()
+    if user is None:
+        return None
+    auth_ok = check_password_hash(
+        password.encode('utf-8'),
+        user.password.encode('utf-8'),
+        user.salt
+    )
+    if auth_ok:
+        return user
+    else:
+        return None
+
+
+def jwt_identity(payload):
+    return User.query.get(payload['identity'])

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -10,6 +10,7 @@ Flask-Login==0.3.2
 Flask-Scrypt==0.1.3.6
 Flask-Cors==2.1.2
 flask-restplus==0.9.2
+Flask-JWT==0.3.2
 requests-oauthlib==0.6.1
 
 icalendar==3.9.2

--- a/tests/api/test_post_api_auth.py
+++ b/tests/api/test_post_api_auth.py
@@ -65,5 +65,50 @@ class TestPostApiBasicAuth(OpenEventTestCase):
         self._test_model('sponsor', POST_SPONSOR_DATA)
 
 
+class TestPostApiJWTAuth(TestPostApiBasicAuth):
+    """
+    Tests the JWT Auth in Post API
+    """
+    def _send_login_request(self, password):
+        """
+        sends a login request and returns the response
+        """
+        response = self.app.post(
+            '/api/v2/login',
+            data=json.dumps({
+                'email': 'myemail@gmail.com',
+                'password': password
+            }),
+            headers={'content-type': 'application/json'}
+        )
+        return response
+
+    def _test_model(self, name, data):
+        """
+        1. Test getting JWT token with wrong credentials and getting 401
+        2. Get JWT token with right credentials
+        3. Send a sample successful POST request
+        """
+        path = get_path() if name == 'event' else get_path(1, name + 's')
+        # get access token
+        response = self._send_login_request('wrong_password')
+        self.assertEqual(response.status_code, 401)
+        response = self._send_login_request('test')
+        self.assertEqual(response.status_code, 200)
+        token = json.loads(response.data)['access_token']
+        # send a post request
+        response = self.app.post(
+            path,
+            data=json.dumps(data),
+            headers={
+                'content-type': 'application/json',
+                'Authorization': 'JWT %s' % token
+            }
+        )
+        self.assertNotEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Test' + str(name).title(), response.data)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #603, #610 and includes fix for #641

Expiry time of token is set to 1 day.
Auth url is `api/v2/login`
Send there a POST request with email and password to get access_token . 
```
{
  "email": "email@gmail.com",
  "password": "test"
}
```
```
{
  "access_token": "string"
}
```

Include the token in Authorization header as "JWT _token_" for accessing authorized methods.

Note - I have not removed the basic auth. Both work. This is becasue many good services like GitHub allow their APIs to be accessed by both, access token and username:password authentication. Let's follow their example.
