### PR TITLE
Option to Export timeline as PNG

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,9 @@
     "jQuery-Smart-Wizard": "~3.3.1",
     "google-material-color": "~1.2.6",
     "datatables.net": "^1.10.12",
-    "datatables.net-bs": "^1.10.12"
+    "datatables.net-bs": "^1.10.12",
+    "html2canvas": "^0.4.1",
+    "file-saver": "^1.3.1",
+    "blob": "*"
   }
 }

--- a/open_event/static/css/admin/scheduling.css
+++ b/open_event/static/css/admin/scheduling.css
@@ -62,6 +62,10 @@
     cursor: pointer
 }
 
+#timeline {
+    background-color: #FFFFFF;
+}
+
 .timeline-table td {
     z-index: -1 !important;
 }

--- a/open_event/static/js/admin/event/scheduling.js
+++ b/open_event/static/js/admin/event/scheduling.js
@@ -773,6 +773,16 @@ $addMicrolocationForm.submit(function (event) {
     });
 });
 
+$(".export-png-button").click(function () {
+    html2canvas($timeline[0], {
+        onrendered: function (canvas) {
+            canvas.id = "generated-canvas";
+            canvas.toBlob(function (blob) {
+                saveAs(blob, "timeline.png");
+            });
+        }
+    });
+});
 
 /**
  * Global document events for date change button, remove button and clear overlaps button

--- a/open_event/static/js/jquery/canvas-to-blob.min.js
+++ b/open_event/static/js/jquery/canvas-to-blob.min.js
@@ -1,0 +1,12 @@
+/* canvas-toBlob.js
+ * A canvas.toBlob() implementation.
+ * 2016-05-26
+ *
+ * By Eli Grey, http://eligrey.com and Devin Samarin, https://github.com/eboyjr
+ * License: MIT
+ *   See https://github.com/eligrey/canvas-toBlob.js/blob/master/LICENSE.md
+ */
+/*global self */
+/*jslint bitwise: true, regexp: true, confusion: true, es5: true, vars: true, white: true,
+  plusplus: true */
+!function(t){"use strict";var o,e=t.Uint8Array,n=t.HTMLCanvasElement,i=n&&n.prototype,s=/\s*;\s*base64\s*(?:;|$)/i,a="toDataURL",l=function(t){for(var n,i,s,a=t.length,l=new e(a/4*3|0),r=0,b=0,d=[0,0],f=0,B=0;a--;)i=t.charCodeAt(r++),n=o[i-43],255!==n&&n!==s&&(d[1]=d[0],d[0]=i,B=B<<6|n,f++,4===f&&(l[b++]=B>>>16,61!==d[1]&&(l[b++]=B>>>8),61!==d[0]&&(l[b++]=B),f=0));return l};e&&(o=new e([62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,0,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51])),!n||i.toBlob&&i.toBlobHD||(i.toBlob||(i.toBlob=function(t,o){if(o||(o="image/png"),this.mozGetAsFile)return void t(this.mozGetAsFile("canvas",o));if(this.msToBlob&&/^\s*image\/png\s*(?:$|;)/i.test(o))return void t(this.msToBlob());var n,i=Array.prototype.slice.call(arguments,1),r=this[a].apply(this,i),b=r.indexOf(","),d=r.substring(b+1),f=s.test(r.substring(0,b));Blob.fake?(n=new Blob,f?n.encoding="base64":n.encoding="URI",n.data=d,n.size=d.length):e&&(n=f?new Blob([l(d)],{type:o}):new Blob([decodeURIComponent(d)],{type:o})),t(n)}),!i.toBlobHD&&i.toDataURLHD?i.toBlobHD=function(){a="toDataURLHD";var t=this.toBlob();return a="toDataURL",t}:i.toBlobHD=i.toBlob)}("undefined"!=typeof self&&self||"undefined"!=typeof window&&window||this.content||this);

--- a/open_event/templates/gentelella/admin/event/details/details.html
+++ b/open_event/templates/gentelella/admin/event/details/details.html
@@ -2,7 +2,6 @@
 {% block head_css %}
     {{ super() }}
     <link href="{{ url_for('static', filename='css/admin/scheduling.css') }}" rel="stylesheet">
-    <link href="{{ url_for('static', filename='admin/lib/pnotify/dist/pnotify.css') }}" rel="stylesheet">
     <link href="{{ url_for('static', filename='admin/lib/bootstrap-daterangepicker/daterangepicker.css') }}" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='admin/lib/bootstrap-colorpicker/dist/css/bootstrap-colorpicker.min.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='admin/lib/datatables.net-bs/css/dataTables.bootstrap.min.css') }}" />

--- a/open_event/templates/gentelella/admin/event/details/details.html
+++ b/open_event/templates/gentelella/admin/event/details/details.html
@@ -105,8 +105,12 @@
     <script src="{{ url_for('static', filename='admin/lib/bootstrap-colorpicker/dist/js/bootstrap-colorpicker.min.js') }}"></script>
     <script src="{{ url_for('static', filename='admin/lib/google-material-color/dist/palette.js') }}"></script>
     <script src="{{ url_for('static', filename='admin/lib/lodash/dist/lodash.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='admin/lib/bootstrap-daterangepicker/daterangepicker.js') }}"></script>
+    <script src="{{ url_for('static', filename='admin/lib/blob/Blob.js') }}"></script>
+    <script src="{{ url_for('static', filename='admin/lib/file-saver/FileSaver.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='admin/lib/html2canvas/build/html2canvas.min.js') }}"></script>
 
-    <script type="text/javascript" src="{{ url_for('static', filename='admin/lib/bootstrap-daterangepicker/daterangepicker.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/jquery/canvas-to-blob.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/jquery/jquery.ellipsis.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='admin/lib/jQuery-Smart-Wizard/js/jquery.smartWizard.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/jquery/jquery.codezero.js') }}"></script>

--- a/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
+++ b/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
@@ -37,11 +37,15 @@
                 <div class="btn-group" role="group">
                     <button type="button" class="btn btn-default clear-overlaps-button">Clear Overlaps</button>
                     <button type="button" class="btn btn-default" data-toggle="modal"
-                            data-target="#add-microlocation-modal"
-                            style="float:right;">Add New Microlocation
+                            data-target="#add-microlocation-modal">Add New Microlocation
                     </button>
-                     <button type="button" class="btn btn-default" style="float:right;" onclick="return export_as_ical();">Export as iCal</button>
                 </div>
+
+                <div class="btn-group" role="group">
+                    <button type="button" class="btn btn-default"  onclick="return export_as_ical();">Export as iCal</button>
+                    <button type="button" class="btn btn-default export-png-button" >Export as PNG</button>
+                </div>
+
             </div>
             <div class="timeline" id="timeline" data-event-id="{{ event.id }}"
                  style="margin-top: 10px; margin-left: 10px; width: 100%;">


### PR DESCRIPTION
An option to download the timeline as a PNG has been added. _(Which could be printed by the organizers and distributed to the participants or displayed somewhere at the venue or emailed to all registrants)._

Resolves #512.

> The initial plan was to generate a PDF. But that was not feasible, as client-side PDF generation of HTML content is still experimental. For example, [jsPDF](https://github.com/MrRio/jsPDF) supports only basic HTML content and styles are ignored.

@SaptakS @rafalkowalski please review and merge into `development`