### PR TITLE
Use JWT for API Authentication in the Scheduler UI

### DIFF
--- a/open_event/static/js/admin/event/scheduling.js
+++ b/open_event/static/js/admin/event/scheduling.js
@@ -752,7 +752,7 @@ $addMicrolocationForm.submit(function (event) {
     };
     $.ajax({
         beforeSend: function (xhr) {
-            xhr.setRequestHeader("Authorization", "Basic " + btoa(getCookie("username").replace(/['"]+/g, '') + ":" + getCookie("password")));
+            xhr.setRequestHeader("Authorization", "jwt " + getCookie("access_token"));
         },
         type: "POST",
         contentType: "application/json; charset=utf-8",

--- a/open_event/views/admin/home.py
+++ b/open_event/views/admin/home.py
@@ -6,29 +6,12 @@ from flask.ext import login
 from flask_admin import expose
 from flask_admin.base import AdminIndexView
 from flask.ext.scrypt import generate_password_hash
-from datetime import datetime
-import jwt
 
 from ...helpers.data import DataManager, save_to_db,get_google_auth,get_facebook_auth
 from ...helpers.data_getter import DataGetter
 from ...helpers.helpers import send_email_after_account_create, send_email_with_reset_password_hash
 from open_event.helpers.oauth import OAuth, FbOAuth
 from flask import current_app
-
-def generate_token(user):
-    _jwt = current_app.extensions['jwt']
-    iat = datetime.utcnow()
-    exp = iat + current_app.config.get('JWT_EXPIRATION_DELTA')
-    nbf = iat + current_app.config.get('JWT_NOT_BEFORE_DELTA')
-    payload = {'exp': exp, 'iat': iat, 'nbf': nbf, 'identity': user.id}
-    secret = current_app.config['JWT_SECRET_KEY']
-    algorithm = current_app.config['JWT_ALGORITHM']
-    required_claims = current_app.config['JWT_REQUIRED_CLAIMS']
-    missing_claims = list(set(required_claims) - set(payload.keys()))
-    if missing_claims:
-        raise RuntimeError('Payload is missing required claims: %s' % ', '.join(missing_claims))
-    headers = _jwt.jwt_headers_callback(user)
-    return jwt.encode(payload, secret, algorithm=algorithm, headers=headers)
 
 def intended_url():
     return request.args.get('next') or url_for('.index')
@@ -61,12 +44,16 @@ class MyHomeView(AdminIndexView):
             if user.password != generate_password_hash(request.form['password'], user.salt):
                 logging.info('Password Incorrect')
                 return redirect(url_for('admin.login_view'))
-            token = generate_token(user)
+
+            _jwt = current_app.extensions['jwt']
+            identity = _jwt.authentication_callback(email, request.form['password'])
+            access_token = _jwt.jwt_encode_callback(identity)
+            
             login.login_user(user)
             logging.info('logged successfully')
             redirect_to_intended = redirect(intended_url())
             response = current_app.make_response(redirect_to_intended)
-            response.set_cookie('access_token', value=token)
+            response.set_cookie('access_token', value=access_token)
             return response
 
     @expose('/register/', methods=('GET', 'POST'))


### PR DESCRIPTION
Since JWT has been implemented in #642 . I have switched from Basic username:password authentication to the new token-based authentication. 

When a user logs into the admin panel, a token for that user is generated and stored in a cookie named `access_token` which can then be used throughout the panel for any API calls. 

A javascript helper function has been provided in `open_event/static/js/jquery/jquery.codezero.js` for reading cookies. `getCookie('access_token')` would provide the access token. 

@rafalkowalski @aviaryan @SaptakS please review and merge into `development`