### PR TITLE
Remove unnecessary authorization header

### DIFF
--- a/open_event/static/js/admin/event/scheduling.js
+++ b/open_event/static/js/admin/event/scheduling.js
@@ -751,9 +751,6 @@ $addMicrolocationForm.submit(function (event) {
         "floor": parseInt($addMicrolocationForm.find("input[name=floor]").val())
     };
     $.ajax({
-        beforeSend: function (xhr) {
-            xhr.setRequestHeader("Authorization", "Basic " + btoa(getCookie("username").replace(/['"]+/g, '') + ":" + getCookie("password")));
-        },
         type: "POST",
         contentType: "application/json; charset=utf-8",
         dataType: "json",

--- a/open_event/views/admin/home.py
+++ b/open_event/views/admin/home.py
@@ -10,9 +10,7 @@ from flask.ext.scrypt import generate_password_hash
 from ...helpers.data import DataManager, save_to_db,get_google_auth,get_facebook_auth
 from ...helpers.data_getter import DataGetter
 from ...helpers.helpers import send_email_after_account_create, send_email_with_reset_password_hash
-from open_event.models.user import User
 from open_event.helpers.oauth import OAuth, FbOAuth
-from flask import current_app
 
 def intended_url():
     return request.args.get('next') or url_for('.index')
@@ -47,14 +45,7 @@ class MyHomeView(AdminIndexView):
                 return redirect(url_for('admin.login_view'))
             login.login_user(user)
             logging.info('logged successfully')
-            redirect_to_intended = redirect(intended_url())
-            response = current_app.make_response(redirect_to_intended)
-
-            # TODO Remove these cookie setters once a proper token-based auth is available in the API. -@niranjan94
-            response.set_cookie('username', value=email)
-            response.set_cookie('password', value=request.form['password'])
-
-            return response
+            return redirect(intended_url())
 
     @expose('/register/', methods=('GET', 'POST'))
     def register_view(self):


### PR DESCRIPTION
From #647:
> @aviaryan: Hey, the authentication system of the API also checks for current session (using flask-login) if both jwt and basic auth tokens are not present. So JWT is practically not needed for the Scheduler UI. Any POST/PUT/DELETE request sent from the orga-server project is automatically authenticated by the current logged in user.  I guess it will be better if the Auth header is completely dropped.

So, that means, we do not need an Authorization header while calling the API from the Admin Panel :tada: :smile: ... 

This PR removes the authorization header that was added in PR #600. 

@SaptakS @rafalkowalski @aviaryan please review and merge.