### PR TITLE
Save each session change/update using the API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "datatables.net-bs": "^1.10.12",
     "html2canvas": "^0.4.1",
     "file-saver": "^1.3.1",
-    "blob": "*"
+    "blob": "*",
+    "swagger-js": "^2.1.14"
   }
 }

--- a/open_event/static/js/admin/api.js
+++ b/open_event/static/js/admin/api.js
@@ -1,0 +1,18 @@
+/**
+ * Created by Niranjan on 09-Jun-16.
+ */
+
+/**
+ * A Swagger Client to access the API.
+ * @doc https://github.com/swagger-api/swagger-js
+ */
+$.getScript("/static/admin/lib/swagger-js/browser/swagger-client.min.js", function () {
+    // Full URL is necessary for proper port handling -@niranjan94
+    var swaggerConfigUrl = window.location.protocol + "//" + window.location.host + "/api/v2/swagger.json";
+    window.api = new SwaggerClient({
+        url: swaggerConfigUrl,
+        success: function () {
+            $(document).trigger("swagger:loaded");
+        }
+    });
+});

--- a/open_event/static/js/admin/event/scheduling.js
+++ b/open_event/static/js/admin/event/scheduling.js
@@ -66,6 +66,7 @@ var days = [];
 var sessionsStore = [];
 var microlocationsStore = [];
 var unscheduledStore = [];
+var eventId;
 
 /**
  * jQuery OBJECT REFERENCES
@@ -750,23 +751,17 @@ $addMicrolocationForm.submit(function (event) {
         "longitude": parseFloat($addMicrolocationForm.find("input[name=longitude]").val()),
         "floor": parseInt($addMicrolocationForm.find("input[name=floor]").val())
     };
-    $.ajax({
-        type: "POST",
-        contentType: "application/json; charset=utf-8",
-        dataType: "json",
-        url: $addMicrolocationForm.attr("action"),
-        data: JSON.stringify(payload),
-        success: function (microlocation) {
-            addMicrolocationToTimeline(microlocation);
-            $('#close-add-microlocation').click();
-            $addMicrolocationForm.find("input, textarea").val("");
-            createSnackbar("Microlocation has been created successfully.");
-        },
-        failure: function () {
-            createSnackbar("An error occurred while creating microlocation.", "Try Again", function () {
-                $addMicrolocationForm.trigger("submit");
-            });
-        }
+
+    api.microlocations.post_microlocation_list({event_id: eventId, payload: payload}, function (success) {
+        addMicrolocationToTimeline(success.obj);
+        $addMicrolocationForm.find(".modal").modal("hide");
+        $addMicrolocationForm.find("input, textarea").val("");
+        createSnackbar("Microlocation has been created successfully.");
+    }, function (error) {
+        console.log('failed with the following: ' + error.statusText);
+        createSnackbar("An error occurred while creating microlocation.", "Try Again", function () {
+            $addMicrolocationForm.trigger("submit");
+        });
     });
 });
 
@@ -798,7 +793,7 @@ $(document)
  * Initialize the Scheduler UI on document ready
  */
 $(document).ready(function () {
-    var eventId = $timeline.data("event-id");
+    eventId = parseInt($timeline.data("event-id"));
     generateTimeUnits();
     initializeTimeline(eventId);
 });

--- a/open_event/templates/gentelella/admin/base.html
+++ b/open_event/templates/gentelella/admin/base.html
@@ -19,6 +19,8 @@
 
     {% block head_js %}
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
+        {# Globally included Swagger API Client. See the file for more details. #}
+        <script type="text/javascript" src="{{ url_for('static', filename='js/admin/api.js') }}"></script>
     {% endblock %}
 </head>
 <body class="nav-md">

--- a/open_event/templates/gentelella/admin/event/details/details.html
+++ b/open_event/templates/gentelella/admin/event/details/details.html
@@ -108,6 +108,8 @@
     <script src="{{ url_for('static', filename='admin/lib/blob/Blob.js') }}"></script>
     <script src="{{ url_for('static', filename='admin/lib/file-saver/FileSaver.min.js') }}"></script>
     <script src="{{ url_for('static', filename='admin/lib/html2canvas/build/html2canvas.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='admin/lib/datatables.net/js/jquery.dataTables.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='admin/lib/datatables.net-bs/js/dataTables.bootstrap.min.js') }}"></script>
 
     <script src="{{ url_for('static', filename='js/jquery/canvas-to-blob.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/jquery/jquery.ellipsis.js') }}"></script>
@@ -117,8 +119,6 @@
     <script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/scheduling.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/callForPaper.js') }}"></script>
 
-    <script type="text/javascript" src="{{ url_for('static', filename='admin/lib/datatables.net/js/jquery.dataTables.min.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='admin/lib/datatables.net-bs/js/dataTables.bootstrap.min.js') }}"></script>
     <script type="text/javascript">
         $('.role-table').DataTable();
     </script>

--- a/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
+++ b/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
@@ -155,7 +155,7 @@
     </div>
 </form>
 
-<form id="add-microlocation-form" method="post" action="{{ url_for('api.microlocations_microlocation_list', event_id=event.id) }}">
+<form id="add-microlocation-form" method="post">
     <div class="modal fade" id="add-microlocation-modal" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal-sm">
             <div class="modal-content">

--- a/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
+++ b/open_event/templates/gentelella/admin/event/details/steps/scheduling.html
@@ -144,7 +144,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" id="close-add-microlocation" class="btn btn-default" data-dismiss="modal">
+                    <button type="button" id="close-edit-session" class="btn btn-default" data-dismiss="modal">
                         Close
                     </button>
                     <button type="submit" class="btn btn-primary">Update Session Information</button>


### PR DESCRIPTION
Anytime a session is rescheduled (move or resize) with the scheduling UI, the updated timings and track has to be stored to the database. This has been implemented in this PR.

Resolves #412 

Also included in this PR:
- A globally accessible Swagger javascript client to make API calls easily (eb201ac6ee487fb994bfc087c989c388ee23e30f and ee8d46937bd1211bacf059927e91788d1a76fd9a)

@SaptakS @rafalkowalski please review and merge into `development`