### PR TITLE
Full custom validation in API

### DIFF
--- a/open_event/api/custom_fields.py
+++ b/open_event/api/custom_fields.py
@@ -12,6 +12,12 @@ class CustomField(Raw):
     """
     Custom Field base class with validate feature
     """
+    __schema_type__ = 'string'
+
+    def __init__(self, *args, **kwargs):
+        super(CustomField, self).__init__(**kwargs)
+        # can be used for managing params
+
     def format(self, value):
         """
         format the text in database for output
@@ -48,7 +54,6 @@ class EmailField(CustomField):
     """
     Email field
     """
-    __schema_type__ = 'string'
     __schema_format__ = 'email'
     __schema_example__ = 'email@domain.com'
 
@@ -64,7 +69,6 @@ class UriField(CustomField):
     """
     URI (link) field
     """
-    __schema_type__ = 'string'
     __schema_format__ = 'uri'
     __schema_example__ = 'http://website.com'
 
@@ -87,7 +91,6 @@ class ColorField(CustomField):
     """
     Color (or colour) field
     """
-    __schema_type__ = 'string'
     __schema_format__ = 'color'
     __schema_example__ = 'green'
 
@@ -106,7 +109,6 @@ class DateTimeField(CustomField):
     """
     Custom DateTime field
     """
-    __schema_type__ = 'string'
     __schema_format__ = 'date-time'
     __schema_example__ = '2016-06-06 11:22:33'
     dt_format = '%Y-%m-%d %H:%M:%S'
@@ -133,3 +135,52 @@ class DateTimeField(CustomField):
         except Exception:
             return False
         return True
+
+
+class StringField(CustomField):
+    """
+    Custom String Field
+    """
+    def validate(self, value):
+        if not value:
+            return self.validate_empty()
+        if value.__class__.__name__ in ['unicode', 'str']:
+            return True
+        else:
+            return False
+
+
+class IntegerField(CustomField):
+    """
+    Custom Integer Field
+    """
+    __schema_type__ = 'integer'
+    __schema_format__ = 'int'
+    __schema_example__ = 0
+
+    def validate(self, value):
+        if value is None:
+            return self.validate_empty()
+        if type(value) == int and value >= 0:
+            # No <0 int values right now
+            return True
+        else:
+            return False
+
+
+class FloatField(CustomField):
+    """
+    Custom Float Field
+    """
+    __schema_type__ = 'number'
+    __schema_format__ = 'float'
+    __schema_example__ = 0.0
+
+    def validate(self, value):
+        if value is None:
+            return self.validate_empty()
+        try:
+            float(value)
+            return True
+        except Exception:
+            return False

--- a/open_event/api/custom_fields.py
+++ b/open_event/api/custom_fields.py
@@ -1,7 +1,7 @@
 import re
 import colour
 from datetime import datetime
-from flask.ext.restplus.fields import Raw
+from flask.ext.restplus.fields import Raw, Nested, List
 
 
 EMAIL_REGEX = re.compile(r'\S+@\S+\.\S+')
@@ -50,7 +50,7 @@ class CustomField(Raw):
         pass
 
 
-class EmailField(CustomField):
+class Email(CustomField):
     """
     Email field
     """
@@ -65,7 +65,7 @@ class EmailField(CustomField):
         return True
 
 
-class UriField(CustomField):
+class Uri(CustomField):
     """
     URI (link) field
     """
@@ -80,14 +80,14 @@ class UriField(CustomField):
         return True
 
 
-class ImageUriField(UriField):
+class ImageUri(Uri):
     """
     Image URL (url ends with image.ext) field
     """
     __schema_example__ = 'http://website.com/image.ext'
 
 
-class ColorField(CustomField):
+class Color(CustomField):
     """
     Color (or colour) field
     """
@@ -105,7 +105,7 @@ class ColorField(CustomField):
         return True
 
 
-class DateTimeField(CustomField):
+class DateTime(CustomField):
     """
     Custom DateTime field
     """
@@ -137,7 +137,7 @@ class DateTimeField(CustomField):
         return True
 
 
-class StringField(CustomField):
+class String(CustomField):
     """
     Custom String Field
     """
@@ -150,7 +150,7 @@ class StringField(CustomField):
             return False
 
 
-class IntegerField(CustomField):
+class Integer(CustomField):
     """
     Custom Integer Field
     """
@@ -168,7 +168,7 @@ class IntegerField(CustomField):
             return False
 
 
-class FloatField(CustomField):
+class Float(CustomField):
     """
     Custom Float Field
     """

--- a/open_event/api/custom_fields.py
+++ b/open_event/api/custom_fields.py
@@ -16,7 +16,8 @@ class CustomField(Raw):
 
     def __init__(self, *args, **kwargs):
         super(CustomField, self).__init__(**kwargs)
-        # can be used for managing params
+        # custom params
+        self.positive = kwargs.get('positive', True)
 
     def format(self, value):
         """
@@ -153,6 +154,8 @@ class String(CustomField):
 class Integer(CustomField):
     """
     Custom Integer Field
+    Args:
+        :positive - accept only positive numbers, True by default
     """
     __schema_type__ = 'integer'
     __schema_format__ = 'int'
@@ -161,11 +164,11 @@ class Integer(CustomField):
     def validate(self, value):
         if value is None:
             return self.validate_empty()
-        if type(value) == int and value >= 0:
-            # No <0 int values right now
-            return True
-        else:
+        if type(value) != int:
             return False
+        if self.positive and value < 0:
+            return False
+        return True
 
 
 class Float(CustomField):

--- a/open_event/api/events.py
+++ b/open_event/api/events.py
@@ -70,7 +70,7 @@ class Event(Resource):
     @requires_auth
     @api.doc('update_event', responses=PUT_RESPONSES)
     @api.marshal_with(EVENT)
-    @api.expect(EVENT_POST, validate=True)
+    @api.expect(EVENT_POST)
     def put(self, event_id):
         """Update a event given its id"""
         validate_payload(self.api.payload, EVENT_POST)

--- a/open_event/api/events.py
+++ b/open_event/api/events.py
@@ -1,8 +1,7 @@
-from flask.ext.restplus import Resource, Namespace, fields
+from flask.ext.restplus import Resource, Namespace
 from flask import g
 
-from custom_fields import EmailField, ColorField, UriField, ImageUriField,\
-    DateTimeField
+import custom_fields as fields
 from open_event.models.event import Event as EventModel, EventsUsers
 from open_event.models.user import ADMIN, SUPERADMIN
 from .helpers import get_object_list, get_object_or_404, get_paginated_list,\
@@ -15,20 +14,20 @@ api = Namespace('events', description='Events')
 
 EVENT = api.model('Event', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
-    'email': EmailField(),
-    'color': ColorField(),
-    'logo': ImageUriField(),
-    'start_time': DateTimeField(required=True),
-    'end_time': DateTimeField(required=True),
-    'latitude': fields.Float,
-    'longitude': fields.Float,
-    'event_url': UriField(),
-    'background_url': UriField(),
-    'description': fields.String,
-    'location_name': fields.String,
-    'state': fields.String,
-    'closing_datetime': DateTimeField(),
+    'name': fields.String(required=True),
+    'email': fields.Email(),
+    'color': fields.Color(),
+    'logo': fields.ImageUri(),
+    'start_time': fields.DateTime(required=True),
+    'end_time': fields.DateTime(required=True),
+    'latitude': fields.Float(),
+    'longitude': fields.Float(),
+    'event_url': fields.Uri(),
+    'background_url': fields.Uri(),
+    'description': fields.String(),
+    'location_name': fields.String(),
+    'state': fields.String(),
+    'closing_datetime': fields.DateTime(),
 })
 
 EVENT_PAGINATED = api.clone('EventPaginated', PAGINATED_MODEL, {
@@ -90,7 +89,7 @@ class EventList(Resource):
     @requires_auth
     @api.doc('create_event', responses=POST_RESPONSES)
     @api.marshal_with(EVENT)
-    @api.expect(EVENT_POST, validate=True)
+    @api.expect(EVENT_POST)
     def post(self):
         """Create an event"""
         validate_payload(self.api.payload, EVENT_POST)

--- a/open_event/api/formats.py
+++ b/open_event/api/formats.py
@@ -1,5 +1,5 @@
-from flask.ext.restplus import Resource, Namespace, fields
-
+from flask.ext.restplus import Resource, Namespace
+import custom_fields as fields
 from open_event.models.session import Format as FormatModel
 from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
@@ -10,8 +10,8 @@ api = Namespace('formats', description='Formats', path='/')
 # Create models
 FORMAT = api.model('Format', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
-    'label_en': fields.String,
+    'name': fields.String(),
+    'label_en': fields.String(),
 })
 
 FORMAT_PAGINATED = api.clone('FormatPaginated', PAGINATED_MODEL, {

--- a/open_event/api/formats.py
+++ b/open_event/api/formats.py
@@ -49,7 +49,7 @@ class Format(Resource):
     @requires_auth
     @api.doc('update_format', responses=PUT_RESPONSES)
     @api.marshal_with(FORMAT)
-    @api.expect(FORMAT_POST, validate=True)
+    @api.expect(FORMAT_POST)
     def put(self, event_id, format_id):
         """Update a format given its id"""
         DAO.validate(self.api.payload, FORMAT_POST)
@@ -67,7 +67,7 @@ class FormatList(Resource):
     @requires_auth
     @api.doc('create_format', responses=POST_RESPONSES)
     @api.marshal_with(FORMAT)
-    @api.expect(FORMAT_POST, validate=True)
+    @api.expect(FORMAT_POST)
     def post(self, event_id):
         """Create a format"""
         DAO.validate(self.api.payload, FORMAT_POST)

--- a/open_event/api/helpers.py
+++ b/open_event/api/helpers.py
@@ -139,6 +139,11 @@ def validate_payload(payload, api_model):
       flask restplus automatically.
     - This is to be called at the start of a post or put method
     """
+    # check if any reqd fields are missing in payload
+    for key in api_model:
+        if api_model[key].required and key not in payload:
+            _error_abort(400, 'Required field \'%s\' missing' % key)
+    # check payload
     for key in payload:
         field = api_model[key]
         if isinstance(field, fields.List):

--- a/open_event/api/helpers.py
+++ b/open_event/api/helpers.py
@@ -1,6 +1,6 @@
 from functools import wraps
 from flask import request, g
-from flask.ext.restplus import abort
+from flask.ext.restplus import abort, fields
 from flask.ext import login
 from flask.ext.scrypt import check_password_hash
 from flask_jwt import jwt_required, JWTError, current_identity
@@ -141,6 +141,9 @@ def validate_payload(payload, api_model):
     """
     for key in payload:
         field = api_model[key]
+        if isinstance(field, fields.List):
+            field = field.container
+            print field.validate
         if isinstance(field, CustomField) and hasattr(field, 'validate'):
             if not field.validate(payload[key]):
                 _error_abort(400, 'Validation of \'%s\' field failed' % key)

--- a/open_event/api/helpers.py
+++ b/open_event/api/helpers.py
@@ -143,10 +143,13 @@ def validate_payload(payload, api_model):
         field = api_model[key]
         if isinstance(field, fields.List):
             field = field.container
-            print field.validate
+            data = payload[key]
+        else:
+            data = [payload[key]]
         if isinstance(field, CustomField) and hasattr(field, 'validate'):
-            if not field.validate(payload[key]):
-                _error_abort(400, 'Validation of \'%s\' field failed' % key)
+            for i in data:
+                if not field.validate(i):
+                    _error_abort(400, 'Validation of \'%s\' field failed' % key)
 
 
 def save_db_model(new_model, model_name, event_id=None):

--- a/open_event/api/languages.py
+++ b/open_event/api/languages.py
@@ -49,7 +49,7 @@ class Language(Resource):
     @requires_auth
     @api.doc('update_language', responses=PUT_RESPONSES)
     @api.marshal_with(LANGUAGE)
-    @api.expect(LANGUAGE_POST, validate=True)
+    @api.expect(LANGUAGE_POST)
     def put(self, event_id, language_id):
         """Update a language given its id"""
         DAO.validate(self.api.payload, LANGUAGE_POST)
@@ -67,7 +67,7 @@ class LanguageList(Resource):
     @requires_auth
     @api.doc('create_language', responses=POST_RESPONSES)
     @api.marshal_with(LANGUAGE)
-    @api.expect(LANGUAGE_POST, validate=True)
+    @api.expect(LANGUAGE_POST)
     def post(self, event_id):
         """Create a language"""
         DAO.validate(self.api.payload, LANGUAGE_POST)

--- a/open_event/api/languages.py
+++ b/open_event/api/languages.py
@@ -1,5 +1,5 @@
-from flask.ext.restplus import Resource, Namespace, fields
-
+from flask.ext.restplus import Resource, Namespace
+import custom_fields as fields
 from open_event.models.session import Language as LanguageModel
 from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
@@ -9,9 +9,9 @@ api = Namespace('languages', description='Languages', path='/')
 
 LANGUAGE = api.model('Language', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
-    'label_en': fields.String,
-    'label_de': fields.String,
+    'name': fields.String(),
+    'label_en': fields.String(),
+    'label_de': fields.String(),
 })
 
 LANGUAGE_PAGINATED = api.clone('LanguagePaginated', PAGINATED_MODEL, {

--- a/open_event/api/levels.py
+++ b/open_event/api/levels.py
@@ -48,7 +48,7 @@ class Level(Resource):
     @requires_auth
     @api.doc('update_level', responses=PUT_RESPONSES)
     @api.marshal_with(LEVEL)
-    @api.expect(LEVEL_POST, validate=True)
+    @api.expect(LEVEL_POST)
     def put(self, event_id, level_id):
         """Update a level given its id"""
         DAO.validate(self.api.payload, LEVEL_POST)
@@ -66,7 +66,7 @@ class LevelList(Resource):
     @requires_auth
     @api.doc('create_level', responses=POST_RESPONSES)
     @api.marshal_with(LEVEL)
-    @api.expect(LEVEL_POST, validate=True)
+    @api.expect(LEVEL_POST)
     def post(self, event_id):
         """Create a level"""
         DAO.validate(self.api.payload, LEVEL_POST)

--- a/open_event/api/levels.py
+++ b/open_event/api/levels.py
@@ -1,5 +1,5 @@
-from flask.ext.restplus import Resource, Namespace, fields
-
+from flask.ext.restplus import Resource, Namespace
+import custom_fields as fields
 from open_event.models.session import Level as LevelModel
 from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
@@ -9,8 +9,8 @@ api = Namespace('levels', description='Levels', path='/')
 
 LEVEL = api.model('Level', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
-    'label_en': fields.String,
+    'name': fields.String(),
+    'label_en': fields.String(),
 })
 
 LEVEL_PAGINATED = api.clone('LevelPaginated', PAGINATED_MODEL, {

--- a/open_event/api/login.py
+++ b/open_event/api/login.py
@@ -1,18 +1,18 @@
 import json
-from flask.ext.restplus import Resource, Namespace, fields
-from custom_fields import EmailField
+from flask.ext.restplus import Resource, Namespace
+import custom_fields as fields
 from helpers import _error_abort
 from flask_jwt import JWTError
 
 api = Namespace('login', description='Login')
 
 LOGIN = api.model('Login', {
-    'email': EmailField(required=True),
+    'email': fields.Email(required=True),
     'password': fields.String(required=True)
 })
 
 TOKEN = api.model('Token', {
-    'access_token': fields.String
+    'access_token': fields.String()
 })
 
 

--- a/open_event/api/login.py
+++ b/open_event/api/login.py
@@ -19,7 +19,7 @@ TOKEN = api.model('Token', {
 @api.route('')
 class Login(Resource):
     @api.doc('get_token')
-    @api.expect(LOGIN, validate=True)
+    @api.expect(LOGIN)
     @api.marshal_with(TOKEN)
     @api.response(401, 'Authentication Failed')
     def post(self):

--- a/open_event/api/microlocations.py
+++ b/open_event/api/microlocations.py
@@ -51,7 +51,7 @@ class Microlocation(Resource):
     @requires_auth
     @api.doc('update_microlocation', responses=PUT_RESPONSES)
     @api.marshal_with(MICROLOCATION)
-    @api.expect(MICROLOCATION_POST, validate=True)
+    @api.expect(MICROLOCATION_POST)
     def put(self, event_id, microlocation_id):
         """Update a microlocation given its id"""
         DAO.validate(self.api.payload, MICROLOCATION_POST)
@@ -69,7 +69,7 @@ class MicrolocationList(Resource):
     @requires_auth
     @api.doc('create_microlocation', responses=POST_RESPONSES)
     @api.marshal_with(MICROLOCATION)
-    @api.expect(MICROLOCATION_POST, validate=True)
+    @api.expect(MICROLOCATION_POST)
     def post(self, event_id):
         """Create a microlocation"""
         DAO.validate(self.api.payload, MICROLOCATION_POST)

--- a/open_event/api/microlocations.py
+++ b/open_event/api/microlocations.py
@@ -1,5 +1,5 @@
-from flask.ext.restplus import Resource, Namespace, fields
-
+from flask.ext.restplus import Resource, Namespace
+import custom_fields as fields
 from open_event.models.microlocation import Microlocation as MicrolocationModel
 from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
@@ -9,11 +9,11 @@ api = Namespace('microlocations', description='Microlocations', path='/')
 
 MICROLOCATION = api.model('Microlocation', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
-    'latitude': fields.Float,
-    'longitude': fields.Float,
-    'floor': fields.Integer,
-    'room': fields.String,
+    'name': fields.String(),
+    'latitude': fields.Float(),
+    'longitude': fields.Float(),
+    'floor': fields.Integer(),
+    'room': fields.String(),
 })
 
 MICROLOCATION_PAGINATED = api.clone('MicrolocationPaginated', PAGINATED_MODEL, {

--- a/open_event/api/sessions.py
+++ b/open_event/api/sessions.py
@@ -153,7 +153,7 @@ class Session(Resource):
     @requires_auth
     @api.doc('update_session', responses=PUT_RESPONSES)
     @api.marshal_with(SESSION)
-    @api.expect(SESSION_POST, validate=True)
+    @api.expect(SESSION_POST)
     def put(self, event_id, session_id):
         """Update a session given its id"""
         DAO.validate(self.api.payload, SESSION_POST)
@@ -171,7 +171,7 @@ class SessionList(Resource):
     @requires_auth
     @api.doc('create_session', responses=POST_RESPONSES)
     @api.marshal_with(SESSION)
-    @api.expect(SESSION_POST, validate=True)
+    @api.expect(SESSION_POST)
     def post(self, event_id):
         """Create a session"""
         DAO.validate(self.api.payload, SESSION_POST)

--- a/open_event/api/sessions.py
+++ b/open_event/api/sessions.py
@@ -1,4 +1,4 @@
-from flask.ext.restplus import Resource, Namespace, fields
+from flask.ext.restplus import Resource, Namespace
 from sqlalchemy.orm.collections import InstrumentedList
 
 from open_event.models.session import Session as SessionModel, \
@@ -9,7 +9,7 @@ from open_event.models.microlocation import Microlocation as MicrolocationModel
 from open_event.models.speaker import Speaker as SpeakerModel
 
 from .helpers import get_paginated_list, requires_auth, save_db_model
-from custom_fields import DateTimeField
+import custom_fields as fields
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
     PAGE_PARAMS, POST_RESPONSES, PUT_RESPONSES
 
@@ -18,43 +18,43 @@ api = Namespace('sessions', description='Sessions', path='/')
 # Create models
 SESSION_TRACK = api.model('SessionTrack', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
+    'name': fields.String(),
 })
 
 SESSION_SPEAKER = api.model('SessionSpeaker', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
+    'name': fields.String(),
 })
 
 SESSION_LEVEL = api.model('SessionLevel', {
     'id': fields.Integer(required=True),
-    'label_en': fields.String,
+    'label_en': fields.String(),
 })
 
 SESSION_LANGUAGE = api.model('SessionLanguage', {
     'id': fields.Integer(required=True),
-    'label_en': fields.String,
-    'label_de': fields.String,
+    'label_en': fields.String(),
+    'label_de': fields.String(),
 })
 
 SESSION_FORMAT = api.model('SessionFormat', {
     'id': fields.Integer(required=True),
-    'name': fields.String
+    'name': fields.String()
 })
 
 SESSION_MICROLOCATION = api.model('SessionMicrolocation', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
+    'name': fields.String(),
 })
 
 SESSION = api.model('Session', {
     'id': fields.Integer(required=True),
-    'title': fields.String,
-    'subtitle': fields.String,
-    'abstract': fields.String,
-    'description': fields.String,
-    'start_time': DateTimeField(),
-    'end_time': DateTimeField(),
+    'title': fields.String(),
+    'subtitle': fields.String(),
+    'abstract': fields.String(),
+    'description': fields.String(),
+    'start_time': fields.DateTime(),
+    'end_time': fields.DateTime(),
     'track': fields.Nested(SESSION_TRACK),
     'speakers': fields.List(fields.Nested(SESSION_SPEAKER)),
     'level': fields.Nested(SESSION_LEVEL),
@@ -68,12 +68,12 @@ SESSION_PAGINATED = api.clone('SessionPaginated', PAGINATED_MODEL, {
 })
 
 SESSION_POST = api.clone('SessionPost', SESSION, {
-    'track_id': fields.Integer,
-    'speaker_ids': fields.List(fields.Integer),
-    'level_id': fields.Integer,
-    'language_id': fields.Integer,
-    'format_id': fields.Integer,
-    'microlocation_id': fields.Integer
+    'track_id': fields.Integer(),
+    'speaker_ids': fields.List(fields.Integer()),
+    'level_id': fields.Integer(),
+    'language_id': fields.Integer(),
+    'format_id': fields.Integer(),
+    'microlocation_id': fields.Integer()
 })
 del SESSION_POST['id']
 del SESSION_POST['track']

--- a/open_event/api/speakers.py
+++ b/open_event/api/speakers.py
@@ -1,7 +1,7 @@
-from flask.ext.restplus import Resource, Namespace, fields
+from flask.ext.restplus import Resource, Namespace
 
 from open_event.models.speaker import Speaker as SpeakerModel
-from custom_fields import UriField, EmailField, ImageUriField
+import custom_fields as fields
 from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
     PAGE_PARAMS, POST_RESPONSES, PUT_RESPONSES
@@ -9,24 +9,24 @@ from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
 api = Namespace('speakers', description='Speakers', path='/')
 
 SPEAKER_SESSION = api.model('SpeakerSession', {
-    'id': fields.Integer,
-    'title': fields.String,
+    'id': fields.Integer(),
+    'title': fields.String(),
 })
 
 SPEAKER = api.model('Speaker', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
-    'photo': ImageUriField(),
-    'biography': fields.String,
-    'email': EmailField(),
-    'web': UriField(),
-    'twitter': fields.String,  # not sure for now whether uri or string field
-    'facebook': fields.String,
-    'github': fields.String,
-    'linkedin': fields.String,
-    'organisation': fields.String,
-    'position': fields.String,
-    'country': fields.String,
+    'name': fields.String(),
+    'photo': fields.ImageUri(),
+    'biography': fields.String(),
+    'email': fields.Email(),
+    'web': fields.Uri(),
+    'twitter': fields.String(),  # not sure for now whether uri or string field
+    'facebook': fields.String(),
+    'github': fields.String(),
+    'linkedin': fields.String(),
+    'organisation': fields.String(),
+    'position': fields.String(),
+    'country': fields.String(),
     'sessions': fields.List(fields.Nested(SPEAKER_SESSION)),
 })
 

--- a/open_event/api/speakers.py
+++ b/open_event/api/speakers.py
@@ -66,7 +66,7 @@ class Speaker(Resource):
     @requires_auth
     @api.doc('update_speaker', responses=PUT_RESPONSES)
     @api.marshal_with(SPEAKER)
-    @api.expect(SPEAKER_POST, validate=True)
+    @api.expect(SPEAKER_POST)
     def put(self, event_id, speaker_id):
         """Update a speaker given its id"""
         DAO.validate(self.api.payload, SPEAKER_POST)
@@ -84,7 +84,7 @@ class SpeakerList(Resource):
     @requires_auth
     @api.doc('create_speaker', responses=POST_RESPONSES)
     @api.marshal_with(SPEAKER)
-    @api.expect(SPEAKER_POST, validate=True)
+    @api.expect(SPEAKER_POST)
     def post(self, event_id):
         """Create a speaker"""
         DAO.validate(self.api.payload, SPEAKER_POST)

--- a/open_event/api/sponsor_types.py
+++ b/open_event/api/sponsor_types.py
@@ -47,7 +47,7 @@ class SponsorType(Resource):
     @requires_auth
     @api.doc('update_sponsor_type', responses=PUT_RESPONSES)
     @api.marshal_with(SPONSOR_TYPE)
-    @api.expect(SPONSOR_TYPE_POST, validate=True)
+    @api.expect(SPONSOR_TYPE_POST)
     def put(self, event_id, sponsor_type_id):
         """Update a sponsor_type given its id"""
         DAO.validate(self.api.payload, SPONSOR_TYPE_POST)
@@ -65,7 +65,7 @@ class SponsorTypeList(Resource):
     @requires_auth
     @api.doc('create_sponsor_type', responses=POST_RESPONSES)
     @api.marshal_with(SPONSOR_TYPE)
-    @api.expect(SPONSOR_TYPE_POST, validate=True)
+    @api.expect(SPONSOR_TYPE_POST)
     def post(self, event_id):
         """Create a sponsor_type"""
         DAO.validate(self.api.payload, SPONSOR_TYPE_POST)

--- a/open_event/api/sponsor_types.py
+++ b/open_event/api/sponsor_types.py
@@ -1,5 +1,5 @@
-from flask.ext.restplus import Resource, Namespace, fields
-
+from flask.ext.restplus import Resource, Namespace
+import custom_fields as fields
 from open_event.models.sponsor import SponsorType as SponsorTypeModel
 from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
@@ -9,7 +9,7 @@ api = Namespace('sponsor_types', description='SponsorTypes', path='/')
 
 SPONSOR_TYPE = api.model('SponsorType', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
+    'name': fields.String(),
 })
 
 SPONSOR_TYPE_PAGINATED = api.clone('SponsorTypePaginated', PAGINATED_MODEL, {

--- a/open_event/api/sponsors.py
+++ b/open_event/api/sponsors.py
@@ -54,7 +54,7 @@ class Sponsor(Resource):
     @requires_auth
     @api.doc('update_sponsor', responses=PUT_RESPONSES)
     @api.marshal_with(SPONSOR)
-    @api.expect(SPONSOR_POST, validate=True)
+    @api.expect(SPONSOR_POST)
     def put(self, event_id, sponsor_id):
         """Update a sponsor given its id"""
         DAO.validate(self.api.payload, SPONSOR_POST)
@@ -73,7 +73,7 @@ class SponsorList(Resource):
     @requires_auth
     @api.doc('create_sponsor', responses=POST_RESPONSES)
     @api.marshal_with(SPONSOR)
-    @api.expect(SPONSOR_POST, validate=True)
+    @api.expect(SPONSOR_POST)
     def post(self, event_id):
         """Create a sponsor"""
         DAO.validate(self.api.payload, SPONSOR_POST)

--- a/open_event/api/sponsors.py
+++ b/open_event/api/sponsors.py
@@ -1,7 +1,6 @@
-from flask.ext.restplus import Resource, Namespace, fields
-
+from flask.ext.restplus import Resource, Namespace
+import custom_fields as fields
 from open_event.models.sponsor import Sponsor as SponsorModel, SponsorType as SponsorTypeModel
-from custom_fields import UriField, ImageUriField
 from .helpers import get_paginated_list, requires_auth, get_object_in_event
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
     PAGE_PARAMS, POST_RESPONSES, PUT_RESPONSES
@@ -10,11 +9,11 @@ api = Namespace('sponsors', description='Sponsors', path='/')
 
 SPONSOR = api.model('Sponsor', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
-    'url': UriField(),
-    'logo': ImageUriField(),
-    'description': fields.String,
-    'sponsor_type_id': fields.Integer,
+    'name': fields.String(),
+    'url': fields.Uri(),
+    'logo': fields.ImageUri(),
+    'description': fields.String(),
+    'sponsor_type_id': fields.Integer(),
 })
 
 SPONSOR_PAGINATED = api.clone('SponsorPaginated', PAGINATED_MODEL, {

--- a/open_event/api/tracks.py
+++ b/open_event/api/tracks.py
@@ -1,7 +1,7 @@
-from flask.ext.restplus import Resource, Namespace, fields
+from flask.ext.restplus import Resource, Namespace
 
 from open_event.models.track import Track as TrackModel
-from custom_fields import ImageUriField, ColorField
+import custom_fields as fields
 from .helpers import get_paginated_list, requires_auth
 from utils import PAGINATED_MODEL, PaginatedResourceBase, ServiceDAO, \
     PAGE_PARAMS, POST_RESPONSES, PUT_RESPONSES
@@ -10,16 +10,16 @@ api = Namespace('tracks', description='Tracks', path='/')
 
 TRACK_SESSION = api.model('TrackSession', {
     'id': fields.Integer(required=True),
-    'title': fields.String,
+    'title': fields.String(),
 })
 
 TRACK = api.model('Track', {
     'id': fields.Integer(required=True),
-    'name': fields.String,
-    'description': fields.String,
-    'color': ColorField(),
-    'track_image_url': ImageUriField(),
-    'location': fields.String,
+    'name': fields.String(),
+    'description': fields.String(),
+    'color': fields.Color(),
+    'track_image_url': fields.ImageUri(),
+    'location': fields.String(),
     'sessions': fields.List(fields.Nested(TRACK_SESSION)),
 })
 

--- a/open_event/api/tracks.py
+++ b/open_event/api/tracks.py
@@ -59,7 +59,7 @@ class Track(Resource):
     @requires_auth
     @api.doc('update_track', responses=PUT_RESPONSES)
     @api.marshal_with(TRACK)
-    @api.expect(TRACK_POST, validate=True)
+    @api.expect(TRACK_POST)
     def put(self, event_id, track_id):
         """Update a track given its id"""
         DAO.validate(self.api.payload, TRACK_POST)
@@ -77,7 +77,7 @@ class TrackList(Resource):
     @requires_auth
     @api.doc('create_track', responses=POST_RESPONSES)
     @api.marshal_with(TRACK)
-    @api.expect(TRACK_POST, validate=True)
+    @api.expect(TRACK_POST)
     def post(self, event_id):
         """Create a track"""
         DAO.validate(self.api.payload, TRACK_POST)

--- a/tests/api/test_custom_fields.py
+++ b/tests/api/test_custom_fields.py
@@ -1,36 +1,36 @@
 import unittest
 from open_event.api.custom_fields import ColorField, EmailField, UriField,\
-    ImageUriField
+    ImageUriField, DateTimeField, IntegerField, FloatField
 
 
 class TestCustomFieldsValidation(unittest.TestCase):
     """
     Test the validation methods of custom fields
     """
-    def _test_empty_field(self, field):
+    def _test_common(self, field):
         field.required = False
-        self.assertTrue(field.validate(''))
         self.assertTrue(field.validate(None))
         field.required = True
         self.assertFalse(field.validate(None))
-        self.assertFalse(field.validate(''))
+        if field.__schema_type__ != 'string':
+            self.assertFalse(field.validate(''))
 
     def test_color_field(self):
         field = ColorField()
-        self._test_empty_field(field)
+        self._test_common(field)
         self.assertFalse(field.validate('randomnothing'))
         self.assertTrue(field.validate('black'))
         self.assertTrue(field.validate('#44ff3b'))
 
     def test_email_field(self):
         field = EmailField()
-        self._test_empty_field(field)
+        self._test_common(field)
         self.assertFalse(field.validate('website.com'))
         self.assertTrue(field.validate('email@gmail.com'))
 
     def test_uri_field(self):
         field = UriField()
-        self._test_empty_field(field)
+        self._test_common(field)
         self.assertFalse(field.validate('somestring'))
         self.assertFalse(field.validate('website.com'))
         self.assertFalse(field.validate('www.website.com'))
@@ -39,10 +39,30 @@ class TestCustomFieldsValidation(unittest.TestCase):
 
     def test_image_uri_field(self):
         field = ImageUriField()
-        self._test_empty_field(field)
+        self._test_common(field)
         # same as uri field, not many tests needed
         self.assertFalse(field.validate('imgur.com/image.png'))
         self.assertTrue(field.validate('http://imgur.com/image.png'))
+
+    def test_datetime_field(self):
+        field = DateTimeField()
+        self._test_common(field)
+        self.assertTrue(field.validate('2014-12-31 23:11:44'))
+        self.assertFalse(field.validate('2014-31-12 23:11:44'))
+        self.assertFalse(field.validate('2014-12-32'))
+        self.assertFalse(field.validate('2014-06-30 12:00'))
+
+    def test_integer_field(self):
+        field = IntegerField()
+        self._test_common(field)
+        self.assertTrue(field.validate(0))
+        self.assertFalse(field.validate(-2323.23))
+        self.assertFalse(field.validate(2323.23))
+
+    def test_float_field(self):
+        field = FloatField()
+        self._test_common(field)
+        self.assertTrue(field.validate(92))
 
 
 if __name__ == '__main__':

--- a/tests/api/test_custom_fields.py
+++ b/tests/api/test_custom_fields.py
@@ -1,6 +1,6 @@
 import unittest
-from open_event.api.custom_fields import ColorField, EmailField, UriField,\
-    ImageUriField, DateTimeField, IntegerField, FloatField
+from open_event.api.custom_fields import Color, Email, Uri,\
+    ImageUri, DateTime, Integer, Float
 
 
 class TestCustomFieldsValidation(unittest.TestCase):
@@ -16,20 +16,20 @@ class TestCustomFieldsValidation(unittest.TestCase):
             self.assertFalse(field.validate(''))
 
     def test_color_field(self):
-        field = ColorField()
+        field = Color()
         self._test_common(field)
         self.assertFalse(field.validate('randomnothing'))
         self.assertTrue(field.validate('black'))
         self.assertTrue(field.validate('#44ff3b'))
 
     def test_email_field(self):
-        field = EmailField()
+        field = Email()
         self._test_common(field)
         self.assertFalse(field.validate('website.com'))
         self.assertTrue(field.validate('email@gmail.com'))
 
     def test_uri_field(self):
-        field = UriField()
+        field = Uri()
         self._test_common(field)
         self.assertFalse(field.validate('somestring'))
         self.assertFalse(field.validate('website.com'))
@@ -38,14 +38,14 @@ class TestCustomFieldsValidation(unittest.TestCase):
         self.assertTrue(field.validate('ftp://domain.com/blah'))
 
     def test_image_uri_field(self):
-        field = ImageUriField()
+        field = ImageUri()
         self._test_common(field)
         # same as uri field, not many tests needed
         self.assertFalse(field.validate('imgur.com/image.png'))
         self.assertTrue(field.validate('http://imgur.com/image.png'))
 
     def test_datetime_field(self):
-        field = DateTimeField()
+        field = DateTime()
         self._test_common(field)
         self.assertTrue(field.validate('2014-12-31 23:11:44'))
         self.assertFalse(field.validate('2014-31-12 23:11:44'))
@@ -53,14 +53,14 @@ class TestCustomFieldsValidation(unittest.TestCase):
         self.assertFalse(field.validate('2014-06-30 12:00'))
 
     def test_integer_field(self):
-        field = IntegerField()
+        field = Integer()
         self._test_common(field)
         self.assertTrue(field.validate(0))
         self.assertFalse(field.validate(-2323.23))
         self.assertFalse(field.validate(2323.23))
 
     def test_float_field(self):
-        field = FloatField()
+        field = Float()
         self._test_common(field)
         self.assertTrue(field.validate(92))
 

--- a/tests/api/test_post_api.py
+++ b/tests/api/test_post_api.py
@@ -8,6 +8,7 @@ from tests.api.utils_post_data import *
 from tests.auth_helper import register
 from open_event import current_app as app
 
+
 class TestPostApiBase(OpenEventTestCase):
     """
     Base class to test POST APIs


### PR DESCRIPTION
Fixes #717 

Purpose: Gain control over input validation and errors. 

#### Fixed in this PR

* null values in the payload of a post/put request no longer give validation errors.
* if required=True for a string field, don't accept an empty value for it.
* also don't accept null value for any field if required = True

@shivamMg  please review