### PR TITLE
Improved Open-Event main page and navbar

### DIFF
--- a/open_event/static/css/custom/index.css
+++ b/open_event/static/css/custom/index.css
@@ -1,63 +1,75 @@
-body{
+body {
     background: white;
 }
 
-.main_container .top_nav {
-    margin-left:0px !important;
+.right_col {
+    padding: 0 !important;
 }
 
-#main-image{
-    background-image: url("/static/img/startup-594090_1920.jpg");
+.carousel {
     height: 500px;
+    margin-bottom: 60px;
+    position: inherit;
+}
+
+.carousel-inner {
+    top: -10px;
+}
+
+.carousel-caption {
+    z-index: 10;
+}
+
+/*noinspection CssOptimizeSimilarProperties,CssUnknownTarget*/
+.carousel .item {
+    height: 500px;
+    background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/static/img/startup-594090_1920.jpg');
+    background-position: center;
+}
+
+.carousel-caption h1 {
+    font-weight: 100;
+}
+
+.carousel-caption .btn {
+    font-weight: 100;
+    font-size: 25px;
+}
+
+.row {
+    margin: 0;
+    padding: 10px;
+}
+
+.thumbnail {
     overflow: hidden;
-    padding:-100px;
-    background-position: 0px -150px;
+    height: auto;
 }
 
-.index-container {
-    padding-right: 15px;
-    padding-left: 15px;
-    margin-right: auto;
-    margin-left: auto;
+.section-header {
+    color: #2196F3;
+    font-weight: 300;
 }
-
 
 @media (min-width: 768px) {
-  .index-container {
-    width: 750px;
-  }
-}
-@media (min-width: 992px) {
-  .index-container {
-    width: 970px;
-  }
-}
-@media (min-width: 1200px) {
-  .index-container {
-    width: 1170px;
-  }
+    .carousel-caption p {
+        margin-bottom: 50px;
+        font-size: 30px;
+        line-height: 1.4;
+    }
+
+    .carousel-caption h1 {
+        font-size: 50px;
+    }
 }
 
-.img-content{
-    text-align:center;
-    padding-top:60px;
-    color:white;
+.hero-feature {
+    margin-bottom: 30px;
 }
 
-.img-content h1 {
-    margin-top:220px;
-    font-size: 60px;
+.no-data-message {
+    font-size: 16px;
+    margin-left: 10px;
 }
 
-.nav_menu{
-    margin-bottom: 0px;
-}
 
-.thumbnail{
-    overflow: none;
-    border: none;
-    height:335px
-}
- .caption{
-    text-align: left
- }

--- a/open_event/templates/gentelella/admin/menu.html
+++ b/open_event/templates/gentelella/admin/menu.html
@@ -1,61 +1,38 @@
 {% macro render_menu(test='') %}
 <div class="top_nav" style="margin-left:0">
     <div class="nav_menu">
-        <nav class="" role="navigation">
+        <nav>
             <ul class="nav navbar-nav">
-                <li class="">
-                    <a href="/">
-                        Home
+                <li style="margin-left: 10px;">
+                    <a href="/" style="font-size: 26px; font-weight: 300;">
+                        Open Event
                     </a>
                 </li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li class="">
-                    <a href="/events/create/" aria-expanded="false">
-                        Create Event
-                    </a>
-                </li>
+                <li><a href="/events/create/" aria-expanded="false">Create Event</a></li>
                 {% if current_user.is_authenticated %}
-
-                <li class="">
-                    <a href="javascript:;" class="user-profile dropdown-toggle" data-toggle="dropdown"
-                       aria-expanded="false">
-                        <img src="{{ url_for('static', filename='img/avatar.png') }}"/>
-                        {{current_user.login}}
-                        <span class=" fa fa-angle-down"></span>
-                    </a>
-                    <ul class="dropdown-menu dropdown-usermenu pull-right">
-                        <li><a href="/events/mysessions/">My Sessions</a></li>
-                        <li><a href="/events/">Manage Events</a></li>
-                        <li class="divider"></li>
-                        <li><a href="/profile"> Profile</a> </li>
-
-                        <li><a href="/logout/"><i class="fa fa-sign-out pull-right"></i> Logout</a>
-                        </li>
-                    </ul>
-                </li>
-
+                    <li>
+                        <a href="#" class="user-profile dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                            <img src="{{ url_for('static', filename='img/avatar.png') }}"/>
+                            {# current_user.user_detail.fullname #}
+                            <span class=" fa fa-angle-down"></span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-usermenu pull-right">
+                            <li><a href="/events/mysessions/">My Sessions</a></li>
+                            <li><a href="/events/">Manage Events</a></li>
+                            <li class="divider"></li>
+                            <li><a href="/profile"> Profile</a> </li>
+                            <li><a href="/logout/"><i class="fa fa-sign-out pull-right"></i> Logout</a>
+                            </li>
+                        </ul>
+                    </li>
                 {% else %}
-
-                <li class="">
-                    <a href="/login" class="user-profile dropdown-toggle" data-toggle="dropdown"
-                       aria-expanded="false">
-                        Login
-                        <span class=" fa fa-angle-down"></span>
-                    </a>
-                </li>
-
+                    <li> <a href="/login" class="user-profile">Login</a></li>
                 {% endif %}
-                <li class="">
-                    <a href="/browse" class="user-profile dropdown-toggle" data-toggle="dropdown"
-                       aria-expanded="false">
-                        Browse Events
-                        <span class=" fa fa-angle-down"></span>
-                    </a>
-                </li>
+                <li><a href="/browse" class="user-profile">Browse Events</a></li>
             </ul>
         </nav>
     </div>
-
 </div>
 {% endmacro %}

--- a/open_event/templates/gentelella/index.html
+++ b/open_event/templates/gentelella/index.html
@@ -1,90 +1,67 @@
-{% import 'gentelella/admin/menu.html' as menu with context %}
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-    {% block head_meta %}
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="">
-    <meta name="author" content="">
-    {% endblock %}
-    {% block head_css %}
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
-          integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}"/>
+{% extends 'gentelella/admin/base.html' %}
+{% block head_css %}
+    {{ super() }}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/custom/index.css') }}"/>
-    {% endblock %}
+{% endblock %}
 
-    {% block head_js %}
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
-    {% endblock %}
-</head>
-<body class="nav-sm">
-<div class="main_container">
-    {{ menu.render_menu() }}
-    <div style="clear:both"></div>
-    <div id="main-image">
-        <div class="img-content">
-            <h1>The simplest way to create events</h1>
-            <a href="/events/new" class="btn btn-info btn-lg">Create event</a>
-        </div>
-    </div>
-    <div class="index-container">
-        <div class="row">
-            <h3 class="blue">Upcoming events</h3>
-            <div class="row text-center">
-                aaa{{aa}}aaa
-                {% for event in aa %}
-                    {{event}}
-                    <div class="col-md-3 col-sm-6 hero-feature">
-                        <div class="thumbnail">
-                            <img src="http://placehold.it/800x500" alt="">
-                            <div class="caption">
-                                <small>{{event.start_time}}</small>
-                                <h4>{{event.title}}</h4>
-                                <small>{{event.location_name}}</small>
-                                <hr>
-                                <p>
-                                    #tech, #conferensce
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                {%endfor%}
-
-
-            </div>
-        </div>
-
-        <div class="row">
-            <h3 class="blue">Call for Speakers</h3>
-            <div class="row text-center">
-
-                {% for event in call_for_papers_evs %}
-                    <div class="col-md-3 col-sm-6 hero-feature">
-                        <div class="thumbnail">
-                            <img src="http://placehold.it/800x500" alt="">
-                            <div class="caption">
-                                <small>{{event.start_time}}</small>
-                                <h4>{{event.title}}</h4>
-                                <small>{{event.location_name}}</small>
-                                <hr>
-                                <p>
-                                    #tech, #conference
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                {%endfor%}
-
+{% macro event_box(event) %}
+    <div class="col-md-2">
+        <div class="thumbnail">
+            <img src="http://placehold.it/800x500" style="width:100%;">
+            <div class="caption">
+                <small>{{ event.start_time.strftime('%B %d, %Y - %I:%M %p') }}</small>
+                <h4>{{ event.name }}</h4>
+                <small>{{ event.location_name }}</small>
+                <hr>
+                <p>
+                    #tech, #conference
+                </p>
             </div>
         </div>
     </div>
+{% endmacro %}
 
 
-</div>
+{% block body %}
+    <div class="carousel slide">
+        <div class="carousel-inner">
+            <div class="item active">
+                <div class="container">
+                    <div class="carousel-caption">
+                        <h1>The simplest way to create events.</h1>
+                        <p></p>
+                        <p><a class="btn btn-info btn-lg" href="/events/create/" role="button">Create an event now</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <h3 class="section-header" style="margin-left: 10px; margin-bottom: 0;">Upcoming Events</h3>
+    </div>
+    {% for published_events_chunk in published_events %}
+        <div class="row">
+            {% for published_event in published_events_chunk %}
+                {{ event_box(published_event) }}
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="row no-data-message">No upcoming events available at this time</div>
+    {% endfor %}
 
-</body>
-</html>
+    <div class="row">
+        <h3 class="section-header" style="margin-left: 10px; margin-bottom: 0;">Call for Speakers</h3>
+    </div>
+    {% for call_for_papers_evs_chunk in call_for_papers_evs %}
+        <div class="row">
+            {% for call_for_papers_evs in call_for_papers_evs_chunk %}
+                {{ event_box(call_for_papers_evs) }}
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="row no-data-message">No call for speakers open at this time</div>
+    {% endfor %}
+    <br>
+    <br>
+{% endblock %}

--- a/open_event/views/views.py
+++ b/open_event/views/views.py
@@ -29,16 +29,22 @@ auto = Autodoc()
 app = Blueprint('', __name__)
 
 
+def chunks(l, n):
+    """Yield successive n-sized chunks from l."""
+    for i in xrange(0, len(l), n):
+        yield l[i:i + n]
+
 @app.route('/', methods=['GET'])
 @auto.doc()
 @cross_origin()
 def get_main_page():
     """Redirect to admin page"""
-    call_for_papers_evs = DataGetter.get_call_for_speakers_events()
-    published_events = DataGetter.get_all_published_events()
+    call_for_papers_evs = DataGetter.get_call_for_speakers_events().all()
+    published_events = DataGetter.get_published_events().all()
+    # Provide data as chunks of 6 for the UI to render in a proper way
     return render_template('gentelella/index.html',
-                           call_for_papers_evs=call_for_papers_evs,
-                           published_events=published_events)
+                           call_for_papers_evs=list(chunks(call_for_papers_evs, 6)),
+                           published_events=list(chunks(published_events, 6)))
 
 
 @app.route('/api/v1/event', methods=['GET'])

--- a/open_event/views/views.py
+++ b/open_event/views/views.py
@@ -40,7 +40,7 @@ def chunks(l, n):
 def get_main_page():
     """Redirect to admin page"""
     call_for_papers_evs = DataGetter.get_call_for_speakers_events().all()
-    published_events = DataGetter.get_published_events().all()
+    published_events = DataGetter.get_all_published_events().all()
     # Provide data as chunks of 6 for the UI to render in a proper way
     return render_template('gentelella/index.html',
                            call_for_papers_evs=list(chunks(call_for_papers_evs, 6)),

--- a/tests/test_fb_oauth.py
+++ b/tests/test_fb_oauth.py
@@ -33,7 +33,7 @@ class TestFacebookOauth(OpenEventTestCase):
             self.app.get(url_for('admin.create_account_after_confirmation_view', hash=data_hash), follow_redirects=True)
             logout(self.app)
             login(self.app, 'email@gmail.com', 'test')
-            self.assertTrue('Create event' in self.app.get('/fCallback/?code=dummy_code&state=dummy_state',
+            self.assertTrue('Open Event' in self.app.get('/fCallback/?code=dummy_code&state=dummy_state',
                                                            follow_redirects=True).data)
             self.assertEqual(self.app.get('/fCallback/?code=dummy_code&state=dummy_state').status_code, 302)
 

--- a/tests/test_google_oauth.py
+++ b/tests/test_google_oauth.py
@@ -26,7 +26,7 @@ class TestGoogleOauth(OpenEventTestCase):
             self.app.get(url_for('admin.create_account_after_confirmation_view', hash=data_hash), follow_redirects=True)
             logout(self.app)
             login(self.app, 'email@gmail.com', 'test')
-            self.assertTrue('Create event' in self.app.get('/gCallback/?state=dummy_state&code=dummy_code',
+            self.assertTrue('Open Event' in self.app.get('/gCallback/?state=dummy_state&code=dummy_code',
                                                            follow_redirects=True).data)
             self.assertEqual(self.app.get('/gCallback/?state=dummy_state&code=dummy_code').status_code, 302)
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -20,7 +20,7 @@ class TestLogin(OpenEventTestCase):
             register(self.app, u'email@gmail.com', u'test')
             logout(self.app)
             rv = login(self.app, 'email@gmail.com', 'test')
-            self.assertTrue("Create event" in rv.data, msg=rv.data)
+            self.assertTrue("Open Event" in rv.data, msg=rv.data)
 
     def test_incorrect_login(self):
         with app.test_request_context():
@@ -32,7 +32,7 @@ class TestLogin(OpenEventTestCase):
     def test_registration(self):
         with app.test_request_context():
             rv = register(self.app, u'email@gmail.com', u'test')
-            self.assertTrue("Create event" in rv.data)
+            self.assertTrue("Open Event" in rv.data)
 
     def test_logout(self):
         login(self.app, 'email@gmail.com', 'test')


### PR DESCRIPTION
Resolves #650.

- Improved the open event main page (UI Improvements). The events are chunked and displayed properly. 
- Improved the navbar
- The home page now extends the base template.

@rafalkowalski @mariobehling @SaptakS  please review and merge into `development`.

#### Screenshots:
**1. When there are events:**

![screencapture-localhost-5000-1465715444961](https://cloud.githubusercontent.com/assets/2404372/15989770/bb4fba06-309e-11e6-8ca0-dfb286bf7e5f.png)

**2. When no events are available:**

![screencapture-localhost-5000-1465717006793](https://cloud.githubusercontent.com/assets/2404372/15989774/c75bc09c-309e-11e6-8fe0-c174e6c10fec.png)

