### PR TITLE
Made DAOs in API independent/self-sufficient

### DIFF
--- a/open_event/api/events.py
+++ b/open_event/api/events.py
@@ -5,9 +5,9 @@ import custom_fields as fields
 from open_event.models.event import Event as EventModel, EventsUsers
 from open_event.models.user import ADMIN, SUPERADMIN
 from .helpers import get_object_list, get_object_or_404, get_paginated_list,\
-    requires_auth, validate_payload, update_model
+    requires_auth, update_model
 from utils import PAGINATED_MODEL, PaginatedResourceBase, PAGE_PARAMS, \
-    POST_RESPONSES, PUT_RESPONSES
+    POST_RESPONSES, PUT_RESPONSES, ServiceDAO
 from open_event.helpers.data import save_to_db, update_version, delete_from_db
 
 api = Namespace('events', description='Events')
@@ -23,7 +23,7 @@ EVENT = api.model('Event', {
     'latitude': fields.Float(),
     'longitude': fields.Float(),
     'event_url': fields.Uri(),
-    'background_url': fields.Uri(),
+    'background_url': fields.ImageUri(),
     'description': fields.String(),
     'location_name': fields.String(),
     'state': fields.String(),
@@ -38,63 +38,31 @@ EVENT_POST = api.clone('EventPost', EVENT)
 del EVENT_POST['id']
 
 
-# Helper function to fix datetime event payload
-# TODO: Make ServiceDAO more versatile so that event can use it
-def fix_payload(data):
-    data['start_time'] = EVENT_POST['start_time'].from_str(data['start_time'])
-    data['end_time'] = EVENT_POST['end_time'].from_str(data['end_time'])
-    data['closing_datetime'] = EVENT_POST['closing_datetime'].from_str(
-        data['closing_datetime'])
-    return data
+class EventDAO(ServiceDAO):
+    """
+    Event DAO
+    """
+    def fix_payload(self, data):
+        """
+        Fixes the payload data.
+        Here converts string time from datetime obj
+        """
+        data['start_time'] = EVENT_POST['start_time'].from_str(data['start_time'])
+        data['end_time'] = EVENT_POST['end_time'].from_str(data['end_time'])
+        data['closing_datetime'] = EVENT_POST['closing_datetime'].from_str(
+            data['closing_datetime'])
+        return data
 
-
-@api.route('/<int:event_id>')
-@api.param('event_id')
-@api.response(404, 'Event not found')
-class Event(Resource):
-    @api.doc('get_event')
-    @api.marshal_with(EVENT)
     def get(self, event_id):
-        """Fetch an event given its id"""
-        return get_object_or_404(EventModel, event_id)
+        return get_object_or_404(self.model, event_id)
 
-    @requires_auth
-    @api.doc('delete_event')
-    @api.marshal_with(EVENT)
-    def delete(self, event_id):
-        """Delete an event given its id"""
-        event = get_object_or_404(EventModel, event_id)
-        delete_from_db(event, 'Event deleted')
-        return event
+    def list(self):
+        return get_object_list(self.model)
 
-    @requires_auth
-    @api.doc('update_event', responses=PUT_RESPONSES)
-    @api.marshal_with(EVENT)
-    @api.expect(EVENT_POST)
-    def put(self, event_id):
-        """Update a event given its id"""
-        validate_payload(self.api.payload, EVENT_POST)
-        payload = fix_payload(self.api.payload)
-        return update_model(EventModel, event_id, payload)
-
-
-@api.route('')
-class EventList(Resource):
-    @api.doc('list_events')
-    @api.marshal_list_with(EVENT)
-    def get(self):
-        """List all events"""
-        return get_object_list(EventModel)
-
-    @requires_auth
-    @api.doc('create_event', responses=POST_RESPONSES)
-    @api.marshal_with(EVENT)
-    @api.expect(EVENT_POST)
-    def post(self):
-        """Create an event"""
-        validate_payload(self.api.payload, EVENT_POST)
-        payload = fix_payload(self.api.payload)
-        new_event = EventModel(**payload)
+    def create(self, data):
+        self.validate(data)
+        payload = self.fix_payload(data)
+        new_event = self.model(**payload)
         # set user (owner)
         a = EventsUsers()
         a.user = g.user
@@ -109,7 +77,63 @@ class EventList(Resource):
             column_to_increment="event_ver"
         )
         # return the new event created
-        return get_object_or_404(EventModel, new_event.id)
+        return get_object_or_404(self.model, new_event.id)
+
+    def update(self, event_id, data):
+        self.validate(data)
+        payload = self.fix_payload(data)
+        return update_model(self.model, event_id, payload)
+
+    def delete(self, event_id):
+        event = get_object_or_404(self.model, event_id)
+        delete_from_db(event, 'Event deleted')
+        return event
+
+
+DAO = EventDAO(EventModel, EVENT_POST)
+
+
+@api.route('/<int:event_id>')
+@api.param('event_id')
+@api.response(404, 'Event not found')
+class Event(Resource):
+    @api.doc('get_event')
+    @api.marshal_with(EVENT)
+    def get(self, event_id):
+        """Fetch an event given its id"""
+        return DAO.get(event_id)
+
+    @requires_auth
+    @api.doc('delete_event')
+    @api.marshal_with(EVENT)
+    def delete(self, event_id):
+        """Delete an event given its id"""
+        return DAO.delete(event_id)
+
+    @requires_auth
+    @api.doc('update_event', responses=PUT_RESPONSES)
+    @api.marshal_with(EVENT)
+    @api.expect(EVENT_POST)
+    def put(self, event_id):
+        """Update a event given its id"""
+        return DAO.update(event_id, self.api.payload)
+
+
+@api.route('')
+class EventList(Resource):
+    @api.doc('list_events')
+    @api.marshal_list_with(EVENT)
+    def get(self):
+        """List all events"""
+        return DAO.list()
+
+    @requires_auth
+    @api.doc('create_event', responses=POST_RESPONSES)
+    @api.marshal_with(EVENT)
+    @api.expect(EVENT_POST)
+    def post(self):
+        """Create an event"""
+        return DAO.create(self.api.payload)
 
 
 @api.route('/page')

--- a/open_event/api/formats.py
+++ b/open_event/api/formats.py
@@ -26,7 +26,7 @@ del FORMAT_POST['id']
 class FormatDAO(ServiceDAO):
     pass
 
-DAO = FormatDAO(model=FormatModel)
+DAO = FormatDAO(FormatModel, FORMAT_POST)
 
 
 @api.route('/events/<int:event_id>/formats/<int:format_id>')
@@ -52,7 +52,6 @@ class Format(Resource):
     @api.expect(FORMAT_POST)
     def put(self, event_id, format_id):
         """Update a format given its id"""
-        DAO.validate(self.api.payload, FORMAT_POST)
         return DAO.update(event_id, format_id, self.api.payload)
 
 
@@ -70,7 +69,6 @@ class FormatList(Resource):
     @api.expect(FORMAT_POST)
     def post(self, event_id):
         """Create a format"""
-        DAO.validate(self.api.payload, FORMAT_POST)
         return DAO.create(event_id, self.api.payload)
 
 

--- a/open_event/api/helpers.py
+++ b/open_event/api/helpers.py
@@ -167,24 +167,31 @@ def save_db_model(new_model, model_name, event_id=None):
     return new_model
 
 
-def create_service_model(model, event_id, data):
+def create_model(model, data, event_id=None):
     """
-    Create a new service model (microlocations, sessions, speakers etc)
-    and save it to database
+    Creates a model.
+    If event_id is set, the model is assumed as a child of event
+    i.e. Service Model
     """
-    get_object_or_404(EventModel, event_id)
-    data['event_id'] = event_id
+    if event_id is not None:
+        get_object_or_404(EventModel, event_id)
+        data['event_id'] = event_id
     new_model = model(**data)
     save_to_db(new_model, "Model %s saved" % model.__name__)
-    update_version(event_id, False, "session_ver")
+    if event_id:
+        update_version(event_id, False, "session_ver")
     return new_model
 
 
-def delete_service_model(model, event_id, service_id):
+def delete_model(model, item_id, event_id=None):
     """
-    Delete a service model.
+    Deletes a model
+    If event_id is set, it is assumed to be a service model
     """
-    item = get_object_in_event(model, service_id, event_id)
+    if event_id is not None:
+        item = get_object_in_event(model, item_id, event_id)
+    else:
+        item = get_object_or_404(model, item_id)
     delete_from_db(item, '{} deleted'.format(model.__name__))
     return item
 

--- a/open_event/api/languages.py
+++ b/open_event/api/languages.py
@@ -26,7 +26,7 @@ del LANGUAGE_POST['id']
 class LanguageDAO(ServiceDAO):
     pass
 
-DAO = LanguageDAO(model=LanguageModel)
+DAO = LanguageDAO(LanguageModel, LANGUAGE_POST)
 
 
 @api.route('/events/<int:event_id>/languages/<int:language_id>')
@@ -52,7 +52,6 @@ class Language(Resource):
     @api.expect(LANGUAGE_POST)
     def put(self, event_id, language_id):
         """Update a language given its id"""
-        DAO.validate(self.api.payload, LANGUAGE_POST)
         return DAO.update(event_id, language_id, self.api.payload)
 
 
@@ -70,7 +69,6 @@ class LanguageList(Resource):
     @api.expect(LANGUAGE_POST)
     def post(self, event_id):
         """Create a language"""
-        DAO.validate(self.api.payload, LANGUAGE_POST)
         return DAO.create(event_id, self.api.payload)
 
 

--- a/open_event/api/levels.py
+++ b/open_event/api/levels.py
@@ -25,7 +25,7 @@ del LEVEL_POST['id']
 class LevelDAO(ServiceDAO):
     pass
 
-DAO = LevelDAO(model=LevelModel)
+DAO = LevelDAO(LevelModel, LEVEL_POST)
 
 
 @api.route('/events/<int:event_id>/levels/<int:level_id>')
@@ -51,7 +51,6 @@ class Level(Resource):
     @api.expect(LEVEL_POST)
     def put(self, event_id, level_id):
         """Update a level given its id"""
-        DAO.validate(self.api.payload, LEVEL_POST)
         return DAO.update(event_id, level_id, self.api.payload)
 
 
@@ -69,7 +68,6 @@ class LevelList(Resource):
     @api.expect(LEVEL_POST)
     def post(self, event_id):
         """Create a level"""
-        DAO.validate(self.api.payload, LEVEL_POST)
         return DAO.create(event_id, self.api.payload)
 
 

--- a/open_event/api/microlocations.py
+++ b/open_event/api/microlocations.py
@@ -28,7 +28,7 @@ del MICROLOCATION_POST['id']
 class MicrolocationDAO(ServiceDAO):
     pass
 
-DAO = MicrolocationDAO(model=MicrolocationModel)
+DAO = MicrolocationDAO(MicrolocationModel, MICROLOCATION_POST)
 
 
 @api.route('/events/<int:event_id>/microlocations/<int:microlocation_id>')
@@ -54,7 +54,6 @@ class Microlocation(Resource):
     @api.expect(MICROLOCATION_POST)
     def put(self, event_id, microlocation_id):
         """Update a microlocation given its id"""
-        DAO.validate(self.api.payload, MICROLOCATION_POST)
         return DAO.update(event_id, microlocation_id, self.api.payload)
 
 
@@ -72,7 +71,6 @@ class MicrolocationList(Resource):
     @api.expect(MICROLOCATION_POST)
     def post(self, event_id):
         """Create a microlocation"""
-        DAO.validate(self.api.payload, MICROLOCATION_POST)
         return DAO.create(event_id, self.api.payload)
 
 

--- a/open_event/api/speakers.py
+++ b/open_event/api/speakers.py
@@ -43,7 +43,7 @@ del SPEAKER_POST['sessions']  # don't allow adding sessions
 class SpeakerDAO(ServiceDAO):
     pass
 
-DAO = SpeakerDAO(model=SpeakerModel)
+DAO = SpeakerDAO(SpeakerModel, SPEAKER_POST)
 
 
 @api.route('/events/<int:event_id>/speakers/<int:speaker_id>')
@@ -69,7 +69,6 @@ class Speaker(Resource):
     @api.expect(SPEAKER_POST)
     def put(self, event_id, speaker_id):
         """Update a speaker given its id"""
-        DAO.validate(self.api.payload, SPEAKER_POST)
         return DAO.update(event_id, speaker_id, self.api.payload)
 
 
@@ -87,7 +86,6 @@ class SpeakerList(Resource):
     @api.expect(SPEAKER_POST)
     def post(self, event_id):
         """Create a speaker"""
-        DAO.validate(self.api.payload, SPEAKER_POST)
         return DAO.create(event_id, self.api.payload)
 
 

--- a/open_event/api/sponsor_types.py
+++ b/open_event/api/sponsor_types.py
@@ -24,7 +24,7 @@ del SPONSOR_TYPE_POST['id']
 class SponsorTypeDAO(ServiceDAO):
     pass
 
-DAO = SponsorTypeDAO(model=SponsorTypeModel)
+DAO = SponsorTypeDAO(SponsorTypeModel, SPONSOR_TYPE_POST)
 
 
 @api.route('/events/<int:event_id>/sponsor_types/<int:sponsor_type_id>')
@@ -50,7 +50,6 @@ class SponsorType(Resource):
     @api.expect(SPONSOR_TYPE_POST)
     def put(self, event_id, sponsor_type_id):
         """Update a sponsor_type given its id"""
-        DAO.validate(self.api.payload, SPONSOR_TYPE_POST)
         return DAO.update(event_id, sponsor_type_id, self.api.payload)
 
 
@@ -68,7 +67,6 @@ class SponsorTypeList(Resource):
     @api.expect(SPONSOR_TYPE_POST)
     def post(self, event_id):
         """Create a sponsor_type"""
-        DAO.validate(self.api.payload, SPONSOR_TYPE_POST)
         return DAO.create(event_id, self.api.payload)
 
 

--- a/open_event/api/sponsors.py
+++ b/open_event/api/sponsors.py
@@ -31,7 +31,18 @@ class SponsorDAO(ServiceDAO):
         if sponsor_type_id is not None:
             get_object_in_event(SponsorTypeModel, sponsor_type_id, event_id)
 
-DAO = SponsorDAO(model=SponsorModel)
+    def create(self, event_id, data):
+        self.validate(data)
+        self.validate_sponsor_type(data, event_id)
+        return ServiceDAO.create(self, event_id, data, validate=False)
+
+    def update(self, event_id, service_id, data):
+        self.validate(data)
+        self.validate_sponsor_type(data, event_id)
+        return ServiceDAO.update(self, event_id, service_id, data, validate=False)
+
+
+DAO = SponsorDAO(SponsorModel, SPONSOR_POST)
 
 
 @api.route('/events/<int:event_id>/sponsors/<int:sponsor_id>')
@@ -57,8 +68,6 @@ class Sponsor(Resource):
     @api.expect(SPONSOR_POST)
     def put(self, event_id, sponsor_id):
         """Update a sponsor given its id"""
-        DAO.validate(self.api.payload, SPONSOR_POST)
-        DAO.validate_sponsor_type(self.api.payload, event_id)
         return DAO.update(event_id, sponsor_id, self.api.payload)
 
 
@@ -76,8 +85,6 @@ class SponsorList(Resource):
     @api.expect(SPONSOR_POST)
     def post(self, event_id):
         """Create a sponsor"""
-        DAO.validate(self.api.payload, SPONSOR_POST)
-        DAO.validate_sponsor_type(self.api.payload, event_id)
         return DAO.create(event_id, self.api.payload)
 
 

--- a/open_event/api/tracks.py
+++ b/open_event/api/tracks.py
@@ -36,7 +36,7 @@ del TRACK_POST['sessions']
 class TrackDAO(ServiceDAO):
     pass
 
-DAO = TrackDAO(model=TrackModel)
+DAO = TrackDAO(TrackModel, TRACK_POST)
 
 
 @api.route('/events/<int:event_id>/tracks/<int:track_id>')
@@ -62,7 +62,6 @@ class Track(Resource):
     @api.expect(TRACK_POST)
     def put(self, event_id, track_id):
         """Update a track given its id"""
-        DAO.validate(self.api.payload, TRACK_POST)
         return DAO.update(event_id, track_id, self.api.payload)
 
 
@@ -80,7 +79,6 @@ class TrackList(Resource):
     @api.expect(TRACK_POST)
     def post(self, event_id):
         """Create a track"""
-        DAO.validate(self.api.payload, TRACK_POST)
         return DAO.create(event_id, self.api.payload)
 
 

--- a/open_event/api/utils.py
+++ b/open_event/api/utils.py
@@ -59,8 +59,9 @@ class ServiceDAO:
     Data Access Object for service models like microlocations,
     speakers and so.
     """
-    def __init__(self, model):
+    def __init__(self, model, post_api_model=None):
         self.model = model
+        self.post_api_model = post_api_model
 
     def get(self, event_id, sid):
         return get_object_in_event(self.model, sid, event_id)
@@ -70,11 +71,15 @@ class ServiceDAO:
         get_object_or_404(EventModel, event_id)
         return get_object_list(self.model, event_id=event_id)
 
-    def create(self, event_id, data):
+    def create(self, event_id, data, validate=True):
+        if validate:
+            self.validate(data)
         item = create_service_model(self.model, event_id, data)
         return item
 
-    def update(self, event_id, service_id, data):
+    def update(self, event_id, service_id, data, validate=True):
+        if validate:
+            self.validate(data)
         item = update_model(self.model, service_id, data, event_id)
         return item
 
@@ -82,5 +87,6 @@ class ServiceDAO:
         item = delete_service_model(self.model, event_id, service_id)
         return item
 
-    def validate(self, data, api_model):
-        validate_payload(data, api_model)
+    def validate(self, data):
+        if self.post_api_model:
+            validate_payload(data, self.post_api_model)


### PR DESCRIPTION
Fixes #746 and #747 

This PR makes the DAO independent meaning if you have the params of a request, you can now use the DAO to successfully execute any type of request and get the return value.
So it will add the ability to internally call an API and execute any type of request.
