### PR TITLE
Method to get latest heroku release info

### DIFF
--- a/open_event/helpers/helpers.py
+++ b/open_event/helpers/helpers.py
@@ -1,4 +1,6 @@
 """Copyright 2015 Rafal Kowalski"""
+import json
+import os
 import re
 import requests
 from flask import request
@@ -100,3 +102,13 @@ def is_event_admin(event_id, users):
 
 def get_serializer(secret_key=None):
     return Serializer('secret_key')
+
+def get_latest_heroku_release():
+    token = os.environ.get('API_TOKEN_HEROKU', None)
+    headers = {
+        "Accept": "application/vnd.heroku+json; version=3",
+        "Authorization": "Bearer " + token,
+        "Range": "version ..; max=1, order=desc"
+    }
+    response = requests.get("https://api.heroku.com/apps/open-event/releases", headers=headers)
+    return json.loads(response.text)[0]

--- a/open_event/views/views.py
+++ b/open_event/views/views.py
@@ -23,6 +23,7 @@ from flask import render_template
 from open_event.helpers.oauth import OAuth, FbOAuth
 from requests.exceptions import HTTPError
 from ..helpers.data import get_google_auth, create_user_oauth, get_facebook_auth
+from ..helpers.helpers import get_latest_heroku_release
 import json
 
 
@@ -536,7 +537,4 @@ def documentation():
 
 @app.route('/heroku_releases')
 def heroku_releases():
-    token = os.environ.get('API_TOKEN_HEROKU', None)
-    result = os.popen(
-        'curl -n https://api.heroku.com/apps/open-event/releases -H "Authorization: Bearer ' + token + '" -H "Accept: application/vnd.heroku+json; version=3"').read()
-    return str(result)
+    return "v" + str(get_latest_heroku_release()['version'])


### PR DESCRIPTION
A helper method `get_latest_heroku_release` has been added to `open_event/helpers/helpers.py` to retrieve the latest release info using the Heroku API. (#683)

The method returns the release info in the form of a `dict`. A sample response is 
```json
{
    "app":{
        "id":"642152af-9a73-421b-a15e-9696c20edf0b",
        "name":"open-event"
    },
    "created_at":"2016-06-12T15:02:57Z",
    "description":"Deploy 01c35bc",
    "status":"succeeded",
    "id":"6e1e5c94-6bdd-4bc0-8ef9-b38fc1f1647d",
    "slug":{
        "id":"64f8c942-f052-4091-b6aa-e96f521944fb"
    },
    "updated_at":"2016-06-12T15:02:57Z",
    "user":{
        "email":"niranjan94@yahoo.com",
        "id":"b7895951-49fb-4ad1-928e-f6d769138f20"
    },
    "version":296,
    "current":true
}
```

To get the current version number, you can do `get_latest_heroku_release()['version']`.

The current version number can also be accessed at https://open-event.herokuapp.com/heroku_releases after this merge.

@rafalkowalski please review and merge. 