### PR TITLE
Export event as json (zip)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ app.db
 # Static files at 'open_event/static/admin/lib'
 lib/
 node_modules
+
+# event export files
+static/exports/event*

--- a/open_event/api/__init__.py
+++ b/open_event/api/__init__.py
@@ -13,6 +13,8 @@ from .levels import api as level_api
 from .formats import api as format_api
 from .languages import api as language_api
 from .login import api as login_api
+from .exports import api as exports_api
+
 
 from helpers.errors import (
     NotFoundError,
@@ -38,6 +40,7 @@ api.add_namespace(level_api)
 api.add_namespace(format_api)
 api.add_namespace(language_api)
 api.add_namespace(login_api)
+api.add_namespace(exports_api)
 
 
 @api.documentation

--- a/open_event/api/exports.py
+++ b/open_event/api/exports.py
@@ -1,0 +1,17 @@
+from flask import send_file, make_response
+from flask.ext.restplus import Resource, Namespace
+
+from helpers.export_helpers import export_event_json
+
+
+api = Namespace('event_exports', description='Event Exports', path='/')
+
+
+@api.route('/events/<int:event_id>/export/json')
+@api.hide
+class EventExportJson(Resource):
+    def get(self, event_id):
+        path = export_event_json(event_id)
+        response = make_response(send_file(path))
+        response.headers['Content-Disposition'] = 'attachment; filename=event%d.zip' % event_id
+        return response

--- a/open_event/api/exports.py
+++ b/open_event/api/exports.py
@@ -2,11 +2,13 @@ from flask import send_file, make_response
 from flask.ext.restplus import Resource, Namespace
 
 from helpers.export_helpers import export_event_json
+from helpers.helpers import nocache
 
 
 api = Namespace('event_exports', description='Event Exports', path='/')
 
 
+@nocache
 @api.route('/events/<int:event_id>/export/json')
 @api.hide
 class EventExportJson(Resource):

--- a/open_event/api/helpers/export_helpers.py
+++ b/open_event/api/helpers/export_helpers.py
@@ -1,0 +1,53 @@
+import json
+import os
+import shutil
+from flask_restplus import marshal
+
+from ..events import DAO as EventDAO, EVENT
+from ..formats import DAO as FormatDAO, FORMAT
+from ..languages import DAO as LanguageDAO, LANGUAGE
+from ..levels import DAO as LevelDAO, LEVEL
+from ..microlocations import DAO as MicrolocationDAO, MICROLOCATION
+from ..sessions import DAO as SessionDAO, SESSION
+from ..speakers import DAO as SpeakerDAO, SPEAKER
+from ..sponsor_types import DAO as SponsorTypeDAO, SPONSOR_TYPE
+from ..sponsors import DAO as SponsorDAO, SPONSOR
+from ..tracks import DAO as TrackDAO, TRACK
+
+
+EXPORTS = [
+    ('event', EventDAO, EVENT),
+    ('formats', FormatDAO, FORMAT),
+    ('languages', LanguageDAO, LANGUAGE),
+    ('levels', LevelDAO, LEVEL),
+    ('microlocations', MicrolocationDAO, MICROLOCATION),
+    ('sessions', SessionDAO, SESSION),
+    ('speakers', SpeakerDAO, SPEAKER),
+    ('sponsor_types', SponsorTypeDAO, SPONSOR_TYPE),
+    ('sponsors', SponsorDAO, SPONSOR),
+    ('tracks', TrackDAO, TRACK)
+]
+
+
+def export_event_json(event_id):
+    """
+    Exports the event as a zip on the server and return its path
+    """
+    # make directory
+    dir_path = 'static/exports/event%d' % event_id
+    if os.path.isdir(dir_path):
+        shutil.rmtree(dir_path, ignore_errors=True)
+    os.mkdir(dir_path)
+    # save to directory
+    for e in EXPORTS:
+        if e[0] == 'event':
+            data = marshal(e[1].get(event_id), e[2])
+        else:
+            data = marshal(e[1].list(event_id), e[2])
+        data_str = json.dumps(data, sort_keys=True, indent=4)
+        fp = open(dir_path + '/' + e[0] + '.json', 'w')
+        fp.write(data_str)
+        fp.close()
+    # make zip
+    shutil.make_archive(dir_path, 'zip', dir_path)
+    return os.path.realpath('.') + '/' + dir_path + '.zip'

--- a/open_event/api/helpers/helpers.py
+++ b/open_event/api/helpers/helpers.py
@@ -1,5 +1,6 @@
-from functools import wraps
-from flask import request, g
+from datetime import datetime
+from functools import wraps, update_wrapper
+from flask import request, g, make_response
 from flask.ext.restplus import fields
 from flask.ext import login
 from flask.ext.scrypt import check_password_hash
@@ -277,3 +278,18 @@ def auth_basic():
         return (False, 'Authentication failed. Wrong username or password')
     g.user = user
     return (True, '')
+
+
+# Disable caching in a view
+# Used in download views
+# http://arusahni.net/blog/2014/03/flask-nocache.html
+def nocache(view):
+    @wraps(view)
+    def no_cache(*args, **kwargs):
+        response = make_response(view(*args, **kwargs))
+        response.headers['Last-Modified'] = datetime.now()
+        response.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0, max-age=0'
+        response.headers['Pragma'] = 'no-cache'
+        response.headers['Expires'] = '-1'
+        return response
+    return update_wrapper(no_cache, view)

--- a/tests/api/test_export_import.py
+++ b/tests/api/test_export_import.py
@@ -1,0 +1,41 @@
+import unittest
+
+from tests.setup_database import Setup
+from tests.utils import OpenEventTestCase
+from tests.api.utils import create_event, get_path, create_services
+from tests.api.utils_post_data import *
+from open_event import current_app as app
+
+
+class TestEventExport(OpenEventTestCase):
+    """
+    Test export of event
+    """
+    def setUp(self):
+        self.app = Setup.create_app()
+        with app.test_request_context():
+            create_event()
+            create_services(1)
+
+    def test_export_success(self):
+        path = get_path(1, 'export', 'json')
+        resp = self.app.get(path)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('event1.zip', resp.headers['Content-Disposition'])
+        size = len(resp.data)
+        with app.test_request_context():
+            create_services(1, '2')
+            create_services(1, '3')
+        # check if size increased
+        resp = self.app.get(path)
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(len(resp.data) > size)
+
+    def test_export_no_event(self):
+        path = get_path(2, 'export', 'json')
+        resp = self.app.get(path)
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #758 

URL is `api/v2/events/<id>/export/json` . Going to it will start the download as `event<id>.zip`

@mariobehling @shivamMg please review

PS - I have not added this to the Swagger spec as I don't think this is an API. (It is more like a download link) 