### PR TITLE
Removed Login error

### DIFF
--- a/open_event/helpers/data.py
+++ b/open_event/helpers/data.py
@@ -867,6 +867,18 @@ def create_user_oauth(user, user_data, token, method):
     return user
 
 
+def create_user_password(form, user):
+    salt = generate_random_salt()
+    password = form['new_password_again']
+    user.password = generate_password_hash(password, salt)
+    hash = random.getrandbits(128)
+    user.reset_password = str(hash)
+    user.salt = salt
+
+    save_to_db(user, "User password created")
+    return user
+
+
 def update_version(event_id, is_created, column_to_increment):
     """Function resposnible for increasing version when some data will be
     created or changed

--- a/open_event/templates/gentelella/admin/login/base.html
+++ b/open_event/templates/gentelella/admin/login/base.html
@@ -36,6 +36,9 @@
 
       {% block change_password %}
           {% endblock %}
+
+      {% block create_password %}
+      {% endblock %}
       </div>
   </div>
 </body>

--- a/open_event/templates/gentelella/admin/login/create_password.html
+++ b/open_event/templates/gentelella/admin/login/create_password.html
@@ -1,0 +1,21 @@
+{% extends 'gentelella/admin/login/base.html' %}
+{% block change_password %}
+<div id="change_password" class="animate form registration_form">
+          <section class="login_content">
+            <form method="post">
+              <h1>Create Password</h1>
+              <div>
+                <input name="new_password" type="password" class="form-control" placeholder="New Password" required="" />
+              </div>
+              <div>
+                <input name="new_password_again" type="password" class="form-control" placeholder="Re-Enter Password" required="" />
+              </div>
+              <div>
+                <button type="submit" class="btn btn-default">Submit</button>
+              </div>
+
+              <div class="clearfix"></div>
+            </form>
+          </section>
+</div>
+{% endblock %}

--- a/open_event/views/admin/home.py
+++ b/open_event/views/admin/home.py
@@ -8,7 +8,7 @@ from flask_admin.base import AdminIndexView
 from flask.ext.scrypt import generate_password_hash
 from wtforms import ValidationError
 
-from ...helpers.data import DataManager, save_to_db, get_google_auth, get_facebook_auth
+from ...helpers.data import DataManager, save_to_db, get_google_auth, get_facebook_auth, create_user_password
 from ...helpers.data_getter import DataGetter
 from ...helpers.helpers import send_email_with_reset_password_hash, send_email_confirmation, get_serializer
 from open_event.helpers.oauth import OAuth, FbOAuth
@@ -73,6 +73,19 @@ class MyHomeView(AdminIndexView):
         user = DataManager.create_user(data)
         login.login_user(user)
         return redirect(intended_url())
+
+    @expose('/password/new/<email>', methods=('GET', 'POST'))
+    def create_password_after_oauth_login(self, email):
+        s = get_serializer()
+        email = s.loads(email)
+        user = DataGetter.get_user_by_email(email)
+        if request.method == 'GET':
+            return self.render('/gentelella/admin/login/create_password.html')
+        if request.method == 'POST':
+            user = create_user_password(request.form, user)
+            if user is not None:
+                login.login_user(user)
+                return redirect(intended_url())
 
     @expose('/password/reset', methods=('GET', 'POST'))
     def password_reset_view(self):

--- a/open_event/views/views.py
+++ b/open_event/views/views.py
@@ -13,6 +13,7 @@ from ..models.event import Event
 from ..models.session import Session, Level, Format, Language
 from ..models.version import Version
 from ..helpers.object_formatter import ObjectFormatter
+from ..helpers.helpers import get_serializer
 from ..helpers.data_getter import DataGetter
 from views_helpers import event_status_code, api_response
 from flask import Blueprint
@@ -478,8 +479,13 @@ def callback():
             email = user_data['email']
             user = DataGetter.get_user_by_email(email)
             user = create_user_oauth(user, user_data, token=token, method='Google')
-            login.login_user(user)
-            return redirect(url_for('admin.index'))
+            if user.password is None:
+                s = get_serializer()
+                email = s.dumps(user.email)
+                return redirect(url_for('admin.create_password_after_oauth_login', email=email))
+            else:
+                login.login_user(user)
+                return redirect(url_for('admin.index'))
         return 'did not find user info'
 
 
@@ -511,8 +517,13 @@ def facebook_callback():
             email = user_info['email']
             user_email = DataGetter.get_user_by_email(email)
             user = create_user_oauth(user_email, user_info, token=token, method='Facebook')
-            login.login_user(user)
-            return redirect(url_for('admin.index'))
+            if user.password is None:
+                s = get_serializer()
+                email = s.dumps(user.email)
+                return redirect(url_for('admin.create_password_after_oauth_login', email=email))
+            else:
+                login.login_user(user)
+                return redirect(url_for('admin.index'))
         return 'did not find user info'
 
 


### PR DESCRIPTION
The login error because of user.salt was there because on logging in through Google or Facebook no password is created for the user. I have added a password creation template for the users who choose to login through Google and Facebook.
![new_password](https://cloud.githubusercontent.com/assets/15054664/16048691/a438a208-3272-11e6-92f7-52ae7441057c.png)
#805 