### PR TITLE
Validate nested fields in API

### DIFF
--- a/open_event/api/helpers/helpers.py
+++ b/open_event/api/helpers/helpers.py
@@ -144,6 +144,8 @@ def validate_payload(payload, api_model):
         if isinstance(field, fields.List):
             field = field.container
             data = payload[key]
+        elif isinstance(field, fields.Nested):
+            validate_payload(payload[key], field.model)
         else:
             data = [payload[key]]
         if isinstance(field, CustomField) and hasattr(field, 'validate'):

--- a/tests/api/test_post_api_validation.py
+++ b/tests/api/test_post_api_validation.py
@@ -19,7 +19,8 @@ class ApiValidationTestCase():
         return self._test_model(
             'event',
             POST_EVENT_DATA,
-            ['color', 'email', 'logo', 'event_url', 'background_url']
+            ['color', 'email', 'logo', 'event_url', 'background_url',
+                'type', 'topic']
         )
 
     def test_speaker_api(self):


### PR DESCRIPTION
Fixes #834 

This adds validation of nested fields in API.. 

Example 

```json
{
    "id": 1,
    "email": "email@gmail.com",
    "user_detail": {
        "fullname": "John Doe",
        "details": "bio",
        "avatar": "http://link/to/avatar",
        "contact": "+91823234433",
        "facebook": "http://fb.com/link",
        "twitter": "http://twitter.com/link"
    }
}
```

Currently everything under user_detail is not being validated.
Note - This type of API does not exist now but it may in the future. 
