### PR TITLE
Session Form: Make Title and Name always required

### DIFF
--- a/open_event/templates/gentelella/admin/event/wizard/step-5.html
+++ b/open_event/templates/gentelella/admin/event/wizard/step-5.html
@@ -1,20 +1,24 @@
 {% macro field_switch(name, group, include=false, require=false ) %}
     {% set identifier = name | replace(group + '.','') %}
     {% set ban_list = ['id', 'event_id', 'start_time', 'end_time', 'microlocation_id', 'level_id', 'format_id', 'event_id', 'state'] %}
+    {% set required_list = ['title', 'name', 'email'] %}
     {% set name = identifier | replace('_id','') | replace('_',' ') %}
     {% if identifier not in ban_list %}
         <tr data-identifier="{{ name }}" data-group="{{ group }}">
-            <td>{{ name | capitalize }}</td>
+            <td>
+                {{ name | capitalize }}
+                {% if identifier in required_list %}<span class="required">*</span>{% endif %}
+            </td>
             <td>
                 <label>
-                    <input type="checkbox" class="js-switch include-switch" data-group="{{ group }}" onclick="includeClick(this)"
-                           {% if include %}checked="checked"{% endif %}/>
+                    <input type="checkbox" class="js-switch include-switch" data-group="{{ group }}" {% if identifier not in required_list %}onclick="includeClick(this)"{% endif %}
+                           {% if include or identifier in required_list %}checked="checked"{% endif %} {% if identifier in required_list %}disabled{% endif %}/>
                 </label>
             </td>
             <td>
                 <label>
-                    <input type="checkbox" class="js-switch require-switch" data-group="{{ group }}" onclick="requireClick(this)"
-                           {% if include %}checked="checked"{% endif %}/>
+                    <input type="checkbox" class="js-switch require-switch" data-group="{{ group }}" {% if identifier not in required_list %}onclick="includeClick(this)"{% endif %}
+                           {% if include or identifier in required_list %}checked="checked"{% endif %}  {% if identifier in required_list %}disabled{% endif %}/>
                 </label>
             </td>
         </tr>

--- a/open_event/views/admin/models_views/events.py
+++ b/open_event/views/admin/models_views/events.py
@@ -29,6 +29,9 @@ class EventsView(ModelView):
     def create_view(self):
         session_columns = DataGetter.get_session_columns()
         speaker_columns = DataGetter.get_speaker_columns()
+        speaker_columns = list(speaker_columns)
+        speaker_columns.insert(2, speaker_columns.pop(4))  # Moving email to the top
+
         if request.method == 'POST':
             event = DataManager.create_event(request.form)
             if event:
@@ -57,6 +60,7 @@ class EventsView(ModelView):
         sponsors = DataGetter.get_sponsors(event_id)
         session_columns = DataGetter.get_session_columns()
         speaker_columns = DataGetter.get_speaker_columns()
+
         if request.method == 'GET':
             return self.render('/gentelella/admin/event/edit/edit.html', event=event, session_types=session_types,
                                tracks=tracks, social_links=social_links, microlocations=microlocations,


### PR DESCRIPTION
Resolves #828. 

Title, Name and email are always required.

@mariobehling @rafalkowalski @SaptakS please review and merge into `development`