### PR TITLE
Add Version Number to Dashboard.

### DIFF
--- a/open_event/__init__.py
+++ b/open_event/__init__.py
@@ -22,7 +22,7 @@ from open_event.models import db
 from open_event.views.admin.admin import AdminView
 from helpers.jwt import jwt_authenticate, jwt_identity
 from open_event.helpers.data_getter import DataGetter
-from open_event.views.views import app as routes
+from open_event.views.api_v1_views import app as api_v1_routes
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -35,7 +35,7 @@ def create_app():
     cal = Calendar()
     event = Event()
 
-    app.register_blueprint(routes)
+    app.register_blueprint(api_v1_routes)
     migrate = Migrate(app, db)
 
     app.config.from_object(environ.get('APP_CONFIG', 'config.ProductionConfig'))

--- a/open_event/helpers/helpers.py
+++ b/open_event/helpers/helpers.py
@@ -106,7 +106,7 @@ def get_serializer(secret_key=None):
 
 
 def get_latest_heroku_release():
-    token = os.environ.get('API_TOKEN_HEROKU', None)
+    token = os.environ.get('API_TOKEN_HEROKU', '')
     headers = {
         "Accept": "application/vnd.heroku+json; version=3",
         "Authorization": "Bearer " + token,

--- a/open_event/templates/gentelella/admin/current_version.html
+++ b/open_event/templates/gentelella/admin/current_version.html
@@ -1,39 +1,75 @@
 {% extends 'gentelella/admin/base.html' %}
-{% block head %}
-{{ super() }}
-{% endblock %}
 
 {% block title %}
-Heroku Info
+    Heroku Info
 {% endblock %}
+
+{% block head_css %}
+    {{ super() }}
+    <style type="text/css">
+
+        .table > tbody > tr > td:nth-child(1) {
+            text-align: right;
+        }
+
+        .table > tbody > tr > td:nth-child(2) {
+                font-weight: 500;
+         }
+    </style>
+{% endblock %}
+
 {% block body %}
 
 
-<div role="main" class="right_col" style="margin-left: 0px; min-height: 706px;">
-    <div class="">
-        <div class="page-title">
-            <div class="title_left">
-                <h3>Heroku info</h3>
+    <div role="main" class="right_col" style="margin-left: 0px; min-height: 706px;">
+        <div class="">
+            <div class="page-title">
+                <div class="title_left">
+                    <h3>Heroku info</h3>
+                </div>
             </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12 col-sm-12 col-xs-12">
-                <div class="x_panel" style="min-height:600px;">
-                    <div style="text-align:center">
-                        <a href="/" style="font-size: 26px; font-weight: 300;">
-                            Open Event
-                        </a>
-                        <p>Heroku Version: <b>{{version.version}}</b></p>
-                        <p>Responsible person for last changes: <b>{{version.user.email}}</b></p>
-                        <p>Revision: <b>{{version.description}}</b></p>
-                        <p>Author Name: <b>{{commit_info.commit.author.name}}</b></p>
-                        <p>Email: <b>{{commit_info.commit.author.email}}</b></p>
+            <div class="row">
+                <div class="col-md-12 col-sm-12 col-xs-12">
+                    <div class="x_panel">
+                        <div class="col-md-8 col-md-push-2">
+
+                            <div style="width: 100%; text-align: center;">
+                                <a href="https://github.com/fossasia/open-event-orga-server" target="_blank"
+                                   style="font-size: 26px; font-weight: 300;">
+                                    Open Event
+                                </a>
+                            </div>
+
+                            <table class="table table-bordered" style="margin-top: 12px;">
+                                <tbody>
+                                <tr>
+                                    <td>Heroku Version</td>
+                                    <td>{{ version.version }}</td>
+                                </tr>
+                                <tr>
+                                    <td>Revision</td>
+                                    <td><a href="{{ commit_info.html_url }}" target="_blank">{{ version.description }} <i class="fa fa-code-fork"></i></a></td>
+                                </tr>
+                                <tr>
+                                    <td>Author Name</td>
+                                    <td><a href="{{ commit_info.author.html_url }}" target="_blank">{{ commit_info.commit.author.name }} <i class="fa fa-external-link"></i></a></td>
+                                </tr>
+                                <tr>
+                                    <td>Email</td>
+                                    <td><a href="mailto:{{ commit_info.commit.author.email }}" target="_blank">{{ commit_info.commit.author.email }}</a></td>
+                                </tr>
+                                <tr>
+                                    <td>Commit Message</td>
+                                    <td><a href="{{ commit_info.html_url }}" target="_blank">{{ commit_info.commit.message }} <i class="fa fa-github"></i></a></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>
+
+
         </div>
-
-
     </div>
-</div>
 {% endblock %}

--- a/open_event/views/admin/admin.py
+++ b/open_event/views/admin/admin.py
@@ -22,6 +22,7 @@ from open_event.views.admin.models_views.session import SessionView
 from open_event.views.admin.models_views.events_speakers import EventsSpeakersView
 from open_event.views.admin.models_views.events_sponsors import EventsSponsorsView
 from open_event.views.admin.home import MyHomeView
+from open_event.views.admin.super_admin import SuperAdminView
 from open_event.views.public.event_detail import EventDetailView
 
 
@@ -40,8 +41,10 @@ class AdminView(object):
         self._add_views()
 
     def _add_views(self):
-        self.admin.add_view(EventsView(Event, db.session, name='Events', url='/events'))
+        self.admin.add_view(SuperAdminView(name='SuperAdmin', url='/admin'))
+        self.admin.add_view(EventDetailView(name='Event Detail', url='/e'))
         self.admin.add_view(MySessionView(name='MySessions', url='/events/mysessions'))
+        self.admin.add_view(EventsView(Event, db.session, name='Events', url='/events'))
         self.admin.add_view(EventsSpeakersView(Speaker, db.session, name='Speaker', url='/events/<event_id>/speakers'))
         self.admin.add_view(EventsSponsorsView(Sponsor, db.session, name='Sponsor', url='/events/<event_id>/sponsors'))
         self.admin.add_view(SessionView(Session, db.session, name='Sessions', url='/events/<event_id>/sessions'))
@@ -50,7 +53,6 @@ class AdminView(object):
         self.admin.add_view(ProfileView(User, db.session, name='Profile', url='/profile'))
         self.admin.add_view(TracksView(Track, db.session, name='Track', url='/events/<event_id>/tracks'))
         self.admin.add_view(InviteView(Invite, db.session, name='Invite', url='/events/<event_id>/invite'))
-        self.admin.add_view(EventDetailView(name='Event Detail', url='/e'))
 
     @staticmethod
     def init_login(app):

--- a/open_event/views/admin/home.py
+++ b/open_event/views/admin/home.py
@@ -17,11 +17,21 @@ from open_event.helpers.oauth import OAuth, FbOAuth
 def intended_url():
     return request.args.get('next') or url_for('.index')
 
+def chunks(l, n):
+    """Yield successive n-sized chunks from l."""
+    for i in xrange(0, len(l), n):
+        yield l[i:i + n]
 
 class MyHomeView(AdminIndexView):
+
     @expose('/')
     def index(self):
-        return self.render('gentelella/admin/index.html')
+        call_for_papers_evs = DataGetter.get_call_for_speakers_events().all()
+        published_events = DataGetter.get_all_published_events().all()
+        # Provide data as chunks of 6 for the UI to render in a proper way
+        return self.render('gentelella/index.html',
+                           call_for_papers_evs=list(chunks(call_for_papers_evs, 6)),
+                           published_events=list(chunks(published_events, 6)))
 
     @expose('/login/', methods=('GET', 'POST'))
     def login_view(self):

--- a/open_event/views/admin/super_admin.py
+++ b/open_event/views/admin/super_admin.py
@@ -1,0 +1,15 @@
+import flask_login
+from flask_admin import BaseView, expose
+
+from open_event.helpers.helpers import get_latest_heroku_release, get_commit_info
+
+class SuperAdminView(BaseView):
+
+    @expose('/')
+    @flask_login.login_required
+    def display_my_sessions_view(self):
+        version = get_latest_heroku_release()
+        commit_number = version['description'].split(' ')[1]
+        commit_info = get_commit_info(commit_number)
+        return self.render('gentelella/admin/current_version.html',
+                           version=version, commit_info=commit_info)

--- a/open_event/views/api_v1_views.py
+++ b/open_event/views/api_v1_views.py
@@ -1,6 +1,5 @@
 """Copyright 2015 Rafal Kowalski"""
 import os
-import uuid
 from flask import jsonify, url_for, redirect, request, send_from_directory
 from flask.ext.cors import cross_origin
 from flask.ext import login
@@ -20,36 +19,13 @@ from flask import Blueprint
 from flask.ext.autodoc import Autodoc
 from icalendar import Calendar
 import icalendar
-from flask import render_template
 from open_event.helpers.oauth import OAuth, FbOAuth
 from requests.exceptions import HTTPError
 from ..helpers.data import get_google_auth, create_user_oauth, get_facebook_auth
-from ..helpers.helpers import get_latest_heroku_release, get_commit_info
-import json
-
 
 auto = Autodoc()
 
 app = Blueprint('', __name__)
-
-
-def chunks(l, n):
-    """Yield successive n-sized chunks from l."""
-    for i in xrange(0, len(l), n):
-        yield l[i:i + n]
-
-@app.route('/', methods=['GET'])
-@auto.doc()
-@cross_origin()
-def get_main_page():
-    """Redirect to admin page"""
-    call_for_papers_evs = DataGetter.get_call_for_speakers_events().all()
-    published_events = DataGetter.get_all_published_events().all()
-    # Provide data as chunks of 6 for the UI to render in a proper way
-    return render_template('gentelella/index.html',
-                           call_for_papers_evs=list(chunks(call_for_papers_evs, 6)),
-                           published_events=list(chunks(published_events, 6)))
-
 
 @app.route('/api/v1/event', methods=['GET'])
 @auto.doc()
@@ -544,12 +520,3 @@ def send_cal(filename):
 @app.route('/documentation')
 def documentation():
     return auto.html()
-
-
-@app.route('/heroku_releases')
-def heroku_releases():
-    version = get_latest_heroku_release()
-    commit_number = version['description'].split(' ')[1]
-    commit_info = get_commit_info(commit_number)
-    return render_template('gentelella/admin/current_version.html',
-                           version=version, commit_info=commit_info)


### PR DESCRIPTION
The Heroku version info has been moved to `/admin` as suggested by @mariobehling in #683. 

The heroku version now shows the last committer's details along with a link to the commit. 

Resolves #683. 

 @mariobehling @SaptakS @rafalkowalski please review and merge into `development`