### PR TITLE
Event wizard: S5 wrong session/speaker form stored.

### DIFF
--- a/open_event/templates/gentelella/admin/event/wizard/step-5.html
+++ b/open_event/templates/gentelella/admin/event/wizard/step-5.html
@@ -122,7 +122,7 @@
             var $row = $(row);
             sessionForm[0][$row.data('identifier')] = {
                 include: $row.find('.include-switch')[0].checked ? 1 : 0,
-                require: $row.find('.require-switch')[0].require ? 1 : 0
+                require: $row.find('.require-switch')[0].checked ? 1 : 0
             }
         });
 
@@ -130,7 +130,7 @@
             var $row = $(row);
             speakerForm[0][$row.data('identifier')] = {
                 include: $row.find('.include-switch')[0].checked ? 1 : 0,
-                require: $row.find('.require-switch')[0].require ? 1 : 0
+                require: $row.find('.require-switch')[0].checked ? 1 : 0
             }
         });
 


### PR DESCRIPTION
There was a small error in the javascript causing only required title, name and email to be required irrespective of the user's choice. 

@SaptakS please review and merge