### PR TITLE
show return model of get sponsor types API

### DIFF
--- a/open_event/api/sponsors.py
+++ b/open_event/api/sponsors.py
@@ -88,7 +88,7 @@ class SponsorList(Resource):
 
 @api.route('/events/<int:event_id>/sponsors/types')
 class SponsorTypesList(Resource):
-    @api.doc('list_sponsor_types')
+    @api.doc('list_sponsor_types', model=[fields.String()])
     def get(self, event_id):
         """List all sponsor types"""
         return DAO.list_types(event_id)


### PR DESCRIPTION
Fixes #889

![sponsor_type_schema](https://cloud.githubusercontent.com/assets/4047597/16110295/b887eb52-33ca-11e6-976f-65d1b2099198.png)
