### PR TITLE
Remove delete/edit buttons from public schedule page

### DIFF
--- a/open_event/static/js/admin/event/scheduler.js
+++ b/open_event/static/js/admin/event/scheduler.js
@@ -708,6 +708,11 @@ function loadMicrolocationsToTimeline(day) {
 
     $microlocations = $microlocationsHolder.find(".microlocation");
     $("[data-toggle=tooltip]").tooltip("hide");
+
+    if (isReadOnly()) {
+        $('.edit-btn').hide();
+        $('.remove-btn').hide();
+    }
 }
 
 function loadData(eventId, callback) {
@@ -734,7 +739,7 @@ function initializeTimeline(eventId) {
                 $('.remove-btn').hide();
             }
 
-            $('.microlocation-container').css("width", $(".microlocations.x1").width()+"px")
+            $('.microlocation-container').css("width", $(".microlocations.x1").width() + "px")
         });
     });
 }


### PR DESCRIPTION
In the public schedule page at `/e/<event_id>/schedule`, the remove and edit buttons are being shown. These buttons have been removed. 

There is no issue for this. it's a quickfix. 

@rafalkowalski @mariobehling @SaptakS please review and merge. 