### PR TITLE
Anonymous User: the public page that holds the Call for Speakers (with a register button) 

### DIFF
--- a/open_event/helpers/data.py
+++ b/open_event/helpers/data.py
@@ -30,7 +30,6 @@ from ..models.user_detail import UserDetail
 from ..models.role import Role
 from ..models.users_events_roles import UsersEventsRoles
 from ..models.session_type import SessionType
-from ..models.sessions_speakers import SessionsSpeakers
 from ..models.social_link import SocialLink
 from ..models.track import Track
 from open_event.helpers.oauth import OAuth, FbOAuth
@@ -129,9 +128,11 @@ class DataManager(object):
         update_version(event_id, False, "session_ver")
 
     @staticmethod
-    def add_session_to_event(form, event_id, speaker_img_name):
+    def add_session_to_event(form, event_id, speaker_img_name, state="pending"):
         """
         Session will be saved to database with proper Event id
+        :param speaker_img_name:
+        :param state:
         :param form: view data form
         :param event_id: Session belongs to Event by event id
         """
@@ -143,10 +144,8 @@ class DataManager(object):
                               end_time="2016-01-01",
                               event_id=event_id,
                               short_abstract=form["short_abstract"] if "short_abstract" in form.keys() else "",
-                              state="pending")
+                              state=state)
 
-        save_to_db(new_session, "Session saved")
-        update_version(event_id, False, "session_ver")
 
         if speaker_img_name != "":
             img_path = 'static/media/image/' + speaker_img_name
@@ -164,14 +163,11 @@ class DataManager(object):
                               organisation=form["organisation"] if "organisation" in form.keys() else "",
                               position=form["position"] if "position" in form.keys() else "",
                               country=form["country"] if "country" in form.keys() else "",
-                              user=login.current_user)
-        save_to_db(new_speaker, "Speaker saved")
+                              user=login.current_user if login and login.current_user.is_authenticated else None)
+        new_session.speakers.append(new_speaker)
+        save_to_db(new_session, "Session saved")
         update_version(event_id, False, "speakers_ver")
-
-        new_session_speaker = SessionsSpeakers(session_id=new_session.id,
-                                               speaker_id=new_speaker.id)
-
-        save_to_db(new_session_speaker, "Session Speaker saved")
+        update_version(event_id, False, "session_ver")
 
         invite_emails = form.getlist("speakers[email]")
         for index, email in enumerate(invite_emails):
@@ -191,6 +187,7 @@ class DataManager(object):
         :param form: view data form
         :param event_id: Session belongs to Event by event id
         """
+        session = DataGetter.get_session(session_id)
         new_speaker = Speaker(name=form["name"] if "name" in form.keys() else "",
                               photo=form["photo"] if "photo" in form.keys() else "",
                               short_biography=form["short_biography"] if "short_biography" in form.keys() else "",
@@ -205,13 +202,9 @@ class DataManager(object):
                               position=form["position"] if "position" in form.keys() else "",
                               country=form["country"] if "country" in form.keys() else "",
                               user=login.current_user)
-        save_to_db(new_speaker, "Speaker saved")
+        session.speakers.append(new_speaker)
+        save_to_db(session, "Speaker saved")
         update_version(event_id, False, "speakers_ver")
-
-        new_session_speaker = SessionsSpeakers(session_id=session_id,
-                                               speaker_id=new_speaker.id)
-
-        save_to_db(new_session_speaker, "Session Speaker saved")
 
     @staticmethod
     def create_speaker_session_relation(session_id, speaker_id, event_id):
@@ -220,10 +213,10 @@ class DataManager(object):
         :param form: view data form
         :param event_id: Session, speaker belongs to Event by event id
         """
-        new_session_speaker = SessionsSpeakers(session_id=session_id,
-                                               speaker_id=speaker_id)
-
-        save_to_db(new_session_speaker, "Session Speaker saved")
+        speaker = DataGetter.get_speaker(speaker_id)
+        session = DataGetter.get_session(session_id)
+        session.speakers.append(speaker)
+        save_to_db(session, "Session Speaker saved")
 
     @staticmethod
     def edit_session(form, session):

--- a/open_event/helpers/data.py
+++ b/open_event/helpers/data.py
@@ -846,6 +846,12 @@ def create_user_password(form, user):
     save_to_db(user, "User password created")
     return user
 
+def user_logged_in(user):
+    speakers = DataGetter.get_speaker_by_email(user.email).all()
+    for speaker in speakers:
+        speaker.user = user
+        save_to_db(speaker)
+    return True
 
 def update_version(event_id, is_created, column_to_increment):
     """Function resposnible for increasing version when some data will be

--- a/open_event/helpers/data_getter.py
+++ b/open_event/helpers/data_getter.py
@@ -127,10 +127,10 @@ class DataGetter:
         :return: Return all Sessions objects with the current user as a speaker
         """
         if upcoming_events:
-            return Session.query.filter(Session.speakers.any(Speaker.email == login.current_user.email)).filter(
+            return Session.query.filter(Session.speakers.any(Speaker.user_id == login.current_user.id)).filter(
                 Event.state != 'Completed')
         else:
-            return Session.query.filter(Session.speakers.any(Speaker.email == login.current_user.email)).filter(
+            return Session.query.filter(Session.speakers.any(Speaker.user_id == login.current_user.id)).filter(
                 Event.state == 'Completed')
 
     @staticmethod
@@ -345,6 +345,11 @@ class DataGetter:
     def get_speaker(speaker_id):
         """Get speaker by id"""
         return Speaker.query.get(speaker_id)
+
+    @staticmethod
+    def get_speaker_by_email(email_id):
+        """Get speaker by id"""
+        return Speaker.query.filter_by(email=email_id)
 
     @staticmethod
     def get_session_types_by_event_id(event_id):

--- a/open_event/models/sessions_speakers.py
+++ b/open_event/models/sessions_speakers.py
@@ -1,9 +1,0 @@
-from . import db
-
-
-class SessionsSpeakers(db.Model):
-    __tablename__ = 'sessions_speakers'
-    id = db.Column(db.Integer, primary_key=True)
-    speaker_id = db.Column(db.Integer, db.ForeignKey('speaker.id'))
-    session_id = db.Column(db.Integer, db.ForeignKey('session.id'))
-    speaker = db.relationship("Speaker", backref="speaker")

--- a/open_event/models/user.py
+++ b/open_event/models/user.py
@@ -7,7 +7,6 @@ from .role import Role
 from .service import Service
 from .permission import Permission
 from .users_events_roles import UsersEventsRoles
-from .sessions_speakers import SessionsSpeakers
 
 # System-wide
 ADMIN = 'admin'
@@ -99,15 +98,6 @@ class User(db.Model):
 
     def can_delete(self, service_class, event_id):
         return self._has_perm('delete', service_class, event_id)
-
-    def is_speaker_at_session(self, session_id):
-        for speaker in self.speakers:
-            ss = SessionsSpeakers.query.filter_by(speaker_id=speaker.id,
-                                                  session_id=session_id).first()
-            if ss is not None:
-                return True
-
-        return False
 
     # Flask-Login integration
     def is_authenticated(self):

--- a/open_event/static/css/guest/details.css
+++ b/open_event/static/css/guest/details.css
@@ -79,7 +79,7 @@ body {
 
 .scrollspy {
     position: absolute;
-    left: 55px;
+    left: 40px;
     z-index: 11;
     text-align: right;
 }

--- a/open_event/templates/gentelella/admin/event/sessions/new.html
+++ b/open_event/templates/gentelella/admin/event/sessions/new.html
@@ -10,87 +10,6 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin/event_wizard.css') }}"/>
 {% endblock %}
 
-{% set textarea_session_fields = ['short_abstract', 'long_abstract'] %}
-{% set media_session_fields = ['slides', 'video', 'audio'] %}
-
-{% set session_fields = ['title', 'subtitle', 'short_abstract', 'long_abstract', 'comments', 'track', 'session_type', 'language', 'slides', 'video', 'audio'] %}
-
-{% macro session_form_field(identifier, require=0) %}
-    {% set name = identifier | replace('_id','') %}
-    {% set pretty_name = name | replace('_',' ') | capitalize %}
-    <div class="item form-group speaker-fields">
-        <label class="control-label">
-            {{ pretty_name }}
-            {% if require==1 %}
-                <span class="required">*</span>
-            {% endif %}
-        </label>
-        {% if identifier in textarea_session_fields %}
-            <textarea {% if require==1 %}
-                required="required"
-            {% endif %}
-                name="{{ identifier }}" class="form-control col-md-7 col-xs-12"></textarea>
-        {% elif identifier in media_session_fields %}
-            <br><input {% if require==1 %}
-            required="required"
-        {% endif %}
-            type="file" id="speaker-file-{{ identifier | default(1) }}" name="{{ identifier }}"
-            class="upload-btn"/>
-            <label class="file-label" for="speaker-file-{{ identifier | default(1) }}">
-                <i class="fa fa-cloud-upload" aria-hidden="true"></i>
-                Choose a file</label>
-        {% else %}
-            <input {% if require==1 %}
-                required="required"
-            {% endif %}
-                name="{{ identifier }}" class="form-control col-md-7 col-xs-12"/>
-        {% endif %}
-    </div>
-{% endmacro %}
-
-{% set textarea_speaker_fields = ['short_biography', 'long_biography'] %}
-{% set media_speaker_fields = ['photo'] %}
-
-{% set speaker_fields = ['name', 'email','photo', 'organisation', 'position', 'country', 'short_biography', 'long_biography', 'mobile', 'website', 'facebook', 'twitter', 'github', 'linkedin'] %}
-
-{% macro speaker_form_field(identifier, require=0) %}
-    {% set name = identifier | replace('_id','') %}
-    {% set pretty_name = name | replace('_',' ') | capitalize %}
-    <div class="item form-group speaker-fields">
-        <label class="control-label">
-            {{ pretty_name }}
-            {% if require==1 %}
-                <span class="required">*</span>
-            {% endif %}
-        </label>
-        {% if identifier in textarea_speaker_fields %}
-            <textarea {% if require==1 %}
-                required="required"
-            {% endif %}
-                name="{{ identifier }}" class="form-control col-md-7 col-xs-12"></textarea>
-        {% elif identifier in media_speaker_fields %}
-            <br><input {% if require==1 %}
-            required="required"
-        {% endif %}
-            type="file" id="speaker-file-{{ identifier | default(1) }}" name="{{ identifier }}"
-            class="upload-btn"/>
-            <label class="file-label" for="speaker-file-{{ identifier | default(1) }}">
-                <i class="fa fa-cloud-upload" aria-hidden="true"></i>
-                Choose a file</label>
-        {% else %}
-            <input {% if require==1 %}
-                required="required"
-            {% endif %}
-                name="{{ identifier }}"
-                    {% if identifier=="email" %}
-                        {% if current_user.is_authenticated %}
-                value="{{ current_user.email }}" disabled
-                        {% endif %}
-                    {% endif %}
-                class="form-control col-md-7 col-xs-12"/>
-        {% endif %}
-    </div>
-{% endmacro %}
 
 {% block content %}
     <div class="row">
@@ -100,52 +19,7 @@
                 <h3>Create Session</h3>
             </div>
 
-            <form enctype="multipart/form-data" name="test" action="" method="POST" role="form" class="admin-form form-horizontal"
-                  id="session-create-form">
-                {% if csrf_token %}
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                {% endif %}
-                <div class="col-md-1 col-sm-1 col-xs-12">
-
-                </div>
-                <div class="col-md-5 col-sm-5 col-xs-12 session_form" style="margin-right: 25px;">
-                    <h4>Session Details</h4>
-                    {% for elem in session_fields %}
-                        {% if session_form[elem].include==1 %}
-                            {{ session_form_field(elem, session_form[elem].require) }}
-                        {% endif %}
-                    {% endfor %}
-                </div>
-                <div class="col-md-5 col-sm-5 col-xs-12 speaker_form">
-                    <h4>Speaker Details</h4>
-                    {% for elem in speaker_fields %}
-                        {% if speaker_form[elem].include==1 %}
-                            {{ speaker_form_field(elem, speaker_form[elem].require) }}
-                        {% endif %}
-                    {% endfor %}
-                    <div class="speakers">
-                        <hr>
-                        <br><h4>Invite Speakers</h4>
-                        <div class="item form-group">
-                            <label class="control-label">Email </label>
-                            <div class="">
-                                <input type="text" class="form-control col-md-7 col-sm-7" name="speakers[email]"
-                                       placeholder="Email Address of Speaker" style="width:60%;">
-                            </div>
-
-                            <div class="col-sm-1 col-md-1 input-group">
-                                    <span class="input-group-btn">
-                                        <button type="button" class="btn btn-primary" id="add-speakers">+</button>
-                                    </span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div style="text-align: center;">
-                    <input type="submit" class="btn btn-primary" value="Save as Draft"/>
-                    <input type="submit" class="btn btn-success" value="Submit Session"/>
-                </div>
-            </form>
+            {% include 'gentelella/admin/event/sessions/session_form.html' %}
 
         </div>
     </div>

--- a/open_event/templates/gentelella/admin/event/sessions/session_form.html
+++ b/open_event/templates/gentelella/admin/event/sessions/session_form.html
@@ -1,0 +1,135 @@
+{% set textarea_session_fields = ['short_abstract', 'long_abstract'] %}
+{% set media_session_fields = ['slides', 'video', 'audio'] %}
+
+{% set session_fields = ['title', 'subtitle', 'short_abstract', 'long_abstract', 'comments', 'track', 'session_type', 'language', 'slides', 'video', 'audio'] %}
+
+{% macro session_form_field(identifier, require=0) %}
+    {% set name = identifier | replace('_id','') %}
+    {% set pretty_name = name | replace('_',' ') | capitalize %}
+    <div class="item form-group speaker-fields">
+        <label class="control-label">
+            {{ pretty_name }}
+            {% if require==1 %}
+                <span class="required">*</span>
+            {% endif %}
+        </label>
+        {% if identifier in textarea_session_fields %}
+            <textarea {% if require==1 %}
+                required="required"
+            {% endif %}
+                name="{{ identifier }}" class="form-control col-md-7 col-xs-12"></textarea>
+        {% elif identifier in media_session_fields %}
+            <br><input {% if require==1 %}
+            required="required"
+        {% endif %}
+            type="file" id="speaker-file-{{ identifier | default(1) }}" name="{{ identifier }}"
+            class="upload-btn"/>
+            <label class="file-label" for="speaker-file-{{ identifier | default(1) }}">
+                <i class="fa fa-cloud-upload" aria-hidden="true"></i>
+                Choose a file</label>
+        {% else %}
+            <input {% if require==1 %}
+                required="required"
+            {% endif %}
+                name="{{ identifier }}" class="form-control col-md-7 col-xs-12"/>
+        {% endif %}
+    </div>
+{% endmacro %}
+
+{% set textarea_speaker_fields = ['short_biography', 'long_biography'] %}
+{% set media_speaker_fields = ['photo'] %}
+
+{% set speaker_fields = ['name', 'email','photo', 'organisation', 'position', 'country', 'short_biography', 'long_biography', 'mobile', 'website', 'facebook', 'twitter', 'github', 'linkedin'] %}
+
+{% macro speaker_form_field(identifier, require=0) %}
+    {% set name = identifier | replace('_id','') %}
+    {% set pretty_name = name | replace('_',' ') | capitalize %}
+    <div class="item form-group speaker-fields">
+        <label class="control-label">
+            {{ pretty_name }}
+            {% if require==1 %}
+                <span class="required">*</span>
+            {% endif %}
+        </label>
+        {% if identifier in textarea_speaker_fields %}
+            <textarea {% if require==1 %}
+                required="required"
+            {% endif %}
+                name="{{ identifier }}" class="form-control col-md-7 col-xs-12"></textarea>
+        {% elif identifier in media_speaker_fields %}
+            <br><input {% if require==1 %}
+            required="required"
+        {% endif %}
+            type="file" id="speaker-file-{{ identifier | default(1) }}" name="{{ identifier }}"
+            class="upload-btn"/>
+            <label class="file-label" for="speaker-file-{{ identifier | default(1) }}">
+                <i class="fa fa-cloud-upload" aria-hidden="true"></i>
+                Choose a file</label>
+        {% else %}
+            <input {% if require==1 %}
+                required="required"
+            {% endif %}
+                name="{{ "email-old" if identifier=="email" and  current_user.is_authenticated else identifier }}"
+                    {% if identifier=="email" %}
+                        {% if current_user.is_authenticated %}
+                value="{{ current_user.email }}" disabled
+                        {% endif %}
+                    {% endif %}
+                class="form-control col-md-7 col-xs-12"/>
+            {% if identifier=="email" %}
+                {% if current_user.is_authenticated %}
+                   <input type="hidden" name="email" value="{{ current_user.email }}">
+                {% endif %}
+            {% endif %}
+
+        {% endif %}
+    </div>
+{% endmacro %}
+
+<form enctype="multipart/form-data" name="test" action="" method="POST" role="form"
+      class="admin-form form-horizontal"
+      id="session-create-form">
+    {% if csrf_token %}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    {% endif %}
+    <div class="col-md-1 col-sm-1 col-xs-12">
+
+    </div>
+    <div class="col-md-5 col-sm-5 col-xs-12 session_form" style="margin-right: 25px;">
+        <h4>Session Details</h4>
+        {% for elem in session_fields %}
+            {% if session_form[elem].include==1 %}
+                {{ session_form_field(elem, session_form[elem].require) }}
+            {% endif %}
+        {% endfor %}
+    </div>
+    <div class="col-md-5 col-sm-5 col-xs-12 speaker_form">
+        <h4>Speaker Details</h4>
+        {% for elem in speaker_fields %}
+            {% if speaker_form[elem].include==1 %}
+                {{ speaker_form_field(elem, speaker_form[elem].require) }}
+            {% endif %}
+        {% endfor %}
+        <div class="speakers">
+            <hr>
+            <br><h4>Invite Speakers</h4>
+            <div class="item form-group">
+                <label class="control-label">Email </label>
+                <div class="">
+                    <input type="text" class="form-control col-md-7 col-sm-7" name="speakers[email]"
+                           placeholder="Email Address of Speaker" style="width:60%;">
+                </div>
+
+                <div class="col-sm-1 col-md-1 input-group">
+                                    <span class="input-group-btn">
+                                        <button type="button" class="btn btn-primary" id="add-speakers">+</button>
+                                    </span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div style="text-align: center;">
+        <input type="submit" class="btn btn-primary" value="Save as Draft"/>
+        <input type="submit" class="btn btn-success" value="Submit Session"/>
+    </div>
+</form>

--- a/open_event/templates/gentelella/guest/event/cfs.html
+++ b/open_event/templates/gentelella/guest/event/cfs.html
@@ -7,7 +7,7 @@
 {% block head_css %}
     {{ super() }}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/guest/details.css') }}"/>
-    <link href="{{ url_for('static', filename='css/admin/scheduler.css') }}" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/admin/event_wizard.css') }}"/>
     <style type="text/css">
         .carousel .item {
             height: {{ carousel_height }}px;
@@ -30,11 +30,6 @@
 {% block head_js %}
     {{ super() }}
 
-    <script type="text/javascript">
-
-        window.scheduler_readonly = true;
-
-    </script>
 {% endblock %}
 
 {% block body %}
@@ -43,11 +38,9 @@
             <li role="presentation"><a href="/e/{{ event.id }}">Info</a></li>
             <li role="presentation"><a href="/e/{{ event.id }}/#speakers">Speakers</a></li>
             <li role="presentation"><a href="/e/{{ event.id }}/#sponsors">Sponsors</a></li>
+            <li role="presentation" class="active"><a href="/e/{{ event.id }}/sessions">Call for speakers</a></li>
             <li role="presentation"><a href="/e/{{ event.id }}/sessions">Sessions</a></li>
-            {% if call_for_speakers %}
-                <li role="presentation"><a href="/e/{{ event.id }}/cfs">Call for speakers</a></li>
-            {% endif %}
-            <li role="presentation" class="active"><a href="/e/{{ event.id }}/schedule">Schedule</a></li>
+            <li role="presentation"><a href="/e/{{ event.id }}/schedule">Schedule</a></li>
             <li role="presentation"><a href="/e/{{ event.id }}/#organizer">Organizer</a></li>
             <li role="presentation"><a href="/e/{{ event.id }}/#getting-here">Getting Here</a></li>
         </ul>
@@ -67,35 +60,56 @@
         </div>
     </div>
     <div class="event-info container" style="min-height: 600px;">
-
         <div class="row">
             <div class="col-md-12">
-                <h1 style="font-weight: 300; font-size: 24px">Schedule
-                    <small>
-                        (Published on {{ event.schedule_published_on.strftime('%B %d, %Y') }})
-                    </small>
-                </h1>
-            </div>
-            <div class="col-md-12" style="margin-top: 10px;">
-                <div class="btn-toolbar" role="toolbar">
-                    <div id="date-change-btn-holder" class="btn-group date-change-btn-holder" role="group">
-
-                    </div>
-                </div>
-                {% include 'gentelella/admin/event/scheduler/components/timeline.html' %}
+                <h1 style="font-weight: 300; font-size: 30px">Call for Speakers</h1>
+                <p>
+                    {% if state == 'now' %}
+                        <span class="label label-success">Open</span>
+                    {% elif state == 'past' %}
+                        <span class="label label-danger">Closed</span>
+                    {% elif state == 'future' %}
+                        <span class="label label-info">Yet to Open</span>
+                    {% endif %}
+                </p>
+                <p><strong>{{ call_for_speakers.start_date.strftime('%a, %B %d at %I:%M %p') }}</strong>
+                 to
+                <strong>{{ call_for_speakers.end_date.strftime('%a, %B %d at %I:%M %p') }}</strong></p>
+                {{ call_for_speakers.announcement | safe }}
+                {% if state == "now" %}
+                    <button class="btn btn-success" data-toggle="modal" data-target="#session-model">Submit Proposal</button>
+                {% endif %}
             </div>
         </div>
     </div>
-    {% include 'gentelella/admin/event/scheduler/components/timeline_templates.html' %}
+    {% if state == "now" %}
+        <div class="modal fade" tabindex="-1" role="dialog" id="session-model">
+            <div class="modal-dialog modal-lg">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title">Submit Proposal</h4>
+                    </div>
+                    <div class="modal-body">
+                        {% include 'gentelella/admin/event/sessions/session_form.html' %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
 
 {% endblock %}
 
+
+
 {% block tail_js %}
     {{ super() }}
-    <script src="{{ url_for('static', filename='admin/lib/moment/min/moment.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='admin/lib/google-material-color/dist/palette.js') }}"></script>
-    <script src="{{ url_for('static', filename='admin/lib/lodash/dist/lodash.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/jquery/jquery.ellipsis.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/jquery/jquery.codezero.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='js/admin/event/scheduler.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/admin/session/new.js') }}"></script>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $("textarea").summernote(summernoteConfig);
+        });
+    </script>
+
 {% endblock %}

--- a/open_event/templates/gentelella/guest/event/details.html
+++ b/open_event/templates/gentelella/guest/event/details.html
@@ -81,6 +81,9 @@
             <li role="presentation"><a href="#speakers">Speakers</a></li>
             <li role="presentation"><a href="#sponsors">Sponsors</a></li>
             <li role="presentation"><a href="/e/{{ event.id }}/sessions">Sessions</a></li>
+            {% if call_for_speakers %}
+                <li role="presentation"><a href="/e/{{ event.id }}/cfs">Call for speakers</a></li>
+            {% endif %}
             {% if event.schedule_published_on %}
                 <li role="presentation"><a href="/e/{{ event.id }}/schedule">Schedule</a></li>
             {% endif %}

--- a/open_event/templates/gentelella/guest/event/sessions.html
+++ b/open_event/templates/gentelella/guest/event/sessions.html
@@ -172,6 +172,9 @@
             <li role="presentation"><a href="/e/{{ event.id }}/#speakers">Speakers</a></li>
             <li role="presentation"><a href="/e/{{ event.id }}/#sponsors">Sponsors</a></li>
             <li role="presentation" class="active"><a href="/e/{{ event.id }}/sessions">Sessions</a></li>
+            {% if call_for_speakers %}
+                <li role="presentation"><a href="/e/{{ event.id }}/cfs">Call for speakers</a></li>
+            {% endif %}
             {% if event.schedule_published_on %}
                 <li role="presentation"><a href="/e/{{ event.id }}/schedule">Schedule</a></li>
             {% endif %}

--- a/open_event/views/admin/admin.py
+++ b/open_event/views/admin/admin.py
@@ -56,7 +56,6 @@ class AdminView(object):
         self.admin.add_view(TracksView(name='Track', url='/events/<event_id>/tracks', endpoint="event_tracks"))
         self.admin.add_view(InviteView(name='Invite', url='/events/<event_id>/invite', endpoint="event_invites"))
 
-
         self.admin.add_view(SuperAdminView(name='Admin', url='/admin/', endpoint="sadmin"))
         self.admin.add_view(SuperAdminEventsView(name='Events', url='/admin/events', endpoint="sadmin_events"))
         self.admin.add_view(SuperAdminMySessionView(name='Sessions', url='/admin/sessions', endpoint="sadmin_sessions"))

--- a/open_event/views/admin/home.py
+++ b/open_event/views/admin/home.py
@@ -8,7 +8,8 @@ from flask_admin.base import AdminIndexView
 from flask.ext.scrypt import generate_password_hash
 from wtforms import ValidationError
 
-from ...helpers.data import DataManager, save_to_db, get_google_auth, get_facebook_auth, create_user_password
+from ...helpers.data import DataManager, save_to_db, get_google_auth, get_facebook_auth, create_user_password, \
+    user_logged_in
 from ...helpers.data_getter import DataGetter
 from ...helpers.helpers import send_email_with_reset_password_hash, send_email_confirmation, get_serializer
 from open_event.helpers.oauth import OAuth, FbOAuth
@@ -57,6 +58,7 @@ class MyHomeView(AdminIndexView):
                 return redirect(url_for('admin.login_view'))
             login.login_user(user)
             logging.info('logged successfully')
+            user_logged_in(user)
             return redirect(intended_url())
 
     @expose('/register/', methods=('GET', 'POST'))
@@ -86,6 +88,7 @@ class MyHomeView(AdminIndexView):
         user.is_verified = True
         save_to_db(user, 'User updated')
         login.login_user(user)
+        user_logged_in(user)
         return redirect(intended_url())
 
     @expose('/password/new/<email>', methods=('GET', 'POST'))
@@ -99,6 +102,7 @@ class MyHomeView(AdminIndexView):
             user = create_user_password(request.form, user)
             if user is not None:
                 login.login_user(user)
+                user_logged_in(user)
                 return redirect(intended_url())
 
     @expose('/password/reset', methods=('GET', 'POST'))

--- a/open_event/views/api_v1_views.py
+++ b/open_event/views/api_v1_views.py
@@ -22,7 +22,7 @@ from icalendar import Calendar
 import icalendar
 from open_event.helpers.oauth import OAuth, FbOAuth
 from requests.exceptions import HTTPError
-from ..helpers.data import get_google_auth, create_user_oauth, get_facebook_auth
+from ..helpers.data import get_google_auth, create_user_oauth, get_facebook_auth, user_logged_in
 
 auto = Autodoc()
 
@@ -382,6 +382,7 @@ def callback():
                 return redirect(url_for('admin.create_password_after_oauth_login', email=email))
             else:
                 login.login_user(user)
+                user_logged_in(user)
                 return redirect(url_for('admin.index'))
         return 'did not find user info'
 
@@ -420,6 +421,7 @@ def facebook_callback():
                 return redirect(url_for('admin.create_password_after_oauth_login', email=email))
             else:
                 login.login_user(user)
+                user_logged_in(user)
                 return redirect(url_for('admin.index'))
         return 'did not find user info'
 

--- a/open_event/views/public/event_detail.py
+++ b/open_event/views/public/event_detail.py
@@ -1,13 +1,21 @@
-from flask import request
-from flask.ext.restplus import abort
-from flask_admin import BaseView, expose
-from werkzeug.utils import redirect
+import json
+import logging
+import os
+from datetime import datetime
 
-from open_event.models.session import Session
+from flask import request, url_for, flash
+from flask.ext.restplus import abort
+from flask.ext import login
+from flask_admin import BaseView, expose
+from markupsafe import Markup
+from werkzeug.utils import redirect, secure_filename
+
+from open_event.helpers.data import DataManager
 from ...helpers.data_getter import DataGetter
 
 def get_published_event_or_abort(event_id):
     event = DataGetter.get_event(event_id=event_id)
+    logging.info(event.state)
     if not event or (event.state != u'Published' and event.state != 'Published'):
         abort(404)
     return event
@@ -20,22 +28,67 @@ class EventDetailView(BaseView):
 
     @expose('/<int:event_id>/')
     def display_event_detail_home(self, event_id):
+        call_for_speakers = DataGetter.get_call_for_papers(event_id).first()
         event = get_published_event_or_abort(event_id)
         accepted_sessions = DataGetter.get_sessions(event_id)
-        return self.render('/gentelella/guest/event/details.html', event=event, accepted_sessions=accepted_sessions)
+        return self.render('/gentelella/guest/event/details.html', event=event, accepted_sessions=accepted_sessions, call_for_speakers=call_for_speakers)
 
     @expose('/<int:event_id>/sessions/')
     def display_event_sessions(self, event_id):
+        call_for_speakers = DataGetter.get_call_for_papers(event_id).first()
         event = get_published_event_or_abort(event_id)
         tracks = DataGetter.get_tracks(event_id)
-        return self.render('/gentelella/guest/event/sessions.html', event=event, tracks=tracks)
+        return self.render('/gentelella/guest/event/sessions.html', event=event, tracks=tracks, call_for_speakers=call_for_speakers)
 
     @expose('/<int:event_id>/schedule/')
     def display_event_schedule(self, event_id):
+        call_for_speakers = DataGetter.get_call_for_papers(event_id).first()
         event = get_published_event_or_abort(event_id)
         if not event.schedule_published_on:
             abort(404)
-        return self.render('/gentelella/guest/event/schedule.html', event=event)
+        return self.render('/gentelella/guest/event/schedule.html', event=event, call_for_speakers=call_for_speakers)
+
+    @expose('/<int:event_id>/cfs/', methods=('GET',))
+    def display_event_cfs(self, event_id):
+        event = get_published_event_or_abort(event_id)
+        call_for_speakers = DataGetter.get_call_for_papers(event_id).first()
+
+        if not call_for_speakers:
+            abort(404)
+
+        form_elems = DataGetter.get_custom_form_elements(event_id).first()
+        speaker_form = json.loads(form_elems.speaker_form)
+        session_form = json.loads(form_elems.session_form)
+
+        now = datetime.now()
+        state = "now"
+        if call_for_speakers.end_date < now:
+            state = "past"
+        elif call_for_speakers.start_date > now:
+            sate = "future"
+
+        return self.render('/gentelella/guest/event/cfs.html', event=event, speaker_form=speaker_form,
+                           session_form=session_form, call_for_speakers=call_for_speakers, state=state)
+
+    @expose('/<int:event_id>/cfs/', methods=('POST',))
+    def process_event_cfs(self, event_id):
+        speaker_img_filename = ""
+        email = request.form['email']
+        if 'slides' in request.files:
+            slide_file = request.files['slides']
+            slide_filename = secure_filename(slide_file.filename)
+            slide_file.save(os.path.join(os.path.realpath('.') + '/static/media/image/', slide_filename))
+        if 'photo' in request.files:
+            speaker_img_file = request.files['photo']
+            speaker_img_filename = secure_filename(speaker_img_file.filename)
+            speaker_img_file.save(os.path.join(os.path.realpath('.') + '/static/media/image/', speaker_img_filename))
+        DataManager.add_session_to_event(request.form, event_id, speaker_img_filename)
+        if login.current_user.is_authenticated:
+            flash("Your session proposal has been submitted", "success")
+            return redirect(url_for('my_sessions.display_my_sessions_view', event_id=event_id))
+        else:
+            flash(Markup("Your session proposal has been submitted. Please login/register with <strong><u>" + email + "</u></strong> to manage it."), "success")
+            return redirect(url_for('admin.login_view', next=url_for('my_sessions.display_my_sessions_view')))
 
     # SLUGGED PATHS
 

--- a/tests/test_guest_event_page.py
+++ b/tests/test_guest_event_page.py
@@ -4,10 +4,12 @@ from datetime import datetime
 from flask import url_for
 
 from open_event.helpers.data import save_to_db
+from open_event.models.call_for_papers import CallForPaper
 from tests.object_mother import ObjectMother
 from tests.utils import OpenEventTestCase
 from tests.setup_database import Setup
 from open_event import current_app as app
+
 
 class TestGuestEventPage(OpenEventTestCase):
     def setUp(self):
@@ -18,14 +20,16 @@ class TestGuestEventPage(OpenEventTestCase):
             event = ObjectMother.get_event()
             event.state = 'Published'
             save_to_db(event, "Event Saved")
-            rv = self.app.get(url_for('event_detail.display_event_detail_home', event_id=event.id), follow_redirects=True)
+            rv = self.app.get(url_for('event_detail.display_event_detail_home', event_id=event.id),
+                              follow_redirects=True)
             self.assertTrue("Open Event" in rv.data, msg=rv.data)
 
     def test_unpublished_event_view_attempt(self):
         with app.test_request_context():
             event = ObjectMother.get_event()
             save_to_db(event, "Event Saved")
-            rv = self.app.get(url_for('event_detail.display_event_detail_home', event_id=event.id), follow_redirects=True)
+            rv = self.app.get(url_for('event_detail.display_event_detail_home', event_id=event.id),
+                              follow_redirects=True)
             self.assertEqual(rv.status_code, 404)
 
     def test_published_event_sessions_view(self):
@@ -87,6 +91,35 @@ class TestGuestEventPage(OpenEventTestCase):
             session.speakers = [speaker]
             save_to_db(speaker, "Session Saved")
             rv = self.app.get(url_for('event_detail.display_event_schedule', event_id=event.id), follow_redirects=True)
+            self.assertEqual(rv.status_code, 404)
+
+    def test_published_event_cfs_view(self):
+        with app.test_request_context():
+
+            event = ObjectMother.get_event()
+            event.state = 'Published'
+            save_to_db(event, "Event Saved")
+
+            custom_form = ObjectMother.get_custom_form()
+            custom_form.event_id = event.id
+            save_to_db(custom_form, "Custom form saved")
+
+            call_for_papers = CallForPaper(announcement="Announce",
+                                           start_date=datetime(2003, 8, 4, 12, 30, 45),
+                                           end_date=datetime(2004, 8, 4, 12, 30, 45),
+                                           event_id=event.id)
+
+            save_to_db(call_for_papers, "Call for papers saved")
+
+            rv = self.app.get(url_for('event_detail.display_event_cfs', event_id=event.id), follow_redirects=True)
+            self.assertTrue("Closed" in rv.data, msg=rv.data)
+
+    def test_published_event_cfs_view_attempt(self):
+        with app.test_request_context():
+            event = ObjectMother.get_event()
+            event.state = 'Published'
+            save_to_db(event, "Event Saved")
+            rv = self.app.get(url_for('event_detail.display_event_cfs', event_id=event.id), follow_redirects=True)
             self.assertEqual(rv.status_code, 404)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #1032 and #1030. 

The session/speaker form is shared through out Open-Event, so that any changes made to the form in one place, is reflected everywhere else.

#### Flow: 
1. If the user is not logged in: 
	1. The user can fill the form inside the modal (lightbox)
	1. When the user saves or submits, the data is saved and user is taken to the login/register page along with a message like, "_Your session proposal has been submitted. Please login/register with **example@example.com** to manage it._".
	1. Once the user logs in or registers, he/she is taken to the **My sessions** page where they can manage the session. 
1. If the user is logged in:	
	1. The user can fill the form inside the modal (lightbox)
	1. When the user saves or submits, the data is saved and user is taken to the **My sessions** page where they can manage the session. 

#### Screenshots: 
![screencapture-localhost-5000-e-1-cfs-1466361551234](https://cloud.githubusercontent.com/assets/2404372/16179230/fa2d150a-367c-11e6-822b-04da718e9b8e.png)
![capture](https://cloud.githubusercontent.com/assets/2404372/16179231/fd0ddba6-367c-11e6-9ff9-073958b519df.PNG)

@mariobehling please review and merge into `development`