### PR TITLE
Admin dashboard: Use natural time and add user status

### DIFF
--- a/open_event/__init__.py
+++ b/open_event/__init__.py
@@ -18,6 +18,7 @@ from flask.ext.jwt import JWT
 from datetime import timedelta, datetime
 
 from icalendar import Calendar, Event
+import humanize
 
 from open_event.helpers.helpers import string_empty
 from open_event.models import db
@@ -58,6 +59,7 @@ def create_app():
     app.logger.setLevel(logging.INFO)
     app.jinja_env.add_extension('jinja2.ext.do')
     app.jinja_env.undefined = SilentUndefined
+    app.jinja_env.filters['humanize'] = humanize.naturaltime
     # logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 
     # set up jwt

--- a/open_event/templates/gentelella/admin/super_admin/users/users.html
+++ b/open_event/templates/gentelella/admin/super_admin/users/users.html
@@ -19,6 +19,7 @@ Users
     <tr>
         <th>Name</th>
         <th>Email</th>
+        <th>Status</th>
         <th>System Roles</th>
         <th>Event Roles</th>
         <th>Member Since</th>
@@ -32,6 +33,7 @@ Users
     <tr>
         <td>{{ 'Not Available' if not user['user'].user_detail.fullname else user['user'].user_detail.fullname }}</td>
         <td>{{ user['user'].email }}</td>
+        <td>{{ 'Active' if user['user'].is_active() else 'Inactive' }}</td>
         <td>
           <ul style="padding-left:0;">
           {% if user['user'].is_super_admin %}

--- a/open_event/templates/gentelella/admin/super_admin/users/users.html
+++ b/open_event/templates/gentelella/admin/super_admin/users/users.html
@@ -51,8 +51,8 @@ Users
         {% endfor %}
         </ul>
         </td>
-        <td>{{user['user'].created_date}}</td>
-        <td>{{user['user'].last_access_time}}</td>
+        <td>{{ user['user'].created_date|humanize }}</td>
+        <td>{{ user['user'].last_access_time|humanize }}</td>
         <td>
             <a href="#" title="Edit record">
             <span class="glyphicon glyphicon-pencil"></span>

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -23,3 +23,4 @@ mock==2.0.0
 SQLAlchemy-Utils==0.32.6
 cryptography==1.3.2
 itsdangerous==0.24
+humanize==0.5.1


### PR DESCRIPTION
https://github.com/fossasia/open-event-orga-server/issues/853#issuecomment-226773524

- Add user Status
- Use natural time for Member since and Last access

![](https://i.imgur.com/asj8Q2x.png)

![](https://i.imgur.com/VeGAk56.png)

@mariobehling Please review.