### PR TITLE
Minify Flask's HTML output to speed up page load

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ class Config(object):
 
 class ProductionConfig(Config):
     DEBUG = False
+    MINIFY_PAGE = True
     try:  # you don't want production on default db
         SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
     except KeyError:

--- a/open_event/__init__.py
+++ b/open_event/__init__.py
@@ -1,4 +1,5 @@
 """Copyright 2015 Rafal Kowalski"""
+from flask.ext.htmlmin import HTMLMIN
 from jinja2 import Undefined
 import logging
 import os.path
@@ -68,6 +69,7 @@ def create_app():
     app.config['JWT_AUTH_URL_RULE'] = None
     jwt = JWT(app, jwt_authenticate, jwt_identity)
 
+    HTMLMIN(app)
     admin_view = AdminView("Open Event")
     admin_view.init(app)
     admin_view.init_login(app)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -26,3 +26,4 @@ cryptography==1.3.2
 itsdangerous==0.24
 humanize==0.5.1
 geoip2
+Flask-HTMLmin


### PR DESCRIPTION
Currently the HTML Output generated by Flask has loads of whitespace and linebreaks which adds up to the page's size. 

This PR would minify the HTML Output of flask. (For, example, the home page's size was reduced by 40% after enabling this. Other pages' size reduction would vary)

(there was no issue created as this is very a small and a non-breaking enhancement)

@rafalkowalski @mariobehling please review and merge .

_We could go for a better cache-based implementation in future._