### PR TITLE
Existing speaker selection for create and edit

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,7 @@
     "bootstrap-validator": "^0.10.2",
     "switchery": "^0.8.1",
     "summernote": "^0.8.1",
-    "sticky-kit": "^1.1.2"
+    "sticky-kit": "^1.1.2",
+    "multiselect": "^0.9.12"
   }
 }

--- a/open_event/helpers/data.py
+++ b/open_event/helpers/data.py
@@ -185,6 +185,12 @@ class DataManager(object):
                               user=login.current_user if login and login.current_user.is_authenticated else None)
 
         new_session.speakers.append(speaker)
+
+        existing_speaker_ids = form.getlist("speakers[]")
+        for existing_speaker_id in existing_speaker_ids:
+            existing_speaker = DataGetter.get_speaker(existing_speaker_id)
+            new_session.speakers.append(existing_speaker)
+
         save_to_db(new_session, "Session saved")
 
         if state == 'pending':
@@ -333,6 +339,12 @@ class DataManager(object):
         session.subtitle = form.get('subtitle', '')
         session.long_abstract = form.get('long_abstract', '')
         session.short_abstract = form.get('short_abstract', '')
+
+        existing_speaker_ids = form.getlist("speakers[]")
+        for existing_speaker_id in existing_speaker_ids:
+            existing_speaker = DataGetter.get_speaker(existing_speaker_id)
+            if existing_speaker not in session.speakers:
+                session.speakers.append(existing_speaker)
 
         save_to_db(session, 'Session Updated')
 

--- a/open_event/helpers/data.py
+++ b/open_event/helpers/data.py
@@ -341,10 +341,12 @@ class DataManager(object):
         session.short_abstract = form.get('short_abstract', '')
 
         existing_speaker_ids = form.getlist("speakers[]")
+
+        session.speakers = []
+
         for existing_speaker_id in existing_speaker_ids:
             existing_speaker = DataGetter.get_speaker(existing_speaker_id)
-            if existing_speaker not in session.speakers:
-                session.speakers.append(existing_speaker)
+            session.speakers.append(existing_speaker)
 
         save_to_db(session, 'Session Updated')
 

--- a/open_event/helpers/data_getter.py
+++ b/open_event/helpers/data_getter.py
@@ -25,7 +25,7 @@ from open_event.helpers.helpers import get_event_id
 from flask.ext import login
 from flask import flash
 import datetime
-from sqlalchemy import desc
+from sqlalchemy import desc, asc
 
 
 class DataGetter:
@@ -166,7 +166,7 @@ class DataGetter:
         :param event_id: Event id
         :return: Speaker objects filter by event_id
         """
-        return Speaker.query.filter_by(event_id=event_id)
+        return Speaker.query.filter_by(event_id=event_id).order_by(asc(Speaker.name))
 
     @staticmethod
     def get_speaker_columns():

--- a/open_event/static/js/admin/global.js
+++ b/open_event/static/js/admin/global.js
@@ -10,3 +10,9 @@ var summernoteConfig = {
     height: 150,
     disableDragAndDrop: true
 };
+
+function imgError(image) {
+    image.onerror = "";
+    image.src = '/static/img/avatar.png';
+    return true;
+}

--- a/open_event/static/js/jquery/jquery.multi-select.js
+++ b/open_event/static/js/jquery/jquery.multi-select.js
@@ -1,0 +1,528 @@
+/*
+* MultiSelect v0.9.12
+* Copyright (c) 2012 Louis Cuny. Modified by Niranjan Rajendran (@niranjan94)
+*
+* This program is free software. It comes without any warranty, to
+* the extent permitted by applicable law. You can redistribute it
+* and/or modify it under the terms of the Do What The Fuck You Want
+* To Public License, Version 2, as published by Sam Hocevar. See
+* http://sam.zoy.org/wtfpl/COPYING for more details.
+*/
+
+!function ($) {
+
+  "use strict";
+
+
+ /* MULTISELECT CLASS DEFINITION
+  * ====================== */
+
+  var MultiSelect = function (element, options) {
+    this.options = options;
+    this.$element = $(element);
+    this.$container = $('<div/>', { 'class': "ms-container" });
+    this.$selectableContainer = $('<div/>', { 'class': 'ms-selectable' });
+    this.$selectionContainer = $('<div/>', { 'class': 'ms-selection' });
+    this.$selectableUl = $('<ul/>', { 'class': "ms-list", 'tabindex' : '-1' });
+    this.$selectionUl = $('<ul/>', { 'class': "ms-list", 'tabindex' : '-1' });
+    this.scrollTo = 0;
+    this.elemsSelector = 'li:visible:not(.ms-optgroup-label,.ms-optgroup-container,.'+options.disabledClass+')';
+  };
+
+  MultiSelect.prototype = {
+    constructor: MultiSelect,
+
+    init: function(){
+      var that = this,
+          ms = this.$element;
+
+      if (ms.next('.ms-container').length === 0){
+        ms.css({ position: 'absolute', left: '-9999px' });
+        ms.attr('id', ms.attr('id') ? ms.attr('id') : Math.ceil(Math.random()*1000)+'multiselect');
+        this.$container.attr('id', 'ms-'+ms.attr('id'));
+        this.$container.addClass(that.options.cssClass);
+        ms.find('option').each(function(){
+          that.generateLisFromOption(this);
+        });
+
+        this.$selectionUl.find('.ms-optgroup-label').hide();
+
+        if (that.options.selectableHeader){
+          that.$selectableContainer.append(that.options.selectableHeader);
+        }
+        that.$selectableContainer.append(that.$selectableUl);
+        if (that.options.selectableFooter){
+          that.$selectableContainer.append(that.options.selectableFooter);
+        }
+
+        if (that.options.selectionHeader){
+          that.$selectionContainer.append(that.options.selectionHeader);
+        }
+        that.$selectionContainer.append(that.$selectionUl);
+        if (that.options.selectionFooter){
+          that.$selectionContainer.append(that.options.selectionFooter);
+        }
+
+        that.$container.append(that.$selectableContainer);
+        that.$container.append(that.$selectionContainer);
+        ms.after(that.$container);
+
+        that.activeMouse(that.$selectableUl);
+        that.activeKeyboard(that.$selectableUl);
+
+        var action = that.options.dblClick ? 'dblclick' : 'click';
+
+        that.$selectableUl.on(action, '.ms-elem-selectable', function(){
+          that.select($(this).data('ms-value'));
+        });
+        that.$selectionUl.on(action, '.ms-elem-selection', function(){
+          that.deselect($(this).data('ms-value'));
+        });
+
+        that.activeMouse(that.$selectionUl);
+        that.activeKeyboard(that.$selectionUl);
+
+        ms.on('focus', function(){
+          that.$selectableUl.focus();
+        })
+      }
+
+      var selectedValues = ms.find('option:selected').map(function(){ return $(this).val(); }).get();
+      that.select(selectedValues, 'init');
+
+      if (typeof that.options.afterInit === 'function') {
+        that.options.afterInit.call(this, this.$container);
+      }
+    },
+
+    'generateLisFromOption' : function(option, index, $container){
+      var that = this,
+          ms = that.$element,
+          attributes = "",
+          $option = $(option);
+
+      for (var cpt = 0; cpt < option.attributes.length; cpt++){
+        var attr = option.attributes[cpt];
+
+        if(attr.name !== 'value' && attr.name !== 'disabled'){
+          attributes += attr.name+'="'+attr.value+'" ';
+        }
+      }
+      var selectableLi = $('<li '+attributes+'><span>'+$option.data("html-addon")+' '+that.escapeHTML($option.text())+'</span></li>'),
+          selectedLi = selectableLi.clone(),
+          value = $option.val(),
+          elementId = that.sanitize(value);
+
+      selectableLi
+        .data('ms-value', value)
+        .addClass('ms-elem-selectable')
+        .attr('id', elementId+'-selectable');
+
+      selectedLi
+        .data('ms-value', value)
+        .addClass('ms-elem-selection')
+        .attr('id', elementId+'-selection')
+        .hide();
+
+      if ($option.prop('disabled') || ms.prop('disabled')){
+        selectedLi.addClass(that.options.disabledClass);
+        selectableLi.addClass(that.options.disabledClass);
+      }
+
+      var $optgroup = $option.parent('optgroup');
+
+      if ($optgroup.length > 0){
+        var optgroupLabel = $optgroup.attr('label'),
+            optgroupId = that.sanitize(optgroupLabel),
+            $selectableOptgroup = that.$selectableUl.find('#optgroup-selectable-'+optgroupId),
+            $selectionOptgroup = that.$selectionUl.find('#optgroup-selection-'+optgroupId);
+
+        if ($selectableOptgroup.length === 0){
+          var optgroupContainerTpl = '<li class="ms-optgroup-container"></li>',
+              optgroupTpl = '<ul class="ms-optgroup"><li class="ms-optgroup-label"><span>'+optgroupLabel+'</span></li></ul>';
+
+          $selectableOptgroup = $(optgroupContainerTpl);
+          $selectionOptgroup = $(optgroupContainerTpl);
+          $selectableOptgroup.attr('id', 'optgroup-selectable-'+optgroupId);
+          $selectionOptgroup.attr('id', 'optgroup-selection-'+optgroupId);
+          $selectableOptgroup.append($(optgroupTpl));
+          $selectionOptgroup.append($(optgroupTpl));
+          if (that.options.selectableOptgroup){
+            $selectableOptgroup.find('.ms-optgroup-label').on('click', function(){
+              var values = $optgroup.children(':not(:selected, :disabled)').map(function(){ return $(this).val() }).get();
+              that.select(values);
+            });
+            $selectionOptgroup.find('.ms-optgroup-label').on('click', function(){
+              var values = $optgroup.children(':selected:not(:disabled)').map(function(){ return $(this).val() }).get();
+              that.deselect(values);
+            });
+          }
+          that.$selectableUl.append($selectableOptgroup);
+          that.$selectionUl.append($selectionOptgroup);
+        }
+        index = index == undefined ? $selectableOptgroup.find('ul').children().length : index + 1;
+        selectableLi.insertAt(index, $selectableOptgroup.children());
+        selectedLi.insertAt(index, $selectionOptgroup.children());
+      } else {
+        index = index == undefined ? that.$selectableUl.children().length : index;
+
+        selectableLi.insertAt(index, that.$selectableUl);
+        selectedLi.insertAt(index, that.$selectionUl);
+      }
+    },
+
+    'addOption' : function(options){
+      var that = this;
+
+      if (options.value) options = [options];
+      $.each(options, function(index, option){
+        if (option.value && that.$element.find("option[value='"+option.value+"']").length === 0){
+          var $option = $('<option value="'+option.value+'">'+option.text+'</option>'),
+              index = parseInt((typeof option.index === 'undefined' ? that.$element.children().length : option.index)),
+              $container = option.nested == undefined ? that.$element : $("optgroup[label='"+option.nested+"']")
+
+          $option.insertAt(index, $container);
+          that.generateLisFromOption($option.get(0), index, option.nested);
+        }
+      })
+    },
+
+    'escapeHTML' : function(text){
+      return $("<div>").text(text).html();
+    },
+
+    'activeKeyboard' : function($list){
+      var that = this;
+
+      $list.on('focus', function(){
+        $(this).addClass('ms-focus');
+      })
+      .on('blur', function(){
+        $(this).removeClass('ms-focus');
+      })
+      .on('keydown', function(e){
+        switch (e.which) {
+          case 40:
+          case 38:
+            e.preventDefault();
+            e.stopPropagation();
+            that.moveHighlight($(this), (e.which === 38) ? -1 : 1);
+            return;
+          case 37:
+          case 39:
+            e.preventDefault();
+            e.stopPropagation();
+            that.switchList($list);
+            return;
+          case 9:
+            if(that.$element.is('[tabindex]')){
+              e.preventDefault();
+              var tabindex = parseInt(that.$element.attr('tabindex'), 10);
+              tabindex = (e.shiftKey) ? tabindex-1 : tabindex+1;
+              $('[tabindex="'+(tabindex)+'"]').focus();
+              return;
+            }else{
+              if(e.shiftKey){
+                that.$element.trigger('focus');
+              }
+            }
+        }
+        if($.inArray(e.which, that.options.keySelect) > -1){
+          e.preventDefault();
+          e.stopPropagation();
+          that.selectHighlighted($list);
+          return;
+        }
+      });
+    },
+
+    'moveHighlight': function($list, direction){
+      var $elems = $list.find(this.elemsSelector),
+          $currElem = $elems.filter('.ms-hover'),
+          $nextElem = null,
+          elemHeight = $elems.first().outerHeight(),
+          containerHeight = $list.height(),
+          containerSelector = '#'+this.$container.prop('id');
+
+      $elems.removeClass('ms-hover');
+      if (direction === 1){ // DOWN
+
+        $nextElem = $currElem.nextAll(this.elemsSelector).first();
+        if ($nextElem.length === 0){
+          var $optgroupUl = $currElem.parent();
+
+          if ($optgroupUl.hasClass('ms-optgroup')){
+            var $optgroupLi = $optgroupUl.parent(),
+                $nextOptgroupLi = $optgroupLi.next(':visible');
+
+            if ($nextOptgroupLi.length > 0){
+              $nextElem = $nextOptgroupLi.find(this.elemsSelector).first();
+            } else {
+              $nextElem = $elems.first();
+            }
+          } else {
+            $nextElem = $elems.first();
+          }
+        }
+      } else if (direction === -1){ // UP
+
+        $nextElem = $currElem.prevAll(this.elemsSelector).first();
+        if ($nextElem.length === 0){
+          var $optgroupUl = $currElem.parent();
+
+          if ($optgroupUl.hasClass('ms-optgroup')){
+            var $optgroupLi = $optgroupUl.parent(),
+                $prevOptgroupLi = $optgroupLi.prev(':visible');
+
+            if ($prevOptgroupLi.length > 0){
+              $nextElem = $prevOptgroupLi.find(this.elemsSelector).last();
+            } else {
+              $nextElem = $elems.last();
+            }
+          } else {
+            $nextElem = $elems.last();
+          }
+        }
+      }
+      if ($nextElem.length > 0){
+        $nextElem.addClass('ms-hover');
+        var scrollTo = $list.scrollTop() + $nextElem.position().top -
+                       containerHeight / 2 + elemHeight / 2;
+
+        $list.scrollTop(scrollTo);
+      }
+    },
+
+    'selectHighlighted' : function($list){
+      var $elems = $list.find(this.elemsSelector),
+          $highlightedElem = $elems.filter('.ms-hover').first();
+
+      if ($highlightedElem.length > 0){
+        if ($list.parent().hasClass('ms-selectable')){
+          this.select($highlightedElem.data('ms-value'));
+        } else {
+          this.deselect($highlightedElem.data('ms-value'));
+        }
+        $elems.removeClass('ms-hover');
+      }
+    },
+
+    'switchList' : function($list){
+      $list.blur();
+      this.$container.find(this.elemsSelector).removeClass('ms-hover');
+      if ($list.parent().hasClass('ms-selectable')){
+        this.$selectionUl.focus();
+      } else {
+        this.$selectableUl.focus();
+      }
+    },
+
+    'activeMouse' : function($list){
+      var that = this;
+
+      $('body').on('mouseenter', that.elemsSelector, function(){
+        $(this).parents('.ms-container').find(that.elemsSelector).removeClass('ms-hover');
+        $(this).addClass('ms-hover');
+      });
+    },
+
+    'refresh' : function() {
+      this.destroy();
+      this.$element.multiSelect(this.options);
+    },
+
+    'destroy' : function(){
+      $("#ms-"+this.$element.attr("id")).remove();
+      this.$element.css('position', '').css('left', '')
+      this.$element.removeData('multiselect');
+    },
+
+    'select' : function(value, method){
+      if (typeof value === 'string'){ value = [value]; }
+
+      var that = this,
+          ms = this.$element,
+          msIds = $.map(value, function(val){ return(that.sanitize(val)); }),
+          selectables = this.$selectableUl.find('#' + msIds.join('-selectable, #')+'-selectable').filter(':not(.'+that.options.disabledClass+')'),
+          selections = this.$selectionUl.find('#' + msIds.join('-selection, #') + '-selection').filter(':not(.'+that.options.disabledClass+')'),
+          options = ms.find('option:not(:disabled)').filter(function(){ return($.inArray(this.value, value) > -1); });
+
+      if (method === 'init'){
+        selectables = this.$selectableUl.find('#' + msIds.join('-selectable, #')+'-selectable'),
+        selections = this.$selectionUl.find('#' + msIds.join('-selection, #') + '-selection');
+      }
+
+      if (selectables.length > 0){
+        selectables.addClass('ms-selected').hide();
+        selections.addClass('ms-selected').show();
+
+        options.prop('selected', true);
+
+        that.$container.find(that.elemsSelector).removeClass('ms-hover');
+
+        var selectableOptgroups = that.$selectableUl.children('.ms-optgroup-container');
+        if (selectableOptgroups.length > 0){
+          selectableOptgroups.each(function(){
+            var selectablesLi = $(this).find('.ms-elem-selectable');
+            if (selectablesLi.length === selectablesLi.filter('.ms-selected').length){
+              $(this).find('.ms-optgroup-label').hide();
+            }
+          });
+
+          var selectionOptgroups = that.$selectionUl.children('.ms-optgroup-container');
+          selectionOptgroups.each(function(){
+            var selectionsLi = $(this).find('.ms-elem-selection');
+            if (selectionsLi.filter('.ms-selected').length > 0){
+              $(this).find('.ms-optgroup-label').show();
+            }
+          });
+        } else {
+          if (that.options.keepOrder && method !== 'init'){
+            var selectionLiLast = that.$selectionUl.find('.ms-selected');
+            if((selectionLiLast.length > 1) && (selectionLiLast.last().get(0) != selections.get(0))) {
+              selections.insertAfter(selectionLiLast.last());
+            }
+          }
+        }
+        if (method !== 'init'){
+          ms.trigger('change');
+          if (typeof that.options.afterSelect === 'function') {
+            that.options.afterSelect.call(this, value);
+          }
+        }
+      }
+    },
+
+    'deselect' : function(value){
+      if (typeof value === 'string'){ value = [value]; }
+
+      var that = this,
+          ms = this.$element,
+          msIds = $.map(value, function(val){ return(that.sanitize(val)); }),
+          selectables = this.$selectableUl.find('#' + msIds.join('-selectable, #')+'-selectable'),
+          selections = this.$selectionUl.find('#' + msIds.join('-selection, #')+'-selection').filter('.ms-selected').filter(':not(.'+that.options.disabledClass+')'),
+          options = ms.find('option').filter(function(){ return($.inArray(this.value, value) > -1); });
+
+      if (selections.length > 0){
+        selectables.removeClass('ms-selected').show();
+        selections.removeClass('ms-selected').hide();
+        options.prop('selected', false);
+
+        that.$container.find(that.elemsSelector).removeClass('ms-hover');
+
+        var selectableOptgroups = that.$selectableUl.children('.ms-optgroup-container');
+        if (selectableOptgroups.length > 0){
+          selectableOptgroups.each(function(){
+            var selectablesLi = $(this).find('.ms-elem-selectable');
+            if (selectablesLi.filter(':not(.ms-selected)').length > 0){
+              $(this).find('.ms-optgroup-label').show();
+            }
+          });
+
+          var selectionOptgroups = that.$selectionUl.children('.ms-optgroup-container');
+          selectionOptgroups.each(function(){
+            var selectionsLi = $(this).find('.ms-elem-selection');
+            if (selectionsLi.filter('.ms-selected').length === 0){
+              $(this).find('.ms-optgroup-label').hide();
+            }
+          });
+        }
+        ms.trigger('change');
+        if (typeof that.options.afterDeselect === 'function') {
+          that.options.afterDeselect.call(this, value);
+        }
+      }
+    },
+
+    'select_all' : function(){
+      var ms = this.$element,
+          values = ms.val();
+
+      ms.find('option:not(":disabled")').prop('selected', true);
+      this.$selectableUl.find('.ms-elem-selectable').filter(':not(.'+this.options.disabledClass+')').addClass('ms-selected').hide();
+      this.$selectionUl.find('.ms-optgroup-label').show();
+      this.$selectableUl.find('.ms-optgroup-label').hide();
+      this.$selectionUl.find('.ms-elem-selection').filter(':not(.'+this.options.disabledClass+')').addClass('ms-selected').show();
+      this.$selectionUl.focus();
+      ms.trigger('change');
+      if (typeof this.options.afterSelect === 'function') {
+        var selectedValues = $.grep(ms.val(), function(item){
+          return $.inArray(item, values) < 0;
+        });
+        this.options.afterSelect.call(this, selectedValues);
+      }
+    },
+
+    'deselect_all' : function(){
+      var ms = this.$element,
+          values = ms.val();
+
+      ms.find('option').prop('selected', false);
+      this.$selectableUl.find('.ms-elem-selectable').removeClass('ms-selected').show();
+      this.$selectionUl.find('.ms-optgroup-label').hide();
+      this.$selectableUl.find('.ms-optgroup-label').show();
+      this.$selectionUl.find('.ms-elem-selection').removeClass('ms-selected').hide();
+      this.$selectableUl.focus();
+      ms.trigger('change');
+      if (typeof this.options.afterDeselect === 'function') {
+        this.options.afterDeselect.call(this, values);
+      }
+    },
+
+    sanitize: function(value){
+      var hash = 0, i, character;
+      if (value.length == 0) return hash;
+      var ls = 0;
+      for (i = 0, ls = value.length; i < ls; i++) {
+        character  = value.charCodeAt(i);
+        hash  = ((hash<<5)-hash)+character;
+        hash |= 0; // Convert to 32bit integer
+      }
+      return hash;
+    }
+  };
+
+  /* MULTISELECT PLUGIN DEFINITION
+   * ======================= */
+
+  $.fn.multiSelect = function () {
+    var option = arguments[0],
+        args = arguments;
+
+    return this.each(function () {
+      var $this = $(this),
+          data = $this.data('multiselect'),
+          options = $.extend({}, $.fn.multiSelect.defaults, $this.data(), typeof option === 'object' && option);
+
+      if (!data){ $this.data('multiselect', (data = new MultiSelect(this, options))); }
+
+      if (typeof option === 'string'){
+        data[option](args[1]);
+      } else {
+        data.init();
+      }
+    });
+  };
+
+  $.fn.multiSelect.defaults = {
+    keySelect: [32],
+    selectableOptgroup: false,
+    disabledClass : 'disabled',
+    dblClick : false,
+    keepOrder: false,
+    cssClass: ''
+  };
+
+  $.fn.multiSelect.Constructor = MultiSelect;
+
+  $.fn.insertAt = function(index, $parent) {
+    return this.each(function() {
+      if (index === 0) {
+        $parent.prepend(this);
+      } else {
+        $parent.children().eq(index - 1).after(this);
+      }
+    });
+}
+
+}(window.jQuery);

--- a/open_event/templates/gentelella/admin/event/sessions/components/session_form.html
+++ b/open_event/templates/gentelella/admin/event/sessions/components/session_form.html
@@ -13,7 +13,29 @@
                 {{ _session_component.session_form_field(elem, session_form[elem].require) }}
             {% endif %}
         {% endfor %}
+        <div class="item form-group">
+            <label>Modify Speakers</label>
+            <select multiple="multiple" id="speakers" name="speakers[]">
+                {% for existing_speaker in speakers %}
+                    <option value="{{ existing_speaker.id }}"
+                            {% if session and existing_speaker in session.speakers %}selected{% endif %}
+                            data-html-addon="<img src='{{ existing_speaker.photo }}' onerror='imgError(this);' style='width: 2rem; height: 2rem;border-radius: 50%;'>">
+                        {{ existing_speaker.name }}
+                    </option>
+                {% endfor %}
+            </select>
+        </div>
+
         <br>
         <button type="submit" class="btn btn-success">Save Session</button>
     </div>
 </form>
+
+<script type="text/javascript">
+    $(function () {
+        $('#speakers').multiSelect({
+            selectableHeader: "<div style='margin: 10px 0;'><strong>Available Speakers</strong></div>",
+            selectionHeader: "<div style='margin: 10px 0;'><strong>Selected Speakers</strong></div>"
+        })
+    });
+</script>

--- a/open_event/templates/gentelella/admin/event/sessions/components/session_speaker_form.html
+++ b/open_event/templates/gentelella/admin/event/sessions/components/session_speaker_form.html
@@ -1,5 +1,6 @@
 {% import "gentelella/admin/event/sessions/components/_session_component.html" as _session_component with context %}
 {% import "gentelella/admin/event/sessions/components/_speaker_component.html" as _speaker_component with context %}
+
 <form enctype="multipart/form-data" action="" method="POST" class="form-horizontal" id="session-create-form">
     {% if csrf_token %}
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
@@ -14,6 +15,17 @@
                 {{ _session_component.session_form_field(elem, session_form[elem].require) }}
             {% endif %}
         {% endfor %}
+        <div class="item form-group">
+            <label>Choose from existing speakers</label>
+            <select multiple="multiple" id="speakers" name="speakers[]">
+                {% for existing_speaker in speakers %}
+                    <option value="{{ existing_speaker.id }}" {% if session and existing_speaker in session.speaker %}selected{% endif %}
+                            data-html-addon="<img src='{{ existing_speaker.photo }}' onerror='imgError(this);' style='width: 2rem; height: 2rem;border-radius: 50%;'>">
+                        {{ existing_speaker.name }}
+                    </option>
+                {% endfor %}
+            </select>
+        </div>
     </div>
     <div class="col-md-5 col-sm-5 col-xs-12 speaker_form">
         <h4>Speaker Details</h4>
@@ -45,3 +57,12 @@
         <button type="submit" class="btn btn-success" name="state" value="pending">Submit Session</button>
     </div>
 </form>
+
+<script type="text/javascript">
+    $(function () {
+        $('#speakers').multiSelect({
+            selectableHeader: "<div style='margin: 10px 0;'><strong>Available Speakers</strong></div>",
+            selectionHeader: "<div style='margin: 10px 0;'><strong>Selected Speakers</strong></div>"
+        })
+    });
+</script>

--- a/open_event/templates/gentelella/admin/event/sessions/edit.html
+++ b/open_event/templates/gentelella/admin/event/sessions/edit.html
@@ -8,6 +8,7 @@
 {% block head_css %}
     {{ super() }}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin/event_wizard.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='admin/lib/multiselect/css/multi-select.css') }}" />
 {% endblock %}
 
 {% block content %}
@@ -23,7 +24,7 @@
 {% endblock %}
 {% block tail_js %}
     {{ super() }}
-    <script src="{{ url_for('static', filename='admin/lib/bootstrap-validator/dist/validator.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/jquery/jquery.multi-select.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/admin/session/new.js') }}"></script>
     <script type="text/javascript">
         $(document).ready(function () {

--- a/open_event/templates/gentelella/admin/event/sessions/new.html
+++ b/open_event/templates/gentelella/admin/event/sessions/new.html
@@ -8,6 +8,7 @@
 {% block head_css %}
     {{ super() }}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin/event_wizard.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='admin/lib/multiselect/css/multi-select.css') }}" />
 {% endblock %}
 
 {% block content %}
@@ -23,8 +24,8 @@
 {% endblock %}
 {% block tail_js %}
     {{ super() }}
-    <script src="{{ url_for('static', filename='admin/lib/bootstrap-validator/dist/validator.min.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='js/admin/session/new.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/jquery/jquery.multi-select.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/admin/session/new.js') }}"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             $("textarea").summernote(summernoteConfig);

--- a/open_event/templates/gentelella/admin/event/speakers/base_speaker_table.html
+++ b/open_event/templates/gentelella/admin/event/speakers/base_speaker_table.html
@@ -42,15 +42,8 @@
 
 {% block head_js %}
     {{ super() }}
-
-    <script type="text/javascript">
-        function imgError(image) {
-            image.onerror = "";
-            image.src = '{{ url_for('static', filename='img/avatar.png') }}';
-            return true;
-        }
-    </script>
 {% endblock %}
+
 {% set active_page = "speakers" %}
 
 {% block content %}

--- a/open_event/templates/gentelella/admin/mysessions/mysession_detail.html
+++ b/open_event/templates/gentelella/admin/mysessions/mysession_detail.html
@@ -3,6 +3,7 @@
     {{ super() }}
     <link href="{{ url_for('static', filename='css/admin/mysessions.css') }}" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin/event_wizard.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='admin/lib/multiselect/css/multi-select.css') }}" />
 
 {% endblock %}
 {% block title %}
@@ -90,6 +91,7 @@
 {% endblock %}
 {% block tail_js %}
     {{ super() }}
+    <script src="{{ url_for('static', filename='js/jquery/jquery.multi-select.js') }}"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             $("textarea").summernote(summernoteConfig);

--- a/open_event/templates/gentelella/guest/event/cfs.html
+++ b/open_event/templates/gentelella/guest/event/cfs.html
@@ -8,6 +8,7 @@
     {{ super() }}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/guest/details.css') }}"/>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin/event_wizard.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='admin/lib/multiselect/css/multi-select.css') }}" />
     <style type="text/css">
         .carousel .item {
             height: {{ carousel_height }}px;
@@ -92,7 +93,7 @@
                         <h4 class="modal-title">Submit Proposal</h4>
                     </div>
                     <div class="modal-body">
-                        {% include 'gentelella/admin/event/sessions/session_form.html' %}
+                        {% include 'gentelella/admin/event/sessions/components/session_speaker_form.html' %}
                     </div>
                 </div>
             </div>
@@ -105,6 +106,7 @@
 
 {% block tail_js %}
     {{ super() }}
+    <script src="{{ url_for('static', filename='js/jquery/jquery.multi-select.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/admin/session/new.js') }}"></script>
     <script type="text/javascript">
         $(document).ready(function () {

--- a/open_event/templates/gentelella/guest/event/details.html
+++ b/open_event/templates/gentelella/guest/event/details.html
@@ -24,14 +24,6 @@
 
 {% block head_js %}
     {{ super() }}
-
-    <script type="text/javascript">
-        function imgError(image) {
-            image.onerror = "";
-            image.src = '{{ url_for('static', filename='img/avatar.png') }}';
-            return true;
-        }
-    </script>
 {% endblock %}
 
 {% block title %}

--- a/open_event/templates/gentelella/guest/event/sessions.html
+++ b/open_event/templates/gentelella/guest/event/sessions.html
@@ -28,14 +28,6 @@
 
 {% block head_js %}
     {{ super() }}
-
-    <script type="text/javascript">
-        function imgError(image) {
-            image.onerror = "";
-            image.src = '{{ url_for('static', filename='img/avatar.png') }}';
-            return true;
-        }
-    </script>
 {% endblock %}
 
 {% macro social_link(link, what) %}

--- a/open_event/views/admin/models_views/my_sessions.py
+++ b/open_event/views/admin/models_views/my_sessions.py
@@ -36,9 +36,9 @@ class MySessionView(BaseView):
         speaker_form = json.loads(form_elems.speaker_form)
         session_form = json.loads(form_elems.session_form)
         event = DataGetter.get_event(session.event_id)
-
+        speakers = DataGetter.get_speakers(session.event_id).all()
         return self.render('/gentelella/admin/mysessions/mysession_detail.html', session=session,
-                           speaker_form=speaker_form, session_form=session_form, event=event)
+                           speaker_form=speaker_form, session_form=session_form, event=event, speakers=speakers)
 
     @expose('/<int:session_id>/', methods=('POST',))
     @flask_login.login_required

--- a/open_event/views/admin/models_views/sessions.py
+++ b/open_event/views/admin/models_views/sessions.py
@@ -65,10 +65,11 @@ class SessionsView(BaseView):
             return redirect(url_for('.index_view', event_id=event_id))
         speaker_form = json.loads(form_elems.speaker_form)
         session_form = json.loads(form_elems.session_form)
+        speakers = DataGetter.get_speakers(event_id).all()
         event = DataGetter.get_event(event_id)
 
         return self.render('/gentelella/admin/event/sessions/new.html',
-                           speaker_form=speaker_form, session_form=session_form, event=event)
+                           speaker_form=speaker_form, session_form=session_form, event=event, speakers=speakers)
 
     @expose('/<int:session_id>/edit/', methods=('GET', 'POST'))
     @can_access
@@ -85,8 +86,9 @@ class SessionsView(BaseView):
             return redirect(url_for('.index_view', event_id=event_id))
         session_form = json.loads(form_elems.session_form)
         event = DataGetter.get_event(event_id)
+        speakers = DataGetter.get_speakers(event_id).all()
         return self.render('/gentelella/admin/event/sessions/edit.html', session=session,
-                           session_form=session_form, event=event)
+                           session_form=session_form, event=event, speakers=speakers)
 
     @expose('/new/<user_id>/<hash>/', methods=('GET', 'POST'))
     def new_view(self, event_id, user_id, hash):

--- a/open_event/views/public/event_detail.py
+++ b/open_event/views/public/event_detail.py
@@ -69,9 +69,9 @@ class EventDetailView(BaseView):
             state = "past"
         elif call_for_speakers.start_date > now:
             sate = "future"
-
+        speakers = DataGetter.get_speakers(event_id).all()
         return self.render('/gentelella/guest/event/cfs.html', event=event, speaker_form=speaker_form,
-                           session_form=session_form, call_for_speakers=call_for_speakers, state=state)
+                           session_form=session_form, call_for_speakers=call_for_speakers, state=state, speakers=speakers)
 
     @expose('/<int:event_id>/cfs/', methods=('POST',))
     def process_event_cfs(self, event_id):


### PR DESCRIPTION
Option to select from existing speakers for session create and edit. 

Resolves #1090. (comment)

#### Screenshots
**Session create form**
![screencapture-localhost-5000-events-5-sessions-create-1466528974409](https://cloud.githubusercontent.com/assets/2404372/16239206/7c3ff3d4-3801-11e6-97ab-ea86d079b8b1.png)
**Session edit form**
![screencapture-localhost-5000-events-5-sessions-259-edit-1466529057297](https://cloud.githubusercontent.com/assets/2404372/16239211/7fab9096-3801-11e6-9df1-3f31ebc24399.png)

@mariobehling please review and merge
