### PR TITLE
Fix wrong IP Address.

### DIFF
--- a/open_event/helpers/helpers.py
+++ b/open_event/helpers/helpers.py
@@ -177,9 +177,11 @@ def get_request_stats():
     """
     Get IP, Browser, Platform, Version etc
     http://werkzeug.pocoo.org/docs/0.11/utils/#module-werkzeug.useragents
+
+    Note: request.remote_addr gives the server's address if the server is behind a reverse proxy. -@niranjan94
     """
     return {
-        'ip': request.remote_addr,
+        'ip': request.environ['REMOTE_ADDR'],
         'platform': request.user_agent.platform,
         'browser': request.user_agent.browser,
         'version': request.user_agent.version,

--- a/open_event/views/api_v1_views.py
+++ b/open_event/views/api_v1_views.py
@@ -459,8 +459,12 @@ def documentation():
 
 @app.route('/api/location/', methods=('GET', 'POST'))
 def location():
+    """
+    Note: request.remote_addr gives the server's address if the server is behind a reverse proxy. -@niranjan94
+    :return:
+    """
     reader = geoip2.database.Reader(os.path.realpath('.') + '/static/data/GeoLite2-Country.mmdb')
-    ip = request.remote_addr
+    ip = request.environ['REMOTE_ADDR']
     if ip == '127.0.0.1' or ip == '0.0.0.0':
         ip = urlopen('http://ip.42.pl/raw').read()
     try:


### PR DESCRIPTION
Resolves #1184.

`request.remote_addr` gives the server's address if the server is behind a reverse proxy. `request.environ['REMOTE_ADDR']` has to be used to get the client IP. 

@rafalkowalski @mariobehling please review and merge