### PR TITLE
Send emails according to settings

### DIFF
--- a/open_event/helpers/data.py
+++ b/open_event/helpers/data.py
@@ -401,6 +401,19 @@ class DataManager(object):
         save_to_db(session, "Session Speaker saved")
 
     @staticmethod
+    def session_accept_reject(session, event_id, state):
+        session.state = state
+        save_to_db(session, 'Session State Updated')
+        link = url_for('event_sessions.session_display_view',
+                       event_id=event_id, session_id=session.id, _external=True)
+        for speaker in session.speakers:
+            print speaker.name
+            email_notification_setting = DataGetter.get_email_notification_settings_by_event_id(speaker.user_id, event_id)
+            if email_notification_setting and email_notification_setting.session_accept_reject == 1:
+                Helper.send_session_accept_reject(speaker.email, session.title, state, link)
+        flash("The session has been %s" % state)
+
+    @staticmethod
     def edit_session(request, session):
         form = request.form
         event_id = session.event_id

--- a/open_event/helpers/data.py
+++ b/open_event/helpers/data.py
@@ -293,7 +293,9 @@ class DataManager(object):
                            event_id=event.id, session_id=new_session.id, _external=True)
             organizers = DataGetter.get_user_event_roles_by_role_name(event.id, 'organizer')
             for organizer in organizers:
-                send_new_session_organizer(organizer.user.email, event.name, link)
+                email_notification_setting = DataGetter.get_email_notification_settings_by_event_id(organizer.user.id, event.id)
+                if email_notification_setting and email_notification_setting.new_paper == 1:
+                    send_new_session_organizer(organizer.user.email, event.name, link)
 
         speaker_modified = False
         session_modified = False

--- a/open_event/helpers/helpers.py
+++ b/open_event/helpers/helpers.py
@@ -12,7 +12,7 @@ from open_event.helpers.flask_helpers import get_real_ip
 from open_event.settings import get_settings
 from ..models.track import Track
 from ..models.mail import INVITE_PAPERS, NEW_SESSION, USER_CONFIRM, \
-    USER_REGISTER, PASSWORD_RESET, EVENT_ROLE, Mail
+    USER_REGISTER, PASSWORD_RESET, SESSION_ACCEPT_REJECT, SESSION_SCHEDULE, EVENT_ROLE, Mail
 from system_mails import MAILS
 
 
@@ -59,6 +59,35 @@ def send_new_session_organizer(email, event_name, link):
         html=MAILS[NEW_SESSION]['message'].format(
             email=str(email),
             event_name=str(event_name),
+            link=link
+        )
+    )
+
+
+def send_session_accept_reject(email, session_name, acceptance, link):
+    """Send session accepted or rejected"""
+    send_email(
+        to=email,
+        action=SESSION_ACCEPT_REJECT,
+        subject=MAILS[SESSION_ACCEPT_REJECT]['subject'].format(session_name=session_name, acceptance=acceptance),
+        html=MAILS[SESSION_ACCEPT_REJECT]['message'].format(
+            email=str(email),
+            session_name=str(session_name),
+            acceptance=str(acceptance),
+            link=link
+        )
+    )
+
+
+def send_schedule_change(email, session_name, link):
+    """Send schedule change in session"""
+    send_email(
+        to=email,
+        action=SESSION_SCHEDULE,
+        subject=MAILS[SESSION_SCHEDULE]['subject'].format(session_name=session_name),
+        html=MAILS[SESSION_SCHEDULE]['message'].format(
+            email=str(email),
+            session_name=str(session_name),
             link=link
         )
     )

--- a/open_event/helpers/helpers.py
+++ b/open_event/helpers/helpers.py
@@ -11,7 +11,7 @@ from flask.ext import login
 from open_event.helpers.flask_helpers import get_real_ip
 from open_event.settings import get_settings
 from ..models.track import Track
-from ..models.mail import INVITE_PAPERS, NEW_SESSION, USER_CONFIRM, \
+from ..models.mail import INVITE_PAPERS, NEW_SESSION, USER_CONFIRM, NEXT_EVENT, \
     USER_REGISTER, PASSWORD_RESET, SESSION_ACCEPT_REJECT, SESSION_SCHEDULE, EVENT_ROLE, Mail
 from system_mails import MAILS
 
@@ -88,6 +88,20 @@ def send_schedule_change(email, session_name, link):
         html=MAILS[SESSION_SCHEDULE]['message'].format(
             email=str(email),
             session_name=str(session_name),
+            link=link
+        )
+    )
+
+
+def send_next_event(email, event_name, link):
+    """Send next event"""
+    send_email(
+        to=email,
+        action=NEXT_EVENT,
+        subject=MAILS[NEXT_EVENT]['subject'].format(event_name=event_name),
+        html=MAILS[NEXT_EVENT]['message'].format(
+            email=str(email),
+            event_name=str(event_name),
             link=link
         )
     )

--- a/open_event/helpers/system_mails.py
+++ b/open_event/helpers/system_mails.py
@@ -3,7 +3,8 @@ All the System mails
 Register a mail here before using it
 """
 from ..models.mail import INVITE_PAPERS, NEW_SESSION, USER_CONFIRM, \
-    USER_REGISTER, PASSWORD_RESET, EVENT_ROLE
+    USER_REGISTER, PASSWORD_RESET, EVENT_ROLE, SESSION_ACCEPT_REJECT, \
+    SESSION_SCHEDULE
 
 
 MAILS = {
@@ -14,6 +15,23 @@ MAILS = {
             "Hi {email}<br/>" +
             "You are invited to submit papers for event: {event_name}" +
             "<br/> Visit this link to fill up details: {link}"
+        )
+    },
+    SESSION_ACCEPT_REJECT: {
+        'recipient': 'Speaker',
+        'subject': 'Session {session_name} has been {acceptance}',
+        'message': (
+            "Hi {email},<br/>" +
+            "The session <strong>{session_name}</strong> has been <strong>{acceptance}</strong> by the organizer. "
+        )
+    },
+    SESSION_SCHEDULE: {
+        'recipient': 'Organizer, Speaker',
+        'subject': 'Schedule for Session {session_name} has been changed',
+        'message': (
+            "Hi {email},<br/>" +
+            "The schedule for session <strong>{session_name}</strong> has been changed. " +
+            "<br/> Visit this link to view the session: {link}"
         )
     },
     NEW_SESSION: {

--- a/open_event/helpers/system_mails.py
+++ b/open_event/helpers/system_mails.py
@@ -4,7 +4,7 @@ Register a mail here before using it
 """
 from ..models.mail import INVITE_PAPERS, NEW_SESSION, USER_CONFIRM, \
     USER_REGISTER, PASSWORD_RESET, EVENT_ROLE, SESSION_ACCEPT_REJECT, \
-    SESSION_SCHEDULE
+    SESSION_SCHEDULE, NEXT_EVENT
 
 
 MAILS = {
@@ -33,6 +33,15 @@ MAILS = {
             "Hi {email},<br/>" +
             "The schedule for session <strong>{session_name}</strong> has been changed. " +
             "<br/> Visit this link to view the session: {link}"
+        )
+    },
+    NEXT_EVENT: {
+        'recipient': 'Organizer, Speaker',
+        'subject': 'Event {event_name} is coming soon',
+        'message': (
+            "Hi {email},<br/>" +
+            "Event {event_name} is coming soon. Get ready!! " +
+            "<br/> Visit this link to view the event: {link}"
         )
     },
     NEW_SESSION: {

--- a/open_event/helpers/system_mails.py
+++ b/open_event/helpers/system_mails.py
@@ -22,7 +22,8 @@ MAILS = {
         'subject': 'Session {session_name} has been {acceptance}',
         'message': (
             "Hi {email},<br/>" +
-            "The session <strong>{session_name}</strong> has been <strong>{acceptance}</strong> by the organizer. "
+            "The session <strong>{session_name}</strong> has been <strong>{acceptance}</strong> by the organizer. " +
+            "<br/> Visit this link to view the session: {link}"
         )
     },
     SESSION_SCHEDULE: {

--- a/open_event/models/email_notifications.py
+++ b/open_event/models/email_notifications.py
@@ -15,10 +15,10 @@ class EmailNotification(db.Model):
     event_id = db.Column(db.Integer, db.ForeignKey('events.id'))
 
     def __init__(self,
-                 next_event=None,
-                 new_paper=None,
-                 session_accept_reject=None,
-                 session_schedule=None,
+                 next_event=0,
+                 new_paper=0,
+                 session_accept_reject=0,
+                 session_schedule=0,
                  user_id=None,
                  event_id=None):
         self.next_event = next_event

--- a/open_event/models/mail.py
+++ b/open_event/models/mail.py
@@ -6,6 +6,7 @@ from . import db
 USER_REGISTER = 'User Registration'
 USER_CONFIRM = 'User Confirmation'
 INVITE_PAPERS = 'Invitation For Papers'
+NEXT_EVENT = 'Next Event'
 NEW_SESSION = 'New Session Proposal'
 PASSWORD_RESET = 'Reset Password'
 EVENT_ROLE = 'Event Role Invitation'

--- a/open_event/models/mail.py
+++ b/open_event/models/mail.py
@@ -9,6 +9,8 @@ INVITE_PAPERS = 'Invitation For Papers'
 NEW_SESSION = 'New Session Proposal'
 PASSWORD_RESET = 'Reset Password'
 EVENT_ROLE = 'Event Role Invitation'
+SESSION_ACCEPT_REJECT = 'Session Accept or Reject'
+SESSION_SCHEDULE = 'Session Schedule Change'
 
 
 class Mail(db.Model):

--- a/open_event/views/admin/models_views/sessions.py
+++ b/open_event/views/admin/models_views/sessions.py
@@ -113,18 +113,14 @@ class SessionsView(BaseView):
     @can_accept_and_reject
     def accept_session(self, event_id, session_id):
         session = get_session_or_throw(session_id)
-        session.state = 'accepted'
-        save_to_db(session, 'Session Accepted')
-        flash("The session has been accepted")
+        DataManager.session_accept_reject(session, event_id, 'accepted')
         return redirect(url_for('.index_view', event_id=event_id))
 
     @expose('/<int:session_id>/reject', methods=('GET',))
     @can_accept_and_reject
     def reject_session(self, event_id, session_id):
         session = get_session_or_throw(session_id)
-        session.state = 'rejected'
-        save_to_db(session, 'Session Rejected')
-        flash("The session has been rejected")
+        DataManager.session_accept_reject(session, event_id, 'rejected')
         return redirect(url_for('.index_view', event_id=event_id))
 
     @expose('/<int:session_id>/delete', methods=('GET',))


### PR DESCRIPTION
#1236 

Functions for sending different emails written.
![screenshot from 2016-06-27 02 43 41](https://cloud.githubusercontent.com/assets/9530293/16364965/422faa18-3c11-11e6-91c4-35d303fb3f0e.png)

Applied conditional settings for new_session and session_accept_reject. The view for next_event hasn't been written so conditional email sending not applied there.

Verified that emails are sent only if they are set in `/settings` page.

@mariobehling please review