### PR TITLE
Modify BOWER.md to include proxy

### DIFF
--- a/docs/BOWER.md
+++ b/docs/BOWER.md
@@ -10,3 +10,21 @@ We use [Bower](http://bower.io) to manage front-end dependencies. `cd` to the di
 bower install
 ```
 
+Note: If you are working from within a proxied network of an organization/institute, Bower might not be able to install the libraries. For that, we need to configure .bowerrc to work via proxy.
+* Open .bowerrc in any text editor like vim. Run:
+```vim .bowerrc```
+* The contents of .bowerrc will be something like this:
+```
+{
+	"directory": "open_event/static/admin/lib"
+}
+```
+* Modify the file to add "proxy" and "https-proxy" properties like this:
+```
+{
+	"directory": "open_event/static/admin/lib",
+	"proxy": "http://172.31.1.23:8080",
+	"https-proxy": "http://172.31.1.23:8080"
+}
+```
+* Save and exit. Now we can run ```bower install``` to install our libraries.


### PR DESCRIPTION
Added steps to include "proxy" and "https-proxy" properties in .bowerrc to use ```bower install``` behind a proxy.