### PR TITLE
Added sitemap

### DIFF
--- a/open_event/__init__.py
+++ b/open_event/__init__.py
@@ -34,6 +34,7 @@ from helpers.jwt import jwt_authenticate, jwt_identity
 from helpers.formatter import operation_name
 from open_event.helpers.data_getter import DataGetter
 from open_event.views.api_v1_views import app as api_v1_routes
+from open_event.views.sitemap import app as sitemap_routes
 import requests
 
 
@@ -47,6 +48,7 @@ def create_app():
     event = Event()
 
     app.register_blueprint(api_v1_routes)
+    app.register_blueprint(sitemap_routes)
     migrate = Migrate(app, db)
 
     app.config.from_object(environ.get('APP_CONFIG', 'config.ProductionConfig'))

--- a/open_event/templates/gentelella/admin/footer.html
+++ b/open_event/templates/gentelella/admin/footer.html
@@ -9,7 +9,7 @@
                     <li><a href="/how_it_works">How it Works</a></li>
                     <li><a href="/pricing">Pricing</a></li>
                     <li><a href="/mobile_apps">Mobile Apps</a></li>
-                    <li><a href="/sitemap">Sitemap</a></li>
+                    <li><a href="/sitemap.xml">Sitemap</a></li>
                 </ul>
             </div>
             <div class="col-md-3">

--- a/open_event/templates/sitemap/sitemap.xml
+++ b/open_event/templates/sitemap/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for url in urls %}
+  <url>
+    <loc>{{ url|safe }}</loc>
+  </url>
+{% endfor %}
+</urlset>

--- a/open_event/templates/sitemap/sitemap_index.xml
+++ b/open_event/templates/sitemap/sitemap_index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for sitemap in sitemaps %}
+<sitemap>
+   <loc>{{ sitemap }}</loc>
+</sitemap>
+{% endfor %}
+</sitemapindex>

--- a/open_event/views/api_v1_views.py
+++ b/open_event/views/api_v1_views.py
@@ -454,9 +454,11 @@ def serve_static(filename):
     """
     return send_from_directory(os.path.realpath('.') + '/static/', filename)
 
+
 @app.route('/documentation')
 def documentation():
     return auto.html()
+
 
 @app.route('/api/location/', methods=('GET', 'POST'))
 def location():
@@ -481,6 +483,7 @@ def location():
             'ip': ip
         })
 
+
 @app.route('/migrate/', methods=('GET', 'POST'))
 def run_migrations():
     try:
@@ -488,6 +491,7 @@ def run_migrations():
     except:
         print "Migrations have been run"
     return jsonify({'status': 'ok'})
+
 
 def intended_url():
     return request.args.get('next') or url_for('admin.index')

--- a/open_event/views/public/pages.py
+++ b/open_event/views/public/pages.py
@@ -21,10 +21,10 @@ class BasicPagesView(BaseView):
         title = "Mobile Apps"
         return self.render('/gentelella/guest/page.html', title=title)
 
-    @expose('/sitemap', methods=('GET', 'POST'))
-    def sitemap(self):
-        title = "SiteMap"
-        return self.render('/gentelella/guest/page.html', title=title)
+    # @expose('/sitemap', methods=('GET', 'POST'))
+    # def sitemap(self):
+    #     title = "SiteMap"
+    #     return self.render('/gentelella/guest/page.html', title=title)
 
     @expose('/about', methods=('GET', 'POST'))
     def about(self):

--- a/open_event/views/public/pages.py
+++ b/open_event/views/public/pages.py
@@ -21,11 +21,6 @@ class BasicPagesView(BaseView):
         title = "Mobile Apps"
         return self.render('/gentelella/guest/page.html', title=title)
 
-    # @expose('/sitemap', methods=('GET', 'POST'))
-    # def sitemap(self):
-    #     title = "SiteMap"
-    #     return self.render('/gentelella/guest/page.html', title=title)
-
     @expose('/about', methods=('GET', 'POST'))
     def about(self):
         title = "About"

--- a/open_event/views/sitemap.py
+++ b/open_event/views/sitemap.py
@@ -1,5 +1,5 @@
 from flask import url_for, render_template, make_response, request, \
-    Blueprint
+    Blueprint, abort
 from math import ceil
 
 from open_event.models.event import Event
@@ -22,6 +22,7 @@ static_pages = [
     'how_it_works',
     'pricing',
     'about'
+    # TODO: add more when the pages are built
 ]
 
 
@@ -60,6 +61,8 @@ def render_event_pages(num):
     start = (num - 1) * PER_PAGE_EVENTS
     end = PER_PAGE_EVENTS * num
     events = get_indexable_events()[start:end]
+    if len(events) == 0:
+        abort(404)
 
     for e in events:
         urls = [
@@ -67,7 +70,7 @@ def render_event_pages(num):
             for view in event_details_pages
         ]
         main_urls += urls
-    return make_sitemap_response(urls)
+    return make_sitemap_response(main_urls)
 
 ##########
 # Helpers

--- a/open_event/views/sitemap.py
+++ b/open_event/views/sitemap.py
@@ -1,20 +1,90 @@
 from flask import url_for, render_template, make_response, request, \
     Blueprint
+from math import ceil
 
 from open_event.models.event import Event
 
 app = Blueprint('sitemaps', __name__)
 
+# INDEX PAGES LIST
+
+PER_PAGE_EVENTS = 500
+
+event_details_pages = [
+    'display_event_detail_home',
+    'display_event_sessions',
+    'display_event_schedule',
+    'display_event_cfs',
+    'display_event_coc'
+]
+
+static_pages = [
+    'how_it_works',
+    'pricing',
+    'about'
+]
+
 
 @app.route('/sitemap.xml', methods=('GET', 'POST'))
 def render_sitemap():
-    events = Event.query.filter_by(privacy='public').all()
+    urls = []
+    # pages sitemap
+    urls.append(
+        full_url(url_for('sitemaps.render_pages_sitemap'))
+    )
+    # get events pages
+    events = get_indexable_events()
+    pages = int(ceil(len(events) / (PER_PAGE_EVENTS * 1.0)))
+    for num in range(1, pages + 1):
+        urls.append(
+            full_url(url_for('sitemaps.render_event_pages', num=num))
+        )
+    # make sitemap
+    sitemap = render_template('sitemap/sitemap_index.xml', sitemaps=urls)
+    resp = make_response(sitemap)
+    resp.headers['Content-Type'] = 'application/xml'
+    return resp
+
+
+@app.route('/sitemaps/pages.xml.gz', methods=('GET', 'POST'))
+def render_pages_sitemap():
     urls = [
-        request.url_root.strip('/') +
-        url_for('event_detail.display_event_detail_home', event_id=e.id)
-        for e in events
+        full_url(url_for('basicpagesview.' + page)) for page in static_pages
     ]
+    return make_sitemap_response(urls)
+
+
+@app.route('/sitemaps/events/<int:num>.xml.gz', methods=('GET', 'POST'))
+def render_event_pages(num):
+    main_urls = []
+    start = (num - 1) * PER_PAGE_EVENTS
+    end = PER_PAGE_EVENTS * num
+    events = get_indexable_events()[start:end]
+
+    for e in events:
+        urls = [
+            full_url(url_for('event_detail.' + view, event_id=e.id))
+            for view in event_details_pages
+        ]
+        main_urls += urls
+    return make_sitemap_response(urls)
+
+##########
+# Helpers
+##########
+
+
+def make_sitemap_response(urls):
     sitemap = render_template('sitemap/sitemap.xml', urls=urls)
     resp = make_response(sitemap)
     resp.headers['Content-Type'] = 'application/xml'
     return resp
+
+
+def get_indexable_events():
+    events = Event.query.filter_by(privacy='public').order_by('id')
+    return list(events)
+
+
+def full_url(url):
+    return request.url_root.strip('/') + url

--- a/open_event/views/sitemap.py
+++ b/open_event/views/sitemap.py
@@ -1,0 +1,20 @@
+from flask import url_for, render_template, make_response, request, \
+    Blueprint
+
+from open_event.models.event import Event
+
+app = Blueprint('sitemaps', __name__)
+
+
+@app.route('/sitemap.xml', methods=('GET', 'POST'))
+def render_sitemap():
+    events = Event.query.filter_by(privacy='public').all()
+    urls = [
+        request.url_root.strip('/') +
+        url_for('event_detail.display_event_detail_home', event_id=e.id)
+        for e in events
+    ]
+    sitemap = render_template('sitemap/sitemap.xml', urls=urls)
+    resp = make_response(sitemap)
+    resp.headers['Content-Type'] = 'application/xml'
+    return resp

--- a/tests/views/guest/test_sitemaps.py
+++ b/tests/views/guest/test_sitemaps.py
@@ -1,0 +1,48 @@
+import unittest
+
+from open_event.helpers.data import save_to_db
+from tests.object_mother import ObjectMother
+from tests.auth_helper import register
+from tests.setup_database import Setup
+from tests.utils import OpenEventTestCase
+from open_event import current_app as app
+
+
+class TestSitemaps(OpenEventTestCase):
+    def setUp(self):
+        self.app = Setup.create_app()
+        with app.test_request_context():
+            register(self.app, u'test@example.com', u'test')
+
+    def test_index(self):
+        resp = self.app.get('/sitemap.xml')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('pages.xml.gz', resp.data)
+        self.assertNotIn('1.xml.gz', resp.data)
+        self.assertIn('sitemap', resp.data)
+
+    def test_index_with_event(self):
+        with app.test_request_context():
+            event = ObjectMother.get_event()
+            save_to_db(event)
+        resp = self.app.get('/sitemap.xml')
+        self.assertIn('1.xml.gz', resp.data)
+
+    def test_pages(self):
+        resp = self.app.get('/sitemaps/pages.xml.gz')
+        self.assertIn('about', resp.data)
+
+    def test_event_page(self):
+        with app.test_request_context():
+            event = ObjectMother.get_event()
+            save_to_db(event)
+        resp = self.app.get('/sitemaps/events/1.xml.gz')
+        self.assertIn('/1/', resp.data)
+
+    def test_event_page_not_exist(self):
+        resp = self.app.get('/sitemaps/events/2.xml.gz')
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #1288 

Sitemap is served at /sitemap.xml . The sitemap at the root (/sitemap.xml) is a sitemap index which links to other sitemaps on the site. 
Sitemaps for events are served at `/sitemaps/events/<number>.xml.gz` where `number` is the page number. Currently each page can have a max of 500 events. The pages continue to increase as the number of events increase. 

PS - A similar technique has been used in [meetup.com](http://www.meetup.com/sitemap.xml) to prevent the main sitemap from becoming massive. 

#### Links

1. [Google Sitemap Ref](https://support.google.com/webmasters/answer/183668?hl=en)
2. [Google Sitemap Index Help](https://support.google.com/webmasters/answer/75712?rd=1)