### PR TITLE
Fix and suppress errors during testing

### DIFF
--- a/open_event/helpers/data.py
+++ b/open_event/helpers/data.py
@@ -1089,7 +1089,7 @@ class DataManager(object):
     @staticmethod
     def trash_event(e_id):
         event = Event.query.get(e_id)
-        event.in_trash = 'True'
+        event.in_trash = True
         save_to_db(event, "Event Added to Trash")
         return event
 
@@ -1147,7 +1147,7 @@ class DataManager(object):
         record_activity('update_role', role=role, user=user, event_id=uer.event_id)
 
 
-def save_to_db(item, msg="Saved to db"):
+def save_to_db(item, msg="Saved to db", print_error=True):
     """Convenience function to wrap a proper DB save
     :param item: will be saved to database
     :param msg: Message to log
@@ -1159,9 +1159,10 @@ def save_to_db(item, msg="Saved to db"):
         db.session.commit()
         return True
     except Exception, e:
-        print e
+        if print_error:
+            print e
+            traceback.print_exc()
         logging.error('DB Exception! %s' % e)
-        traceback.print_exc()
         db.session.rollback()
         return False
 

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -43,7 +43,7 @@ def create_session(event_id, serial_no='', **kwargs):
         event_id=event_id,
         **kwargs
     )
-    save_to_db(session, 'Session saved')
+    save_to_db(session, 'Session saved', print_error=False)
 
 
 def create_services(event_id, serial_no=''):


### PR DESCRIPTION
https://github.com/fossasia/open-event-orga-server/issues/1377

There were two warnings and two errors during testing. I've fixed one of the errors, it was occurring because of using string "True" instead of True. The other error is an `sqlite3.IntegrityError` (followed by an AssertionError occurring because of that). It is occurring in `test_import_extended` method in `test_export_import.py`. They are not failing the tests. I'll see if I can fix it, right now I've marked for the traceback not to be printed. 

The two warnings are internally displayed by sqlalchemy package and cannot be suppressed. You can look them up here: https://travis-ci.org/fossasia/open-event-orga-server/builds/141966192

@niranjan94 Please review.