### PR TITLE
Validate event url in step 1 wizard

### DIFF
--- a/open_event/templates/gentelella/admin/event/wizard/step-1.html
+++ b/open_event/templates/gentelella/admin/event/wizard/step-1.html
@@ -162,7 +162,8 @@
         <div class="item form-group">
             <label>Event Url</label>
             <input type="url" pattern="https?://.+" value="{{ event.event_url | default('', true) }}" name="event_url"
-                   class="form-control"/>
+                   class="form-control" data-error="Please enter a valid URL"/>
+            <div class="help-block with-errors"></div>
         </div>
 
         <div class="item form-group">


### PR DESCRIPTION
Fixes #1407 
The field is validated (i.e. the message is shown) when you press Next or Save. 

![url-event-validate](https://cloud.githubusercontent.com/assets/4047597/16560573/f400f25a-4211-11e6-94f7-0cf1babfcef7.png)
