### PR TITLE
copyright api fix

### DIFF
--- a/open_event/api/events.py
+++ b/open_event/api/events.py
@@ -118,8 +118,11 @@ class EventDAO(BaseDAO):
         # Extract and save copyright info
         copyright_data = payload.get('copyright')
         payload.pop('copyright', None)
-        copyright = EventCopyright(**copyright_data)
-        save_to_db(copyright, 'Copyright info saved')
+        if copyright_data is not None:
+            copyright = EventCopyright(**copyright_data)
+            save_to_db(copyright, 'Copyright info saved')
+        else:
+            copyright = None
 
         new_event = self.model(**payload)
         save_to_db(new_event, "Event saved")

--- a/open_event/api/events.py
+++ b/open_event/api/events.py
@@ -115,7 +115,8 @@ class EventDAO(BaseDAO):
         data = self.validate(data)
         payload = self.fix_payload(data)
         # save copyright info
-        payload['copyright'] = CopyrightDAO.create(payload.get('copyright'),
+        payload['copyright'] = CopyrightDAO.create(payload['copyright']
+                                                   if payload.get('copyright') else {},
                                                    validate=False)
         # save event
         new_event = self.model(**payload)
@@ -140,10 +141,12 @@ class EventDAO(BaseDAO):
         payload = self.fix_payload(data)
         # get event
         event = self.get(event_id)
-        # update/create copyright
-        CopyrightDAO.update(event.copyright.id, payload['copyright'])
-        # delete related fields
-        payload.pop('copyright')
+        # update copyright if key exists
+        if 'copyright' in payload:
+            CopyrightDAO.update(event.copyright.id, payload['copyright']
+                                if payload['copyright'] else {})
+            payload.pop('copyright')
+
         return BaseDAO.update(self, event_id, payload, validate=False)
 
 

--- a/open_event/api/events.py
+++ b/open_event/api/events.py
@@ -142,9 +142,10 @@ class EventDAO(BaseDAO):
         event = self.get(event_id)
         # update/create copyright
         if payload.get('copyright'):
-            payload['copyright']['event_id'] = event_id
-            if event.copyright is None:
-                CopyrightDAO.create(payload['copyright'])
+            payload['copyright']['event'] = event
+            if not event.copyright:
+                # validate=False to not delete event key
+                CopyrightDAO.create(payload['copyright'], validate=False)
             else:
                 CopyrightDAO.update(event.copyright.id, payload['copyright'])
         # delete related fields

--- a/open_event/api/events.py
+++ b/open_event/api/events.py
@@ -114,9 +114,9 @@ class EventDAO(BaseDAO):
     def create(self, data, url):
         data = self.validate(data)
         payload = self.fix_payload(data)
-        # Extract and save copyright info
-        if payload.get('copyright'):
-            payload['copyright'] = CopyrightDAO.create(payload['copyright'])
+        # save copyright info
+        payload['copyright'] = CopyrightDAO.create(payload.get('copyright'),
+                                                   validate=False)
         # save event
         new_event = self.model(**payload)
         new_event.creator = g.user
@@ -141,13 +141,7 @@ class EventDAO(BaseDAO):
         # get event
         event = self.get(event_id)
         # update/create copyright
-        if payload.get('copyright'):
-            payload['copyright']['event'] = event
-            if not event.copyright:
-                # validate=False to not delete event key
-                CopyrightDAO.create(payload['copyright'], validate=False)
-            else:
-                CopyrightDAO.update(event.copyright.id, payload['copyright'])
+        CopyrightDAO.update(event.copyright.id, payload['copyright'])
         # delete related fields
         payload.pop('copyright')
         return BaseDAO.update(self, event_id, payload, validate=False)

--- a/open_event/api/helpers/helpers.py
+++ b/open_event/api/helpers/helpers.py
@@ -218,6 +218,8 @@ def create_model(model, data, event_id=None):
     if event_id is not None:
         get_object_or_404(EventModel, event_id)
         data['event_id'] = event_id
+    if data is None:
+        data = dict()
     new_model = model(**data)
     save_to_db(new_model, "Model %s saved" % model.__name__)
     if event_id:

--- a/open_event/api/helpers/helpers.py
+++ b/open_event/api/helpers/helpers.py
@@ -186,7 +186,8 @@ def validate_payload(payload, api_model):
             field = field.container
             data = payload[key]
         elif isinstance(field, fields.Nested):
-            validate_payload(payload[key], field.model)
+            if payload[key]:  # not null
+                validate_payload(payload[key], field.model)
         else:
             data = [payload[key]]
         if isinstance(field, CustomField) and hasattr(field, 'validate'):

--- a/open_event/api/helpers/helpers.py
+++ b/open_event/api/helpers/helpers.py
@@ -218,8 +218,6 @@ def create_model(model, data, event_id=None):
     if event_id is not None:
         get_object_or_404(EventModel, event_id)
         data['event_id'] = event_id
-    if data is None:
-        data = dict()
     new_model = model(**data)
     save_to_db(new_model, "Model %s saved" % model.__name__)
     if event_id:

--- a/tests/api/test_get_api_200.py
+++ b/tests/api/test_get_api_200.py
@@ -32,7 +32,7 @@ class TestGetApi(OpenEventTestCase):
 
     def test_event_api(self):
         path = get_path(1)
-        self._test_path(path, 'TestEvent', '"copyright": null')
+        self._test_path(path, 'TestEvent')
 
     def test_track_api(self):
         path = get_path(1, 'tracks', 1)

--- a/tests/api/test_get_api_200.py
+++ b/tests/api/test_get_api_200.py
@@ -32,7 +32,7 @@ class TestGetApi(OpenEventTestCase):
 
     def test_event_api(self):
         path = get_path(1)
-        self._test_path(path, 'TestEvent', "'copyright': null")
+        self._test_path(path, 'TestEvent', '"copyright": null')
 
     def test_track_api(self):
         path = get_path(1, 'tracks', 1)

--- a/tests/api/test_get_api_200.py
+++ b/tests/api/test_get_api_200.py
@@ -19,7 +19,7 @@ class TestGetApi(OpenEventTestCase):
             # Associate services to event_id
             create_services(event_id)
 
-    def _test_path(self, path, string):
+    def _test_path(self, path, *strings):
         """Helper function.
         Test response for 200 status code. Also test if response body
         contains event/service name.
@@ -27,11 +27,12 @@ class TestGetApi(OpenEventTestCase):
         with app.test_request_context():
             response = self.app.get(path, follow_redirects=True)
             self.assertEqual(response.status_code, 200)
-            self.assertIn(string, response.data)
+            for string in strings:
+                self.assertIn(string, response.data)
 
     def test_event_api(self):
         path = get_path(1)
-        self._test_path(path, 'TestEvent')
+        self._test_path(path, 'TestEvent', "'copyright': null")
 
     def test_track_api(self):
         path = get_path(1, 'tracks', 1)

--- a/tests/api/test_post_api.py
+++ b/tests/api/test_post_api.py
@@ -64,7 +64,10 @@ class TestPostApi(TestPostApiBase):
         return response
 
     def test_event_api(self):
-        self._test_model('event', POST_EVENT_DATA, ['test@example.com'])
+        self._test_model(
+            'event', POST_EVENT_DATA,
+            ['test@example.com', 'Test licence']
+        )
 
     def test_track_api(self):
         self._test_model('track', POST_TRACK_DATA)

--- a/tests/api/test_put_api.py
+++ b/tests/api/test_put_api.py
@@ -39,7 +39,7 @@ class TestPutApi(TestPutApiBase):
     Test PUT APIs against 401 (unauthorized) and
     200 (successful) status codes
     """
-    def _test_model(self, name, data):
+    def _test_model(self, name, data, *args):
         """
         Tests -
         1. Without login, try to do a PUT request and catch 401 error
@@ -55,9 +55,12 @@ class TestPutApi(TestPutApiBase):
         self.assertEqual(200, response.status_code, msg=response.data)
         # surrounded by quotes for strict checking
         self.assertIn('"Test%s"' % str(name).title(), response.data)
+        # check more things
+        for _ in args:
+            self.assertIn(_, response.data, response.data)
 
     def test_event_api(self):
-        self._test_model('event', POST_EVENT_DATA)
+        self._test_model('event', POST_EVENT_DATA, 'Test licence')
 
     def test_track_api(self):
         self._test_model('track', POST_TRACK_DATA)

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -6,7 +6,6 @@ from open_event.models.event import Event
 from open_event.models.session import Session
 from open_event.models.speaker import Speaker
 from open_event.models.sponsor import Sponsor
-from open_event.models.event_copyright import EventCopyright as Copyright
 from open_event.models.microlocation import Microlocation
 from open_event.models.session_type import SessionType
 from open_event.models.social_link import SocialLink
@@ -17,11 +16,9 @@ def create_event(name='TestEvent', creator_email=None):
     """Creates Event and returns its `id`.
     :param name Name of Event
     """
-    copyright = Copyright(holder='copyright holder')
     event = Event(name=name,
                   start_time=datetime(2016, 4, 8, 12, 30, 45),
-                  end_time=datetime(2016, 4, 9, 12, 30, 45),
-                  copyright=copyright)
+                  end_time=datetime(2016, 4, 9, 12, 30, 45))
     if creator_email:
         event.creator = User.query.filter_by(email=creator_email).first()
     save_to_db(event, 'Event saved')

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -10,15 +10,18 @@ from open_event.models.microlocation import Microlocation
 from open_event.models.session_type import SessionType
 from open_event.models.social_link import SocialLink
 from open_event.models.track import Track
+from open_event.models.event_copyright import EventCopyright as Copyright
 
 
 def create_event(name='TestEvent', creator_email=None):
     """Creates Event and returns its `id`.
     :param name Name of Event
     """
+    copyright = Copyright(holder='copyright holder')
     event = Event(name=name,
                   start_time=datetime(2016, 4, 8, 12, 30, 45),
-                  end_time=datetime(2016, 4, 9, 12, 30, 45))
+                  end_time=datetime(2016, 4, 9, 12, 30, 45),
+                  copyright=copyright)
     if creator_email:
         event.creator = User.query.filter_by(email=creator_email).first()
     save_to_db(event, 'Event saved')


### PR DESCRIPTION
Fixes provided by @aviaryan : https://github.com/fossasia/open-event-orga-server/pull/1430 with some changes mentioned [here](https://github.com/fossasia/open-event-orga-server/pull/1430#issuecomment-230558837).

One thing, I've updated the tests as well, so create_event binds a copyright to it. This is to reflect the apis. If you give a copyright:null in a post request it would create an empty `<EventCopyright None>` object and bind it to event (after the changes in this pr). But since we are directly creating an event in the database (not through apis) it should have an `<EventCopyright>` object, event if it's empty. 

You can test them first locally.

edit: One question, why do we have a validate param for DAO create and update. Aren't they already being validated.