### PR TITLE
Fix Bad Request for ots16 sample set

### DIFF
--- a/open_event/static/js/admin/event/importEvent.js
+++ b/open_event/static/js/admin/event/importEvent.js
@@ -6,6 +6,8 @@ function importEventZip(){
     });
 
     $('#import_status').text('Working...');
+    $('#import_error').text('');
+    $('#btnImportEvent').prop('disabled', true);
     jQuery.ajax({
         url: '/api/v2/events/import/json',
         data: data,
@@ -22,6 +24,7 @@ function importEventZip(){
             obj = JSON.parse(x.responseText);
             console.log(obj);
             $('#import_status').text('');
+            $('#btnImportEvent').prop('disabled', false);
             $('#import_error').text(obj['message']);
         }
     });

--- a/samples/ots16/event.json
+++ b/samples/ots16/event.json
@@ -56,5 +56,6 @@
     "state": "Completed",
     "ticket_url": "http://www.eventnook.com/event/ots16/register",
     "topic": "Science & Technology",
+    "sub_topic": "",
     "type": "Conference"
 }


### PR DESCRIPTION
https://github.com/fossasia/open-event-orga-server/issues/1516

@aviaryan There was no sub_topic field in the event sample. So after it was imported, it was not set. You can see the sub_topic field as empty (not "Choice..") in the edit page. So after POST, the backed never gets the sub_topic form field. Hence the 400. I've also made the Create Event button in import modal to disable while import is being performed and the error message to reset with a new import action.