### PR TITLE
Replace Licence lightbox with Slide-list 

### DIFF
--- a/open_event/helpers/static.py
+++ b/open_event/helpers/static.py
@@ -11,7 +11,7 @@ EVENT_LICENCES = {
     'All rights reserved': (
         'All rights reserved',
         u'The copyright holder reserves, or holds for their own use, all the rights provided by copyright law under one specific copyright treaty.',
-        '',
+        'https://en.wikipedia.org/wiki/All_rights_reserved',
         '',
         ''),
     'Attribution': (

--- a/open_event/templates/gentelella/admin/event/wizard/step-1.html
+++ b/open_event/templates/gentelella/admin/event/wizard/step-1.html
@@ -316,6 +316,15 @@
         </div>
         <div class="item form-group">
             <label>License of Event Data and Content <a class="btn btn-info btn-xs licence-help" data-toggle="licence-modal" data-target="#licence_modal">?</a></label>
+            <div id="licence-list" style="display: none;">
+                <ul style="background-color: #f2f2f2; padding-left: 28px; padding-bottom: 5px; padding-top: 5px; border-radius: 1px;">
+                {% for licence_name, info in event_licences.iteritems() %}
+                    <li>
+                        <a href="{{ info.2 }}" target="_blank">{{ licence_name }}</a>
+                    </li>
+                {% endfor %}
+                </ul>
+            </div>
             <select name="copyright_licence" class="form-control">
                 <option value="">Choose Licence</option>
                 {{ event_licences }}
@@ -325,37 +334,6 @@
                     </option>
                 {% endfor %}
             </select>
-
-            <!-- Licences Modal -->
-            <div id="licence_modal" class="modal fade" role="dialog">
-                <div class="modal-dialog">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal">&times;</button>
-                        <h4 class="modal-title">Licences</h4>
-                      </div>
-                      <div class="modal-body">
-                      {% for licence_name, info in event_licences.iteritems() %}
-                         <div class="row">
-                             <div class="col-sm-9">
-                                <h5>{{ licence_name }}</h5>
-                                <p>{{ info.1 }}
-                                    {% if info.2 %}
-                                    <a href="{{ info.2 }}" target="_blank" style="color:#1a75ff;">Read more.</a>
-                                    {% endif %}
-                                </p>
-                             </div>
-                             <div class="col-sm-3">
-                            {% if info.3 %}
-                                <img src="{{ info.3 }}" alt="{{ licence_name }}" class="pull-right">
-                            {% endif %}
-                             </div>
-                         </div>
-                      {% endfor %}
-                      </div>
-                    </div>
-                </div>
-            </div>
         </div>
 
     </div>
@@ -513,7 +491,7 @@
         });
 
         $(".licence-help").click(function () {
-            $("#licence_modal").modal('show');
+            $("#licence-list").slideToggle();
         });
 
         var sub_topics = {{event_sub_topics|safe}};


### PR DESCRIPTION
https://github.com/fossasia/open-event-orga-server/issues/1397#issuecomment-231566376

@mariobehling It replaces this:

![](https://cloud.githubusercontent.com/assets/7882752/16622669/9276dbe6-43b8-11e6-9949-f44289e4b802.png)

with this:

![out](https://cloud.githubusercontent.com/assets/7882752/16893506/bd6e411c-4b57-11e6-92c6-a7315a957623.gif)

which are links to the licence information. Also I've added https://en.wikipedia.org/wiki/All_rights_reserved as a link to all rights reserved, since it was empty. 