### PR TITLE
Export meta.json in event zip

### DIFF
--- a/app/api/helpers/export_helpers.py
+++ b/app/api/helpers/export_helpers.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import requests
+from flask import request
 from flask_restplus import marshal
 
 from ..events import DAO as EventDAO, EVENT, \
@@ -89,6 +90,15 @@ def _download_media(data, srv, dir_path, settings):
             pass
 
 
+def _generate_meta():
+    """
+    Generate Meta information for export
+    """
+    d = {}
+    d['root_url'] = request.url_root
+    return d
+
+
 def export_event_json(event_id, settings):
     """
     Exports the event as a zip on the server and return its path
@@ -111,6 +121,11 @@ def export_event_json(event_id, settings):
         fp = open(dir_path + '/' + e[0] + '.json', 'w')
         fp.write(data_str)
         fp.close()
+    # add meta
+    data_str = json.dumps(_generate_meta(), sort_keys=True, indent=4)
+    fp = open(dir_path + '/meta.json', 'w')
+    fp.write(data_str)
+    fp.close()
     # make zip
     shutil.make_archive(dir_path, 'zip', dir_path)
     return os.path.realpath('.') + '/' + dir_path + '.zip'

--- a/tests/api/test_export_import.py
+++ b/tests/api/test_export_import.py
@@ -107,7 +107,7 @@ class TestEventExport(ImportExportBase):
 
     def test_export_media(self):
         """
-        test successful export of media
+        test successful export of media (and more)
         """
         resp = self._put(get_path(1), {'logo': 'https://placehold.it/350x150'})
         self.assertIn('placehold', resp.data, resp.data)
@@ -118,6 +118,9 @@ class TestEventExport(ImportExportBase):
         obj = json.loads(data)
         logo_data = open(dr + obj['logo'], 'r').read()
         self.assertTrue(len(logo_data) > 10)
+        # test meta.json
+        data = open(dr + '/meta.json', 'r').read()
+        self.assertIn('http', data)
 
     def test_export_settings_marshal(self):
         """


### PR DESCRIPTION
Fixes #1745 

For now, meta.json looks like 

```js
{
    "root_url": "http://open-event-dev.heroku.com/"
}
```

@niranjan94 @mariobehling please review