### PR TITLE
Restrict private fields in Speaker API from showing to unauthorized users

### DIFF
--- a/app/api/helpers/helpers.py
+++ b/app/api/helpers/helpers.py
@@ -64,6 +64,7 @@ def get_list_or_404(klass, **kwargs):
         raise NotFoundError(message='Object list is empty')
     return obj_list
 
+
 def get_object_or_404(klass, id_):
     """Returns a specific object of a model class given its identifier. In case
     the object is not found, 404 is returned.

--- a/tests/api/test_get_api_200.py
+++ b/tests/api/test_get_api_200.py
@@ -2,7 +2,7 @@ import unittest
 
 from tests.setup_database import Setup
 from tests.utils import OpenEventTestCase
-from tests.auth_helper import register, login
+from tests.auth_helper import register, logout
 from tests.api.utils import get_path, create_event, create_services
 
 from app import current_app as app
@@ -27,7 +27,6 @@ class TestGetApi(OpenEventTestCase):
         contains event/service name.
         """
         with app.test_request_context():
-            login(self.app, u'test@example.com', u'test')
             response = self.app.get(path, follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             for string in strings:
@@ -51,7 +50,13 @@ class TestGetApi(OpenEventTestCase):
 
     def test_speaker_api(self):
         path = get_path(1, 'speakers', 1)
-        self._test_path(path, 'TestSpeaker_1')
+        # logged in and check
+        self._test_path(path, 'TestSpeaker_1', 'email', 'mobile')
+        # logged out, private fields not present
+        logout(self.app)
+        resp = self.app.get(path)
+        self.assertNotIn('email', resp.data)
+        self.assertNotIn('mobile', resp.data)
 
     def test_sponsor_api(self):
         path = get_path(1, 'sponsors', 1)


### PR DESCRIPTION
Fixes #1870 

Mobile and email fields in Speaker API are omitted if an unauthorized user is accessing the data. 

PS - No change has been made in the export module and it exports the complete dataset as suggested at https://github.com/fossasia/open-event-orga-server/issues/1870#issuecomment-235412884 . 
If we need to protect the exported data, we can think of using some sort of encryption or similar technique in the future. 
