### PR TITLE
Fix version update issue in event API

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -205,9 +205,7 @@ class EventDAO(BaseDAO):
 LinkDAO = SocialLinkDAO(SocialLinkModel, SOCIAL_LINK_POST)
 DAO = EventDAO(EventModel, EVENT_POST)
 CopyrightDAO = BaseDAO(EventCopyright, EVENT_COPYRIGHT)
-CopyrightDAO.version_key = 'event_ver'
 CFSDAO = BaseDAO(EventCFS, EVENT_CFS)  # CFS = Call For Speakers
-CFSDAO.version_key = 'event_ver'
 
 # DEFINE PARAMS
 


### PR DESCRIPTION
PR #1939 added this issue. The 2 lines which I have deleted in this PR were unnecessary because the Copyright and CFS update will have to go through Event API were version is automatically updated. 
Updating version through CFSDAO and CopyrightDAO in turn causes event not found error because event has not been saved when they are created. 

This bug happens when importing an event with 'call_for_papers' information in a Postgres database. 
The tests weren't able to catch it because they run on SQLite. 

@shivamMg @niranjan94 please merge