### PR TITLE
Heroku One Click Deploy Patched

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,10 +25,10 @@
   ],
   "buildpacks":[
       {
-          "url":"heroku/nodejs"
+          "url":"heroku/python"
       },
       {
-          "url":"heroku/python"
+          "url":"heroku/nodejs"
       }
     ],
   "scripts": {

--- a/app.json
+++ b/app.json
@@ -19,6 +19,18 @@
       "generator": "secret"
     }
   },
+  "addons":[
+      "heroku-postgresql:hobby-dev",
+      "heroku-redis:hobby-dev"
+  ],
+  "buildpacks":[
+      {
+          "url":"heroku/nodejs"
+      },
+      {
+          "url":"heroku/python"
+      }
+    ],
   "scripts": {
     "postdeploy": "python create_db.py"
   }


### PR DESCRIPTION
The previous Heroku deploy using the button did not work properly because it didn't list out all the steps like in doc/heroku.md 
I have added the following :
- Addons:
    - Postgres:hobby-dev
    - Redis:hobby-dev
- Buildpacks (In same order as mentioned in the docs)

(Above changes are in app.json)
This should fix the one click heroku button deploy