### PR TITLE
Run notification mark as read as AJAX

### DIFF
--- a/app/templates/gentelella/admin/profile/notifications.html
+++ b/app/templates/gentelella/admin/profile/notifications.html
@@ -117,7 +117,12 @@ Notifications
 
         $("body").click(function(e) {
             if($(e.target).is('a.read-btn')) {
-                return true;
+                e.preventDefault(); // prevent href behavior
+                $.getJSON($(e.target).attr('href'), function(data){
+                  console.log(data['status']);
+                  $(e.target).parents('.notification').removeClass('info'); // show notification as read
+                  $(e.target).remove(); // delete mark as read button
+                });
             }else if (e.target.class == "notification" || $(e.target).parents(".notification").size()) {
                 var read_button = $(e.target).parents(".notification").find('a.read-btn');
                 $.getJSON(read_button.attr('href'), function(data){


### PR DESCRIPTION
Fixes #1968 

After a notification is marked as read, an AJAX request to mark the notification read is sent in the background. When it finishes, "Mark as Read" button disappears and notification changes color from blue to white showing it has been read.

![after-read](https://cloud.githubusercontent.com/assets/4047597/17275428/1e203d70-5725-11e6-89bd-a349fc6841d5.png)


@shivamMg please review 

 
