### PR TITLE
Fix for Ticket Time fields

### DIFF
--- a/app/templates/gentelella/admin/event/wizard/step-1.html
+++ b/app/templates/gentelella/admin/event/wizard/step-1.html
@@ -803,7 +803,11 @@
 
         /* Bind datepicker to dates */
         $ticketMore.find("input.date").datepicker();
-        $ticketMore.find("input.time").timepicker();
+        $ticketMore.find("input.time").timepicker({
+            'showDuration': true,
+            'timeFormat': 'H:i',
+            'scrollDefault': 'now'
+        });
 
         /* Bind events to Edit and Remove buttons */
         var $ticketEdit = $ticket.children("td").last().children().children().first();


### PR DESCRIPTION
Creation of event is currently failing because the time (ticket sales start and end) sent by the form are in incorrect format. They should in 24 hour format.