### PR TITLE
Make API response view in export event scrollable

### DIFF
--- a/app/templates/gentelella/admin/event/export/export.html
+++ b/app/templates/gentelella/admin/event/export/export.html
@@ -28,7 +28,9 @@
         .boolean { color: blue; }
         .null { color: magenta; }
         .key { color: red; }
-
+        #json-response {
+          max-height: 650px;
+        }
     </style>
 {% endblock %}
 


### PR DESCRIPTION
Fixes #1988 

![scroll-api-response](https://cloud.githubusercontent.com/assets/4047597/17303718/7aeb87d8-583f-11e6-98f6-582a6af853b0.png)
