### PR TITLE
Make the event background more visible in the event page

### DIFF
--- a/app/templates/gentelella/guest/event/base.html
+++ b/app/templates/gentelella/guest/event/base.html
@@ -11,7 +11,7 @@
     <style type="text/css">
         .carousel .item {
             height: {{ carousel_height }}px;
-            background: linear-gradient(rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.8)), url('{% if event.background_url %}{{ event.background_url }}{% elif event.topic%}{{ url_for("static", filename="placeholders/" + placeholder_images[event.topic])}}{% elif event.subtopic %}{{ url_for("static", filename="placeholders/" + placeholder_images[event.subtopic])}}{% else %}{{url_for("static", filename="placeholders/" + placeholder_images["Other"])}}{% endif %}');
+            background: linear-gradient(rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.7)), url('{% if event.background_url %}{{ event.background_url }}{% elif event.topic%}{{ url_for("static", filename="placeholders/" + placeholder_images[event.topic])}}{% elif event.subtopic %}{{ url_for("static", filename="placeholders/" + placeholder_images[event.subtopic])}}{% else %}{{url_for("static", filename="placeholders/" + placeholder_images["Other"])}}{% endif %}');
             background-size: cover;
         }
 


### PR DESCRIPTION
Resolves #1995.

![screenshot 2](https://cloud.githubusercontent.com/assets/2404372/17337648/51f24f8e-5901-11e6-841b-0c7332790ce6.png)

@rafalkowalski @mariobehling @SaptakS please review and merge