### PR TITLE
Fix locale error on certain linux hosts, install redis at docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,12 @@ RUN echo "listen_addresses='*'" >> /etc/postgresql/$PG_VERSION/main/postgresql.c
 RUN echo "host    all             all             all                     md5" >> "/etc/postgresql/$PG_VERSION/main/pg_hba.conf"
 RUN echo "client_encoding = utf8" >> "/etc/postgresql/$PG_VERSION/main/postgresql.conf"
 EXPOSE 5432
-RUN service postgresql restart
-RUN localedef -v -c -i en_US -f UTF-8 en_US.UTF-8; exit 0
+# gen utf-8 locale
+#RUN localedef -v -c -i en_US -f UTF-8 en_US.UTF-8; exit 0
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 #add database user
 USER postgres
 RUN /etc/init.d/postgresql start \
@@ -40,6 +44,8 @@ RUN /etc/init.d/postgresql start \
 USER root
 #install dependencies
 RUN pip install -r requirements/prod.txt
+#setup redis
+RUN bash run_redis.sh
 #set environment
 EXPOSE 80 5000
 RUN chmod 0755 *.sh

--- a/run.sh
+++ b/run.sh
@@ -3,10 +3,9 @@ export DATABASE_URL=postgresql://open_event_user:start@127.0.0.1:5432/test
 postgres -D /usr/local/pgsql/data >logfile 2>&1 &
 service postgresql restart
 python create_db.py
-# run redis (can take some time first time as redis will be downloaded)
-# It is recommended you run 'bash run_redis.sh' in another terminal windows
-# first to have it downloaded.
-bash run_redis.sh &
+# download and run redis
+bash run_redis.sh
+redis-3.2.1/src/redis-server &
 # run worker
 celery worker -A app.celery &
 # run app

--- a/run_redis.sh
+++ b/run_redis.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
-# This script downloads and runs redis-server.
-# If redis has been already downloaded, it just runs it
+# This script downloads and installs redis-server.
+# If redis has been already installed, it skips it
 if [ ! -d redis-3.2.1/src ]; then
     wget http://download.redis.io/releases/redis-3.2.1.tar.gz
     tar xzf redis-3.2.1.tar.gz
     rm redis-3.2.1.tar.gz
     cd redis-3.2.1
     make
-else
-    cd redis-3.2.1
 fi
-src/redis-server


### PR DESCRIPTION
Fixes #2031 

In addition to that, I also added the step of installing redis server in docker build. This is to avoid downloading and installling redis each time the container is run. (this will save time) 
