### PR TITLE
Added query params to order_by column in Sessions API

### DIFF
--- a/app/api/helpers/query_filters.py
+++ b/app/api/helpers/query_filters.py
@@ -135,7 +135,11 @@ def sessions_end_time_lt(value, query):
 
 
 def sessions_order_by(value, query):
-    return query.order_by(value.replace('.', ' '))
+    col, direction = value.split('.')
+    col = getattr(Session, col)
+    if direction == 'desc':
+        col = col.desc()
+    return query.order_by(col)
 
 
 #######

--- a/app/api/helpers/query_filters.py
+++ b/app/api/helpers/query_filters.py
@@ -80,7 +80,7 @@ def event_search_location(value, query):
 
 
 def get_query_close_area(lng, lat):
-    up_lat =  lat + 0.249788
+    up_lat = lat + 0.249788
     bottom_lat = lat - 0.249788
     left_lng = lng - 0.249788
     right_lng = lng + 0.249788
@@ -134,6 +134,10 @@ def sessions_end_time_lt(value, query):
     return query.filter(Session.end_time <= DateTime().from_str(value))
 
 
+def sessions_order_by(value, query):
+    return query.order_by(value.replace('.', ' '))
+
+
 #######
 # ADD CUSTOM FILTERS TO LIST
 #######
@@ -153,4 +157,5 @@ FILTERS_LIST = {
     '__sessions_start_time_lt': sessions_start_time_lt,
     '__sessions_end_time_gt': sessions_end_time_gt,
     '__sessions_end_time_lt': sessions_end_time_lt,
+    '__sessions_order_by': sessions_order_by
 }

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -201,6 +201,9 @@ SESSIONS_PARAMS = {
     'start_time_lt': {},
     'end_time_gt': {},
     'end_time_lt': {},
+    'order_by': {
+        'description': 'Order by a field, example "start_time.asc" or "end_time.desc"'
+    }
 }
 
 # #########
@@ -217,6 +220,7 @@ class SessionResource():
     session_parser.add_argument('start_time_lt', dest='__sessions_start_time_lt')
     session_parser.add_argument('end_time_gt', dest='__sessions_end_time_gt')
     session_parser.add_argument('end_time_lt', dest='__sessions_end_time_lt')
+    session_parser.add_argument('order_by', dest='__sessions_order_by')
 
 
 @api.route('/events/<int:event_id>/sessions/<int:session_id>')

--- a/tests/api/test_get_list_queries.py
+++ b/tests/api/test_get_list_queries.py
@@ -107,6 +107,24 @@ class TestGetListQueries(OpenEventTestCase):
                 resp = self.app.get(path + '?%s=2015-05-12T00:00:00' % _)
                 self.assertIn('TestSession', resp.data)
 
+    def test_session_order_by(self):
+        with app.test_request_context():
+            path = get_path(1, 'sessions')
+            self._post(path, POST_SESSION_DATA)
+            # 2016-05-30 8:47 to 9:47
+            new_data = POST_SESSION_DATA.copy()
+            new_data['start_time'] = '2016-05-30T10:47:37'
+            new_data['end_time'] = '2016-05-30T11:47:37'
+            self._post(path, new_data)
+            # check ordering
+            data = json.loads(self.app.get(path + '?order_by=start_time.asc').data)
+            self.assertEqual(data[0]['id'], 1)
+            self.assertEqual(data[1]['id'], 2)
+            # order reverse
+            data = json.loads(self.app.get(path + '?order_by=start_time.desc').data)
+            self.assertEqual(data[0]['id'], 2)
+            self.assertEqual(data[1]['id'], 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2099 

Examples
```
http://localhost:5000/api/v2/events/1/sessions?end_time_gt=2016-05-05T15%3A30%3A00&order_by=start_time.desc

http://localhost:5000/api/v2/events/1/sessions?order_by=end_time.asc
```