### PR TITLE
Base sales tab and event-wise sales view

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,6 @@ import warnings
 from flask.exthook import ExtDeprecationWarning
 from forex_python.converter import CurrencyCodes
 from pytz import utc
-
 warnings.simplefilter('ignore', ExtDeprecationWarning)
 # Keep it before flask extensions are imported
 import arrow
@@ -36,6 +35,7 @@ import sqlalchemy as sa
 from nameparser import HumanName
 import stripe
 from app.helpers.flask_helpers import SilentUndefined, camel_case, slugify, MiniJSONEncoder
+from app.helpers.payment import forex
 from app.models import db
 from app.models.user import User
 from app.models.event import Event
@@ -242,7 +242,7 @@ def flask_helpers():
     def current_date(format='%a, %B %d %I:%M %p', **kwargs):
         return (datetime.now() + timedelta(**kwargs)).strftime(format)
 
-    return dict(string_empty=string_empty, current_date=current_date)
+    return dict(string_empty=string_empty, current_date=current_date, forex=forex)
 
 
 @app.context_processor

--- a/app/helpers/payment.py
+++ b/app/helpers/payment.py
@@ -6,12 +6,23 @@ import stripe
 from flask import url_for, current_app
 
 import requests
+from forex_python.converter import CurrencyRates
 
+from app.helpers.cache import cache
 from app.helpers.data_getter import DataGetter
 from app.helpers.data import save_to_db
 from app.helpers.helpers import represents_int
 from app.models.stripe_authorization import StripeAuthorization
 from app.settings import get_settings
+
+@cache.memoize(50)
+def forex(from_currency, to_currency, amount):
+    try:
+        currency_rates = CurrencyRates()
+        return currency_rates.convert(from_currency, to_currency, amount)
+    except:
+        return amount
+
 
 class StripePaymentsManager(object):
 

--- a/app/templates/gentelella/admin/event/tickets/orders.html
+++ b/app/templates/gentelella/admin/event/tickets/orders.html
@@ -85,7 +85,7 @@
             <tr>
                 <td></td>
                 <td>
-                    <a href="#" class="order-link">{{ order.get_invoice_number() }}</a> -
+                    <a href="{{ url_for('ticketing.view_order_after_payment', order_identifier=order.identifier) if order.status == 'completed' else url_for('ticketing.show_transaction_error', order_identifier=order.identifier) }}" class="order-link">{{ order.get_invoice_number() }}</a> -
                     by {{ order.user.user_detail.fullname if order.user.user_detail and order.user.user_detail.fullname else order.user.email }}
                     <br>
                     {% if order.status == 'completed' %}

--- a/app/templates/gentelella/admin/super_admin/dashboard.html
+++ b/app/templates/gentelella/admin/super_admin/dashboard.html
@@ -23,6 +23,7 @@
 {% set navigation_bar = [
 ('/admin/', 'home', 'Admin', 'Dashboard'),
 ('/admin/events/', 'events', 'Events', 'Manage All Events'),
+('/admin/sales/', 'sales', 'Sales', 'View all Sales'),
 ('/admin/sessions/', 'sessions', 'Sessions', 'Manage All Sessions'),
 ('/admin/users/', 'users', 'Users', 'Manage All Users'),
 ('/admin/permissions/', 'permissions', 'Permissions', 'Manage All Permissions'),

--- a/app/templates/gentelella/admin/super_admin/sales/by_events.html
+++ b/app/templates/gentelella/admin/super_admin/sales/by_events.html
@@ -1,0 +1,127 @@
+{% extends 'gentelella/admin/super_admin/sales/sales_base.html' %}
+
+{% set active_side_page = "by_events" %}
+
+
+{% block head_css %}
+    {{ super() }}
+    <style type="text/css">
+            #tickets-summary-table tr, #tickets-summmary-table th {
+            text-align: right;
+            font-size: 15px;
+
+        }
+
+        #tickets-summary-table th {
+            text-align: center;
+            border-left: 1px solid #ddd;
+            border-top: 1px solid #ddd;
+        }
+
+        #tickets-summary-table th[rowspan="2"]:nth-child(1) {
+            text-align: left;
+            vertical-align: bottom;
+            border-left-color: transparent;
+            border-top-color: transparent;
+        }
+
+        #tickets-summary-table td {
+            text-align: center;
+            border-left: 1px solid #ddd;
+        }
+
+        #tickets-summary-table td:nth-child(1) {
+            text-align: left;
+            border-left-color: transparent;
+        }
+
+        #tickets-summary-table tfoot th {
+            border-top: 2px solid #ddd;
+            border-right-color: transparent;
+            border-left-color: transparent;
+        }
+
+    </style>
+{% endblock %}
+
+{% block inner_content %}
+    <h3>Tickets Summary</h3>
+    <div class="col-md-12">
+        <table class="table no-global-dt" id="tickets-summary-table">
+            <thead>
+            <tr>
+                <th rowspan="2">
+                    Event
+                </th>
+                <th colspan="2" class="success">
+                    Completed Orders
+                </th>
+                <th colspan="2" class="warning">
+                    Pending Orders
+                </th>
+            </tr>
+            <tr class="active">
+                <th>
+                    Tickets
+                </th>
+                <th>
+                    Sales
+                </th>
+                <th>
+                    Tickets
+                </th>
+                <th>
+                    Sales
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for id, item in tickets_summary.iteritems() %}
+
+                <tr>
+                    <td>
+                        {{ item.name }}
+                    </td>
+                    <td>
+                        {{ item.completed.tickets_count }}
+                    </td>
+                    <td>
+                        {{ display_currency | currency_symbol }}{{ forex(item.payment_currency, display_currency, item.completed.sales) | money }}
+                    </td>
+                    <td>
+                        {{ item.pending.tickets_count }}
+                    </td>
+                    <td>
+                        {{ display_currency | currency_symbol }}{{ forex(item.payment_currency, display_currency, item.pending.sales) | money }}
+                    </td>
+                </tr>
+            {% endfor %}
+
+            </tbody>
+            <tfoot>
+            <tr>
+                <th>
+                    Total
+                </th>
+                <th>
+                    {{ orders_summary.completed.tickets_count }}
+                </th>
+                <th>
+                    {{ display_currency | currency_symbol }}{{ orders_summary.completed.total_sales | money }}
+                </th>
+                <th>
+                    {{ orders_summary.pending.tickets_count }}
+                </th>
+                <th>
+                    {{ display_currency | currency_symbol }}{{ orders_summary.pending.total_sales | money }}
+                </th>
+            </tr>
+            </tfoot>
+        </table>
+    </div>
+
+{% endblock %}
+{% block tail_js %}
+    {{ super() }}
+{% endblock %}
+

--- a/app/templates/gentelella/admin/super_admin/sales/sales_base.html
+++ b/app/templates/gentelella/admin/super_admin/sales/sales_base.html
@@ -1,0 +1,44 @@
+{% extends 'gentelella/admin/super_admin/dashboard.html' %}
+
+{% block title %}
+    Sales
+{% endblock %}
+
+{% set active_page = "sales" %}
+
+{% set side_bar = [
+    ('/events/' ~ event.id ~ '/tickets', 'by_events', 'By Events'),
+    ('/events/' ~ event.id ~ '/tickets/orders', 'by_organizer', 'By Organizer'),
+    ('/events/' ~ event.id ~ '/tickets/attendees', 'by_location', 'By Location'),
+    ('/events/' ~ event.id ~ '/tickets/discounts', 'fees', 'Fees'),
+    ('/events/' ~ event.id ~ '/tickets/add-order', 'fees_status', 'Fees Status'),
+] -%}
+
+{% set active_side_page = active_side_page|default('home') -%}
+
+
+{% block head_css %}
+    {{ super() }}
+{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-md-2 col-xs-12">
+            <div class="list-group">
+                {% for href, id, caption in side_bar %}
+                    <a class="list-group-item {% if id == active_side_page %}active{% endif %}" href="{{ href|e }}">{{ caption|e }} <i class="fa fa-caret-right fa-lg pull-right" style="margin-top: 3px;"></i> </a>
+                {% endfor %}
+            </div>
+
+        </div>
+        <div class="col-md-10 col-xs-12">
+            {% block inner_content %}
+
+            {% endblock %}
+        </div>
+    </div>
+{% endblock %}
+{% block tail_js %}
+    {{ super() }}
+{% endblock %}
+

--- a/app/views/admin/admin.py
+++ b/app/views/admin/admin.py
@@ -18,6 +18,7 @@ from app.views.admin.models_views.speakers import SpeakersView
 from app.views.admin.home import MyHomeView
 from app.views.admin.models_views.sponsors import SponsorsView
 from app.views.admin.models_views.ticket_sales import TicketSalesView
+from app.views.admin.super_admin.sales import SuperAdminSalesView
 from app.views.public.event_detail import EventDetailView
 from app.views.public.explore import ExploreView
 from app.views.public.pages import BasicPagesView
@@ -90,6 +91,7 @@ class AdminView(object):
         self.admin.add_view(SuperAdminMessagesView(name='Messages', url='/admin/messages', endpoint="sadmin_messages"))
         self.admin.add_view(SuperAdminModulesView(name='Modules', url='/admin/modules', endpoint="sadmin_modules"))
         self.admin.add_view(SuperAdminContentView(name='Content', url='/admin/content', endpoint="sadmin_content"))
+        self.admin.add_view(SuperAdminSalesView(name='Sales', url='/admin/sales', endpoint="sadmin_sales"))
 
     @staticmethod
     def init_login(app):

--- a/app/views/admin/models_views/ticket_sales.py
+++ b/app/views/admin/models_views/ticket_sales.py
@@ -81,7 +81,8 @@ class TicketSalesView(BaseView):
                 orders_summary[str(order.status)]['tickets_count'] += order_ticket.quantity
                 ticket = self.get_ticket(order_ticket.ticket_id)
                 tickets_summary[str(ticket.id)][str(order.status)]['tickets_count'] += order_ticket.quantity
-                tickets_summary[str(ticket.id)][str(order.status)]['sales'] += order_ticket.quantity * ticket.price
+                if order.paid_via != 'free' and order.amount > 0:
+                    tickets_summary[str(ticket.id)][str(order.status)]['sales'] += order_ticket.quantity * ticket.price
 
         return self.render('/gentelella/admin/event/tickets/tickets.html', event=event, event_id=event_id,
                            orders_summary=orders_summary, tickets_summary=tickets_summary)

--- a/app/views/admin/super_admin/sales.py
+++ b/app/views/admin/super_admin/sales.py
@@ -1,0 +1,85 @@
+from flask_admin import expose
+
+from app import forex
+from app.helpers.data_getter import DataGetter
+from app.helpers.ticketing import TicketingManager
+from app.models.ticket import Ticket
+from app.views.admin.super_admin.super_admin_base import SuperAdminBaseView
+from app.helpers.cache import cache
+
+class SuperAdminSalesView(SuperAdminBaseView):
+
+    display_currency = 'USD'
+
+    @cache.memoize(50)
+    def get_ticket(self, ticket_id):
+        return Ticket.query.get(ticket_id)
+
+    @expose('/')
+    def sales_by_events_view(self):
+        events = DataGetter.get_all_events()
+        orders = TicketingManager.get_orders()
+
+        completed_count = 0
+        completed_amount = 0
+        tickets_count = 0
+
+        orders_summary = {
+            'completed': {
+                'class': 'success',
+                'tickets_count': 0,
+                'orders_count': 0,
+                'total_sales': 0
+            },
+            'pending': {
+                'class': 'warning',
+                'tickets_count': 0,
+                'orders_count': 0,
+                'total_sales': 0
+            },
+            'expired': {
+                'class': 'danger',
+                'tickets_count': 0,
+                'orders_count': 0,
+                'total_sales': 0
+            }
+        }
+
+        tickets_summary = {}
+        for event in events:
+            tickets_summary[str(event.id)] = {
+                'name': event.name,
+                'payment_currency': event.payment_currency,
+                'completed': {
+                    'tickets_count': 0,
+                    'sales': 0
+                },
+                'pending': {
+                    'tickets_count': 0,
+                    'sales': 0
+                },
+                'expired': {
+                    'class': 'danger',
+                    'tickets_count': 0,
+                    'sales': 0
+                }
+            }
+
+        for order in orders:
+            if order.status == 'initialized':
+                order.status = 'pending'
+            orders_summary[str(order.status)]['orders_count'] += 1
+            orders_summary[str(order.status)]['total_sales'] += forex(order.event.payment_currency,
+                                                                      self.display_currency, order.amount)
+            for order_ticket in order.tickets:
+                orders_summary[str(order.status)]['tickets_count'] += order_ticket.quantity
+                ticket = self.get_ticket(order_ticket.ticket_id)
+                tickets_summary[str(order.event_id)][str(order.status)]['tickets_count'] += order_ticket.quantity
+                if order.paid_via != 'free' and order.amount > 0:
+                    tickets_summary[str(order.event_id)][str(order.status)]['sales'] += order_ticket.quantity \
+                                                                                        * ticket.price
+
+        return self.render('/gentelella/admin/super_admin/sales/by_events.html',
+                           tickets_summary=tickets_summary,
+                           display_currency=self.display_currency,
+                           orders_summary=orders_summary)


### PR DESCRIPTION
Partial resolution of #2024. (only event-wise sales view has been added now)

All the sales amounts are converted to `USD` from their respective currencies and displayed. 

**Currency Rates Source:** [Fixer.io](http://fixer.io/) - a free API for current and historical foreign exchange rates published by European Central Bank. The rates are updated daily 3PM CET.

#### Screenshot:
![capture](https://cloud.githubusercontent.com/assets/2404372/17562370/3bed67a8-5f48-11e6-9e88-320cd9e9dbc6.PNG)


