### PR TITLE
Display 'No new notifications' message for empty dropdown

### DIFF
--- a/app/templates/gentelella/admin/menu.html
+++ b/app/templates/gentelella/admin/menu.html
@@ -94,6 +94,10 @@
                                         </a>
                                     </li>
                                 {% endfor %}
+                            {% else %}
+                                <li>
+                                    <div class="text-center">No new notifications</div>
+                                </li>
                             {% endif %}
                             </ul>
                         </li>


### PR DESCRIPTION
Fixes: https://github.com/fossasia/open-event-orga-server/issues/2189

@niranjan94 Please take a look.

![screenshot from 2016-08-13 18 08 08](https://cloud.githubusercontent.com/assets/7882752/17643232/423d5fe2-6181-11e6-85a4-5851d04097f9.png)