### PR TITLE
Export speaker photo with their name

### DIFF
--- a/app/api/helpers/export_helpers.py
+++ b/app/api/helpers/export_helpers.py
@@ -72,7 +72,7 @@ DOWNLOAD_FIEDLS = {
         'slides': ['document', '/slides/session_%d']
     },
     'speakers': {
-        'photo': ['image', '/images/speakers/photo_%d']
+        'photo': ['image', '/images/speakers/%s_%d']
     },
     'event': {
         'logo': ['image', '/images/logo'],
@@ -118,7 +118,9 @@ def _download_media(data, srv, dir_path, settings):
         if not settings[DOWNLOAD_FIEDLS[srv][i][0]]:
             continue
         path = DOWNLOAD_FIEDLS[srv][i][1]
-        if srv != 'event':
+        if srv == 'speakers':
+            path = path % (make_speaker_name(data['name']), data['id'])
+        elif srv != 'event':
             path = path % (data['id'])
         if data[i].find('.') > -1:  # add extension
             ext = data[i].rsplit('.', 1)[1]
@@ -220,3 +222,10 @@ def send_export_mail(event_id, result):
     else:
         event_name = event.name
     send_email_after_export(job.user_email, event_name, result)
+
+
+# FIELD DATA FORMATTERS
+
+def make_speaker_name(name):
+    """Make speaker image filename for export"""
+    return ''.join(s.title() for s in name.split() if s)

--- a/tests/api/test_export_import.py
+++ b/tests/api/test_export_import.py
@@ -113,6 +113,8 @@ class TestEventExport(ImportExportBase):
         """
         resp = self._put(get_path(1), {'logo': 'https://placehold.it/350x150'})
         self.assertIn('placehold', resp.data, resp.data)
+        # set speaker photo so that its export is checked
+        resp = self._put(get_path(1, 'speakers', 1), {'photo': 'https://placehold.it/350x150'})
         self._create_set()
         dr = 'static/temp/test_event_import'
         data = open(dr + '/event', 'r').read()


### PR DESCRIPTION
Fixes #2169 

Speaker photos are export as `FirstnameSecondname_ID.ext` 

