### PR TITLE
Fix application error on /admin

### DIFF
--- a/app/helpers/data_getter.py
+++ b/app/helpers/data_getter.py
@@ -41,7 +41,7 @@ from ..models.fees import TicketFees
 from ..models.order import Order
 from .language_list import LANGUAGE_LIST
 from .static import EVENT_TOPICS, EVENT_LICENCES, PAYMENT_COUNTRIES, PAYMENT_CURRENCIES, DEFAULT_EVENT_IMAGES
-from app.helpers.helpers import get_event_id, string_empty, represents_int
+from app.helpers.helpers import get_event_id, string_empty, represents_int, get_count
 from flask.ext import login
 from flask import flash, abort
 import datetime
@@ -749,16 +749,17 @@ class DataGetter(object):
 
     @staticmethod
     def get_all_super_admins():
-        return len(User.query.filter_by(is_super_admin=True).all())
+        return get_count(User.query.filter_by(is_super_admin=True))
 
     @staticmethod
     def get_all_admins():
-        return len(User.query.filter_by(is_admin=True).all())
+        return get_count(User.query.filter_by(is_admin=True))
 
     @staticmethod
     def get_all_registered_users():
-        return len(User.query.filter_by(is_verified=True).all())
+        return get_count(User.query.filter_by(is_verified=True))
 
+    # TODO Make this more efficient
     @staticmethod
     def get_all_organizers():
         events = Event.query.all()
@@ -771,6 +772,7 @@ class DataGetter(object):
 
         return len(organizers)
 
+    # TODO Make this more efficient
     @staticmethod
     def get_all_co_organizers():
         events = Event.query.all()
@@ -783,6 +785,7 @@ class DataGetter(object):
 
         return len(co_organizers)
 
+    # TODO Make this more efficient
     @staticmethod
     def get_all_track_organizers():
         events = Event.query.all()
@@ -809,28 +812,28 @@ class DataGetter(object):
 
     @staticmethod
     def get_all_accepted_sessions():
-        return len(Session.query.filter_by(state='accepted').all())
+        return get_count(Session.query.filter_by(state='accepted'))
 
     @staticmethod
     def get_all_rejected_sessions():
-        return len(Session.query.filter_by(state='rejected').all())
+        return get_count(Session.query.filter_by(state='rejected'))
 
     @staticmethod
     def get_all_draft_sessions():
-        return len(Session.query.filter_by(state='pending').all())
+        return get_count(Session.query.filter_by(state='pending'))
 
     @staticmethod
     def get_email_by_times():
         email_times = []
-        email_in_last_24 = len(
-            Mail.query.filter(datetime.datetime.now() - Mail.time <= datetime.timedelta(hours=24)).all())
-        email_in_last_3_days = len(
-            Mail.query.filter(datetime.datetime.now() - Mail.time <= datetime.timedelta(days=3)).all())
-        email_in_last_7_days = len(
-            Mail.query.filter(datetime.datetime.now() - Mail.time <= datetime.timedelta(days=7)).all())
-        email_in_last_30_days = len(
-            Mail.query.filter(datetime.datetime.now() - Mail.time <= datetime.timedelta(days=30)).all())
-        total_emails = len(Mail.query.all())
+        email_in_last_24 = get_count(
+            Mail.query.filter(datetime.datetime.now() - Mail.time <= datetime.timedelta(hours=24)))
+        email_in_last_3_days = get_count(
+            Mail.query.filter(datetime.datetime.now() - Mail.time <= datetime.timedelta(days=3)))
+        email_in_last_7_days = get_count(
+            Mail.query.filter(datetime.datetime.now() - Mail.time <= datetime.timedelta(days=7)))
+        email_in_last_30_days = get_count(
+            Mail.query.filter(datetime.datetime.now() - Mail.time <= datetime.timedelta(days=30)))
+        total_emails = get_count(Mail.query)
 
         email_times.append(email_in_last_24)
         email_times.append(email_in_last_3_days)

--- a/app/views/admin/super_admin/super_admin.py
+++ b/app/views/admin/super_admin/super_admin.py
@@ -19,7 +19,7 @@ class SuperAdminView(SuperAdminBaseView):
         organizers = DataGetter.get_all_organizers()
         co_organizers = DataGetter.get_all_co_organizers()
         track_organizers = DataGetter.get_all_track_organizers()
-        attendees= DataGetter.get_all_attendees()
+        attendees = DataGetter.get_all_attendees()
         accepted_sessions = DataGetter.get_all_accepted_sessions()
         rejected_sessions = DataGetter.get_all_rejected_sessions()
         draft_sessions = DataGetter.get_all_draft_sessions()

--- a/app/views/admin/super_admin/super_admin.py
+++ b/app/views/admin/super_admin/super_admin.py
@@ -16,10 +16,11 @@ class SuperAdminView(SuperAdminBaseView):
         super_admins = DataGetter.get_all_super_admins()
         admins = DataGetter.get_all_admins()
         registered_users = DataGetter.get_all_registered_users()
-        organizers = []
-        co_organizers = []
-        track_organizers = []
-        attendees = []
+        # TODO Fix function and correct this
+        organizers = 0
+        co_organizers = 0
+        track_organizers = 0
+        attendees = 0
         accepted_sessions = DataGetter.get_all_accepted_sessions()
         rejected_sessions = DataGetter.get_all_rejected_sessions()
         draft_sessions = DataGetter.get_all_draft_sessions()

--- a/app/views/admin/super_admin/super_admin.py
+++ b/app/views/admin/super_admin/super_admin.py
@@ -2,7 +2,7 @@ from flask_admin import expose
 
 from app.views.admin.super_admin.super_admin_base import SuperAdminBaseView
 from ....helpers.data_getter import DataGetter
-from app.helpers.helpers import get_latest_heroku_release, get_commit_info
+from app.helpers.helpers import get_latest_heroku_release, get_commit_info, get_count
 
 
 class SuperAdminView(SuperAdminBaseView):
@@ -10,16 +10,16 @@ class SuperAdminView(SuperAdminBaseView):
     @expose('/')
     def index_view(self):
         events = DataGetter.get_all_events()[:5]
-        number_live_events = DataGetter.get_all_live_events().count()
-        number_draft_events = DataGetter.get_all_draft_events().count()
-        number_past_events = DataGetter.get_all_past_events().count()
+        number_live_events = get_count(DataGetter.get_all_live_events())
+        number_draft_events = get_count(DataGetter.get_all_draft_events())
+        number_past_events = get_count(DataGetter.get_all_past_events())
         super_admins = DataGetter.get_all_super_admins()
         admins = DataGetter.get_all_admins()
         registered_users = DataGetter.get_all_registered_users()
-        organizers = DataGetter.get_all_organizers()
-        co_organizers = DataGetter.get_all_co_organizers()
-        track_organizers = DataGetter.get_all_track_organizers()
-        attendees = DataGetter.get_all_attendees()
+        organizers = []
+        co_organizers = []
+        track_organizers = []
+        attendees = []
         accepted_sessions = DataGetter.get_all_accepted_sessions()
         rejected_sessions = DataGetter.get_all_rejected_sessions()
         draft_sessions = DataGetter.get_all_draft_sessions()


### PR DESCRIPTION
Resolves #2223. 

The error was due to high memory usage as pointed out by @SaptakS . The high memeory usage was due to some pretty inefficient queries on `app/views/admin/super_admin/super_admin.py`. 

Everyone, please use the `get_count` method from `app/helpers/helpers.py` and pass it an SQLAlchemy query to make any row counts. 

This is not a complete fix yet, the methods `get_all_organizers`, `get_all_co_organizers`, `get_all_track_organizers`, and `get_all_attendees` in `app/helpers/data_getter.py` that are used to get a count of the same need to be rewritten more efficiently. And will do the same. 

@rafalkowalski @mariobehling @SaptakS please review and merge. 



