### PR TITLE
Optimized image sizes

### DIFF
--- a/app/helpers/data.py
+++ b/app/helpers/data.py
@@ -1029,6 +1029,11 @@ class DataManager(object):
                                          thumbnail_height=200)
                 save_to_db(image_sizes, "Image Sizes Saved")
             if temp_background:
+                im = Image.open(temp_background[len('/serve_'):])
+                out_im = temp_background[len('/serve_'):].replace('png', 'jpg')
+                bg = Image.new("RGB", im.size, (255, 255, 255))
+                bg.paste(im, (0, 0), im)
+                bg.save(out_im, quality=55)
                 filename = '{}.png'.format(time.time())
                 filepath = '{}/static/{}'.format(path.realpath('.'),
                            temp_background[len('/serve_static/'):])
@@ -1038,6 +1043,11 @@ class DataManager(object):
                     UPLOAD_PATHS['event']['background_url'].format(
                         event_id=event.id
                     ))
+
+                filename = '{}.jpg'.format(time.time())
+                filepath = '{}/static/{}'.format(path.realpath('.'),
+                           temp_background[len('/serve_static/'):])
+                background_file = UploadedFile(filepath, filename)
 
                 temp_img_file = upload_local(background_file,
                                              'events/{event_id}/temp'.format(event_id=int(event.id)))


### PR DESCRIPTION
#2346 #2019 

@mariobehling @niranjan94 I couldn't reduce the size of the uploaded image because due to some reason converting it to jpg was giving error. So instead I generated the 3 new images (Large, Thumbnail, Icon) in JPG format and downscaled them.

Now, for example, if you upload an image of 150 KB,

Uploaded Image(full) - 1MB
Large - 100KB
Thumbnail - 20KB
Icon - 5KB

@mariobehling please review