### PR TITLE
Provide proper content-type for s3 upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update
 # update some packages
 RUN apt-get install -y wget git ca-certificates curl && update-ca-certificates && apt-get clean -y
 # install deps
-RUN apt-get install -y --no-install-recommends build-essential python-dev libpq-dev libevent-dev && apt-get clean -y
+RUN apt-get install -y --no-install-recommends build-essential python-dev libpq-dev libevent-dev libmagic-dev && apt-get clean -y
 # nodejs bower
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash && apt-get install -y --force-yes nodejs && apt-get clean -y
 # ^^ https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -51,3 +51,4 @@ Flask-Cache
 forex-python
 oauth2
 qrcode
+python-magic


### PR DESCRIPTION
Attempts to resolve #2424 .
Library used : https://github.com/ahupp/python-magic

Sample image with proper Content-Type : 
https://s3-us-west-2.amazonaws.com/opevorga/events/1/background/WUdDYkdNc0/1475011859.25.png