### PR TITLE
librabbitmq version set to 1.5.1

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -43,7 +43,7 @@ stripe
 xhtml2pdf
 nameparser
 pillow
-librabbitmq
+librabbitmq==1.5.1
 anyjson
 mako
 functools32


### PR DESCRIPTION
librabbitmq version 1.6.1 build-out fails in Fedora ( [issue](https://github.com/celery/librabbitmq/issues/61) ). So hardcoding the version of librabbitmq to 1.5.1 for the time in which it works fine.