### PR TITLE
Add Twitter card analytics

### DIFF
--- a/app/templates/gentelella/guest/event/base.html
+++ b/app/templates/gentelella/guest/event/base.html
@@ -19,6 +19,15 @@
 {% block head_meta %}
     {# Facebook Open Graph Tags #}
     <meta property="fb:app_id" content="{{ fb_app_id | default('', true) }}"/>
+
+    {# Twitter Card Tags Start #}
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@fossasia"/>
+    <meta name="twitter:title" content="{{ event.name }}"/>
+    <meta name="twitter:description" content="{{ event.description }}"/>
+    <meta name="twitter:image" content="{{ event_image | external_url }}"/>
+    {# Twitter Card Tags Over #}
+
     <meta property="og:title" content="{{ event.name }}"/>
     <meta property="og:site_name" content="Organizer Server"/>
     <meta property="og:url" content="{{ request.url }}"/>


### PR DESCRIPTION
Intends to resolve #2145 .

Do we collect the info about event's official twitter handle or the organiser's twitter handle ?

Though definitely not necessary, If we do have some such info it would help in managing the organiser in managing twitter card analytics by changing the `twitter:site` tag , refer https://dev.twitter.com/cards/analytics#card-types.

Right now the default is fossasia's official twitter handle.