### PR TITLE
Temporarily disabling robot tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 # command to run tests
 script:
   - nosetests tests/unittests --with-coverage
-  - robot -v BROWSER:phantomjs tests/robot
+#  - robot -v BROWSER:phantomjs tests/robot
 # upload coverage
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
There seems to be some weird issues on Travis with Robot tests causing builds to fail from time to time. (Inconsistent. A build restart fixes it). 

We don't have any robot tests other than a basic login. So temporarily disabling it on travis will not impact us in any way as we still have our python unittest suits

@mariobehling @SaptakS please review and merge