### PR TITLE
fix pycrypto installation fail

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -43,7 +43,7 @@ pycountry
 stripe
 xhtml2pdf
 nameparser
-pillow
+pillow==3.4.1
 librabbitmq==1.5.1
 anyjson
 mako


### PR DESCRIPTION
On docker installation, the pillow-3.4.2 released on Oct 17, 2016 breaks Fabric-1.11.1 (which requires pycrypto-2.6.1)

Error log,
```sh
Collecting pycrypto!=2.4,<3.0,>=2.1 (from paramiko<2.0,>=1.10->Fabric==1.11.1->-r requirements/prod.txt (line 4))
  Downloading pycrypto-2.6.1.tar.gz (446kB)
Installing collected packages: itsdangerous, ..., pillow, ..., Fabric
...
  Running setup.py install for pillow: started
    Running setup.py install for pillow: finished with status 'error'
    Complete output from command /usr/local/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-rhENMK/pillow/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-9x_yy4-record/install-record.txt --single-version-externally-managed --compile:
...

    reading manifest file 'Pillow.egg-info/SOURCES.txt'
    reading manifest template 'MANIFEST.in'
    warning: no files found matching '*.sh'
    no previously-included directories found matching 'docs/_static'
    warning: no previously-included files found matching '.coveragerc'
    warning: no previously-included files found matching '.editorconfig'
    warning: no previously-included files found matching '.landscape.yaml'
    warning: no previously-included files found matching 'appveyor.yml'
    warning: no previously-included files found matching 'build_children.sh'
    warning: no previously-included files found matching 'tox.ini'
    warning: no previously-included files matching '.git*' found anywhere in distribution
    warning: no previously-included files matching '*.pyc' found anywhere in distribution
    warning: no previously-included files matching '*.so' found anywhere in distribution
    writing manifest file 'Pillow.egg-info/SOURCES.txt'
    copying PIL/OleFileIO-README.md -> build/lib.linux-x86_64-2.7/PIL
    running build_ext
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-rhENMK/pillow/setup.py", line 753, in <module>
        zip_safe=not debug_build(), )
      File "/usr/local/lib/python2.7/distutils/core.py", line 151, in setup
        dist.run_commands()
      File "/usr/local/lib/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python2.7/site-packages/setuptools/command/install.py", line 61, in run
        return orig.install.run(self)
      File "/usr/local/lib/python2.7/distutils/command/install.py", line 563, in run
        self.run_command('build')
      File "/usr/local/lib/python2.7/distutils/cmd.py", line 326, in run_command
        self.distribution.run_command(command)
      File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python2.7/distutils/command/build.py", line 127, in run
        self.run_command(cmd_name)
      File "/usr/local/lib/python2.7/distutils/cmd.py", line 326, in run_command
        self.distribution.run_command(command)
      File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python2.7/distutils/command/build_ext.py", line 339, in run
        self.build_extensions()
      File "/tmp/pip-build-rhENMK/pillow/setup.py", line 521, in build_extensions
        ' using --disable-%s, aborting' % (f, f))
    ValueError: jpeg is required unless explicitly disabled using --disable-jpeg, aborting
```

For whatever reason it could be, specify the previous pillow release fix this break.