### PR TITLE
UI for datetime made responsive

### DIFF
--- a/app/templates/gentelella/admin/event/wizard/step-1.html
+++ b/app/templates/gentelella/admin/event/wizard/step-1.html
@@ -22,7 +22,7 @@
 
 <div>
     <div class="col-md-8 col-md-push-2">
-        <div class="item form-group">
+        <div class="item row form-group">
             <label>Name <span class="required">*</span></label>
             <input required="required"
                    data-error="Event name is required"
@@ -31,7 +31,7 @@
 
         </div>
 
-        <div class="form-group">
+        <div class="row form-group">
             <label>Location</label>
             <input value="{{ event.location_name | default('', true) }}" name="location_name" id="location_name"
                    placeholder="Location is required to make event live"
@@ -39,7 +39,7 @@
         </div>
         <a id="show_addr" onclick="show_map_holder();" style="cursor:pointer;">Enter Address</a>
 
-        <div id="map-holder" style="display:none;">
+        <div class="row" id="map-holder" style="display:none;">
             <div class="col-md-6">
                 <div class="item form-group">
                     <input value="" name="street_number" id="street_number" class="form-control col-md-3 col-xs-12"
@@ -86,7 +86,7 @@
             </div>
             <br>
             <br>
-        </div>
+        </div><br><br>
 
         <div class="row event-date-picker">
             <div class="col-md-4">


### PR DESCRIPTION
Before:

![selection_005](https://cloud.githubusercontent.com/assets/9530293/19796021/d8b10c72-9cfe-11e6-826f-8545e1f6b188.png)

After:

![selection_004](https://cloud.githubusercontent.com/assets/9530293/19796024/e280b266-9cfe-11e6-8286-f5f38babe64e.png)

Fixes #2504 

@niranjan94 @mariobehling please review
