### PR TITLE
System image page : add helper text and maintain image proportions

### DIFF
--- a/app/templates/gentelella/admin/menu.html
+++ b/app/templates/gentelella/admin/menu.html
@@ -41,7 +41,16 @@
                                 {%  elif current_user.user_detail.avatar_uploaded %}
                                 <img src="{{ current_user.user_detail.avatar_uploaded }}" onerror="imgError(this)"/>
                                 {% else %}
-                                <img src="{{ url_for('static', filename='/placeholders/avatar.png') }}" onerror="imgError(this)"/>
+                                  {% set vars = {'foo': False} %}
+                                  {% for custom_image in custom_placeholder %}
+                                    {% if custom_image.name == "Avatar" %}
+                                      <img src='{{ custom_image.url }}' />
+                                      {% if vars.update({'foo': True}) %} {% endif %}
+                                    {% endif %}
+                                  {% endfor %}
+                                  {% if not vars.foo %}
+                                    <img src="{{ url_for('static', filename='/placeholders/avatar.png') }}" onerror="imgError(this)"/>
+                                  {% endif %}
                                 {% endif %}
                                 <span class="user-text">{{ current_user.user_detail.firstname | default(current_user.email, true) }}</span>
                                 <span class=" fa fa-angle-down"></span>

--- a/app/templates/gentelella/admin/super_admin/content/_system_images.html
+++ b/app/templates/gentelella/admin/super_admin/content/_system_images.html
@@ -66,7 +66,7 @@
                     </label><br>
                 </div>
                 <span class="text-muted" style="color: #a2a2a2;">
-                    {{_("We recommend using at least a 1300x550px (2:1 ratio) image")}}<br>{{_("that's no larger than 10MB")}}.
+                    {{_("For Cover Photos : We recommend using at least a 1300x550px (2:1 ratio) image")}}<br>{{_("For Avatar Photos : We recommend using at least a 360x360px (1:1 ratio) image")}}<br>{{_("The images should be no larger than 10MB")}}.
                 </span>
             </div>
 

--- a/app/templates/gentelella/admin/super_admin/content/_system_images.html
+++ b/app/templates/gentelella/admin/super_admin/content/_system_images.html
@@ -17,7 +17,7 @@
                 <b>{{ subtopic }}</b>
               {% for custom_image in custom_placeholder %}
                 {% if custom_image.name == subtopic %}
-                  <img src='{{ custom_image.url }}' style="width:80%; " id="image-{{ subtopic | replace(',', '') | replace('&', '') | replace(' ','_')}}"/>
+                  <img src='{{ custom_image.url }}' style="max-width:80%; " id="image-{{ subtopic | replace(',', '') | replace('&', '') | replace(' ','_')}}"/>
                   {% if vars.update({'foo': True}) %} {% endif %}
                   {% if custom_image.copyright %}
                     <p><b>{{_("Copyright Info")}}:</b> {{ custom_image.copyright }}</p>
@@ -28,7 +28,7 @@
                 {% endif %}
               {% endfor %}
                 {% if not vars.foo %}
-                  <img src='{{ url_for("static", filename="placeholders/" + placeholder_images[subtopic]) }}' style="width:80%; " id="image-{{ subtopic | replace(',', '') | replace('&', '') | replace(' ','_')}}"/>
+                  <img src='{{ url_for("static", filename="placeholders/" + placeholder_images[subtopic]) }}' style="max-width:80%; " id="image-{{ subtopic | replace(',', '') | replace('&', '') | replace(' ','_')}}"/>
                 {% endif %}
                 <br>
                 <button class="btn btn-primary btn-sys" id="sys-{{ subtopic | replace(',', '') |replace('&', '') | replace(' ','_')}}" style="margin-top:10px;"> {{_("Change")}}</button>


### PR DESCRIPTION
regarding #2308 ,

resolves 

> The user placeholder displayed is too big and out of proportions

and 

> The upload dialog box is not displaying the correct dimensions required for the profile placeholder image

![selection_016](https://cloud.githubusercontent.com/assets/13910561/20223058/bf4d73aa-a85d-11e6-930c-fb0f3d7ac98c.png)


![selection_015](https://cloud.githubusercontent.com/assets/13910561/20223059/bf7493ae-a85d-11e6-8c97-70e341fb5bbc.png)
