### PR TITLE
Ticket sales timings fixed

### DIFF
--- a/app/templates/gentelella/admin/event/wizard/step-1.html
+++ b/app/templates/gentelella/admin/event/wizard/step-1.html
@@ -1381,6 +1381,8 @@ payment and indicate your order ref. no.&#13;&#10;&#13;&#10;Account Details&#13;
         }
         $($ticket.children()[1]).html(html);
 
+        $ticketMore.find('.ticket-sales.date.end').val($("input[name=end_date]").val());
+        $ticketMore.find('.ticket-sales.time.end').val($("input[name=end_time]").val());
         /* Append ticket to table */
         $ticket.hide();
         $ticketMore.hide();

--- a/app/templates/gentelella/admin/event/wizard/wizard.html
+++ b/app/templates/gentelella/admin/event/wizard/wizard.html
@@ -163,7 +163,7 @@
                                         <input value="{{ sales_start.strftime('%m/%d/%Y') if sales_start else current_date.strftime('%m/%d/%Y') }}" class="form-control col-xs-6 date start" placeholder="MM/DD/YYYY" name="tickets[sales_start_date]">
                                     </div>
                                     <div class="col-xs-5">
-                                        <input value="{{ sales_start.strftime('%H:%M') if sales_start else '19:00' }}" class="form-control col-xs-6 time start ui-timepicker-input" placeholder="HH:MM" autocomplete="off" name="tickets[sales_start_time]">
+                                        <input value="{{ sales_start.strftime('%H:%M') if sales_start else current_date.strftime('%H:%M') }}" class="form-control col-xs-6 time start ui-timepicker-input" placeholder="HH:MM" autocomplete="off" name="tickets[sales_start_time]">
                                     </div>
                                 </div>
                                 {# Calculate default Ticket Sales End date #}
@@ -177,10 +177,10 @@
                                 <div class="item form-group">
                                     <label>{{_("Sales End")}}</label><br>
                                     <div class="col-xs-7" style="padding: 0;">
-                                        <input value="{{ sales_end_date }}" class="form-control col-xs-6 date end" placeholder="MM/DD/YYYY" name="tickets[sales_end_date]">
+                                        <input value="{{ sales_end_date }}" class="form-control col-xs-6 date end ticket-sales" placeholder="MM/DD/YYYY" name="tickets[sales_end_date]">
                                     </div>
                                     <div class="col-xs-5">
-                                        <input value="{{ sales_end.strftime('%H:%M') if sales_end else '22:00' }}" class="form-control col-xs-6 time end ui-timepicker-input" placeholder="HH:MM" autocomplete="off" name="tickets[sales_end_time]">
+                                        <input value="{{ sales_end.strftime('%H:%M') if sales_end else '22:00' }}" class="form-control col-xs-6 ticket-sales time end ui-timepicker-input" placeholder="HH:MM" autocomplete="off" name="tickets[sales_end_time]">
                                     </div>
                                 </div>
                                 <div class="item form-group">


### PR DESCRIPTION
Resolves #2543.

> When I fill in the ticketing and do not change the timing, the ticket sales should start immediately. The time that ticket sales start, should be set to the "current time". If the user changes the time him/herself of course the sale should start according to what the user sets.

- [x] Done

> The end time of the ticket sales should be set to the end time of the event as a standard.

- [x] Done

> Apparently the ticketing time is not set to the same timezone as the event time. Ticketing time should be in the same timezone

Seems to be correct already.

@mariobehling @SaptakS please review and merge

