### PR TITLE
Remove old version of gcloud in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ addons:
     - libffi-dev
 python:
   - "2.7"
-cache:
-  directories:
-  - "$HOME/google-cloud-sdk/"
 install:
 - pip install -r requirements/tests.txt
 # Environment variables

--- a/kubernetes/deployment/deploy.sh
+++ b/kubernetes/deployment/deploy.sh
@@ -5,12 +5,15 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_REPO_SLUG" != "fossasia/open-
     exit 0
 fi
 
-if ! type "kubectl" > /dev/null; then
-  rm -rf $HOME/google-cloud-sdk/
-  curl https://sdk.cloud.google.com | bash;
-  gcloud components install kubectl
-fi
-gcloud components update
+sudo rm -f /usr/bin/git-credential-gcloud.sh
+sudo rm -f /usr/bin/bq
+sudo rm -f /usr/bin/gsutil
+sudo rm -f /usr/bin/gcloud
+
+curl https://sdk.cloud.google.com | bash;
+source ~/.bashrc
+gcloud components install kubectl
+
 gcloud config set compute/zone us-west1-a
 # Decrypt the credentials we added to the repo using the key we added with the Travis command line tool
 openssl aes-256-cbc -K $encrypted_27e15b7757b4_key -iv $encrypted_27e15b7757b4_iv -in eventyay-8245fde7ab8a.json.enc -out eventyay-8245fde7ab8a.json -d

--- a/kubernetes/image/Dockerfile
+++ b/kubernetes/image/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Niranjan Rajendran <niranjan94@yahoo.com>
 ENV REPOSITORY https://github.com/fossasia/open-event-orga-server.git
 ENV BRANCH development
 
-ENV COMMIT_HASH $COMMIT_HASH
+ARG COMMIT_HASH
 
 # apt-get update
 RUN apt-get clean -y && apt-get update -y


### PR DESCRIPTION
Travis has an old version `gcloud` causing issue during auto deployment to GCE. So, now removing the old version before installing the new one.

@mariobehling @SaptakS please review and merge