### PR TITLE
Remove 'account information' tab

### DIFF
--- a/app/templates/gentelella/admin/settings/base.html
+++ b/app/templates/gentelella/admin/settings/base.html
@@ -15,7 +15,6 @@
     ('/settings/contact-info', 'contact_info', 'Contact Info', 'Contact Info'),
     ('/settings/password/', 'password', 'Password', 'Your Password'),
     ('/settings/email-preferences/', 'email_preferences', 'Email Preferences', 'Email Preferences'),
-    ('/settings/', 'account_info', 'Account Information', 'Account Information')
 ] -%}
 
 {% set active_page = active_page|default('account_info') -%}


### PR DESCRIPTION
Resolves #2301

Other websites seem to have what we already have in the 'Contact Info' tab in the account information tab. So, I don't think we need that tab as of now.
