### PR TITLE
Added super() call

### DIFF
--- a/app/templates/gentelella/guest/event/base.html
+++ b/app/templates/gentelella/guest/event/base.html
@@ -21,6 +21,7 @@
 {% endif %}
 
 {% block head_meta %}
+    {{ super() }}
     {# Facebook Open Graph Tags #}
     <meta property="fb:app_id" content="{{ fb_app_id | default('', true) }}"/>
 


### PR DESCRIPTION
`{{ super() }}` is missing in the public event pages for the `meta` block. Resulting in the viewport meta tag not being rendered. This is causing the page to be rendered with the incorrect viewport setting on mobiles.