### PR TITLE
external link does not appear on page after social link given

### DIFF
--- a/app/helpers/wizard/event.py
+++ b/app/helpers/wizard/event.py
@@ -124,10 +124,11 @@ def save_event_from_json(json, event_id=None):
         abort(400)
 
     event.name = event_data['name']
-    if not event_data['event_url'].startswith("http"):
-        event.event_url = "https://" + event_data['event_url']
-    else:
-        event.event_url = event_data['event_url']
+    if event_data['event_url'].strip() != "":
+        if not event_data['event_url'].startswith("http"):
+            event.event_url = "https://" + event_data['event_url']
+        else:
+            event.event_url = event_data['event_url']
     event.location_name = event_data['location_name']
     event.show_map = 1 if event_data['show_map'] else 0
     event.start_time = start_time


### PR DESCRIPTION
fixed issue #2749 
along with External event url appearing on page, when social link is given, even when the external link is left blank