### PR TITLE
Generate navigation_bar list in the views itself

### DIFF
--- a/app/templates/gentelella/admin/super_admin/dashboard.html
+++ b/app/templates/gentelella/admin/super_admin/dashboard.html
@@ -18,19 +18,6 @@
         }
     </style>
 {% endblock %}
-{% set navigation_bar = [
-    ('/admin/', 'home', 'Admin', 'Dashboard'),
-    ('/admin/events/', 'events', 'Events', 'Manage All Events'),
-    ('/admin/sales/', 'sales', 'Sales', 'View all Sales'),
-    ('/admin/sessions/', 'sessions', 'Sessions', 'Manage All Sessions'),
-    ('/admin/users/', 'users', 'Users', 'Users'),
-    ('/admin/permissions/', 'permissions', 'Permissions', 'Permissions'),
-    ('/admin/messages/', 'messages', 'Messages', 'System Messages'),
-    ('/admin/reports/', 'reports', 'Reports', 'Reports'),
-    ('/admin/settings/', 'settings', 'Settings', 'Settings'),
-    ('/admin/modules/', 'modules', 'Modules', 'Modules'),
-    ('/admin/content/', 'content', 'Content', 'Content')
-    ] -%}
 {% set active_page = active_page|default('home') -%}
 {% macro tabs() %}
     <ul class="nav nav-tabs bar_tabs right admin_tabs" role="tablist"

--- a/app/views/super_admin/__init__.py
+++ b/app/views/super_admin/__init__.py
@@ -30,6 +30,20 @@ PANEL_LIST = [
     CONTENT,
 ]
 
+NAVIGATION_BAR = {
+    'admin': ('/admin/', 'home', 'Admin', 'Dashboard'),
+    'events': ('/admin/events/', 'events', 'Events', 'Manage All Events'),
+    'sales': ('/admin/sales/', 'sales', 'Sales', 'View all Sales'),
+    'sessions': ('/admin/sessions/', 'sessions', 'Sessions', 'Manage All Sessions'),
+    'users': ('/admin/users/', 'users', 'Users', 'Users'),
+    'permissions': ('/admin/permissions/', 'permissions', 'Permissions', 'Permissions'),
+    'messages': ('/admin/messages/', 'messages', 'Messages', 'System Messages'),
+    'reports': ('/admin/reports/', 'reports', 'Reports', 'Reports'),
+    'settings': ('/admin/settings/', 'settings', 'Settings', 'Settings'),
+    'modules': ('/admin/modules/', 'modules', 'Modules', 'Modules'),
+    'content': ('/admin/content/', 'content', 'Content', 'Content')
+}
+
 
 def check_accessible(panel_name):
     if not AuthManager.is_accessible():
@@ -37,3 +51,13 @@ def check_accessible(panel_name):
     else:
         if not current_user.can_access_panel(panel_name) and not current_user.is_staff:
             abort(403)
+
+
+def list_navbar():
+    navigation_bar = []
+    for panel_name in PANEL_LIST:
+        if current_user.can_access_panel(panel_name) or current_user.is_staff:
+            navigation_bar.append(NAVIGATION_BAR[panel_name])
+
+    return navigation_bar
+

--- a/app/views/super_admin/content.py
+++ b/app/views/super_admin/content.py
@@ -17,7 +17,7 @@ from app.helpers.helpers import uploaded_file
 from app.helpers.storage import upload, UploadedFile
 from app.models.custom_placeholder import CustomPlaceholder
 from app.settings import get_settings, set_settings
-from app.views.super_admin import check_accessible, CONTENT
+from app.views.super_admin import check_accessible, CONTENT, list_navbar
 from config import basedir, LANGUAGES
 
 BASE_TRANSLATIONS_DIR = str(basedir) + "/app/translations"
@@ -50,7 +50,7 @@ def index_view():
     return render_template(
         'gentelella/admin/super_admin/content/content.html', pages=pages, settings=settings,
         placeholder_images=placeholder_images, subtopics=subtopics, custom_placeholder=custom_placeholder,
-        languages=languages_copy
+        languages=languages_copy, navigation_bar=list_navbar()
     )
 
 
@@ -130,7 +130,7 @@ def details_view(page_id):
     pages = DataGetter.get_all_pages()
     return render_template('gentelella/admin/super_admin/content/content.html',
                            pages=pages,
-                           current_page=page)
+                           current_page=page, navigation_bar=list_navbar())
 
 
 @sadmin_content.route('/pages/<page_id>/trash/', methods=['GET'])

--- a/app/views/super_admin/dep_settings.py
+++ b/app/views/super_admin/dep_settings.py
@@ -8,7 +8,7 @@ from app.helpers.data import save_to_db, delete_from_db
 from app.helpers.data_getter import DataGetter
 from app.models.image_sizes import ImageSizes
 from app.settings import get_settings, set_settings
-from app.views.super_admin import SETTINGS, check_accessible
+from app.views.super_admin import SETTINGS, check_accessible, list_navbar
 from app.views.users.events import get_module_settings
 
 sadmin_settings = Blueprint('sadmin_settings', __name__, url_prefix='/admin/settings')
@@ -126,5 +126,6 @@ def index_view():
         image_config=image_config,
         super_admin_email=DataGetter.get_super_admin_user().email,
         event_image_sizes=event_image_sizes,
-        profile_image_sizes=profile_image_sizes
+        profile_image_sizes=profile_image_sizes,
+        navigation_bar=list_navbar()
     )

--- a/app/views/super_admin/events.py
+++ b/app/views/super_admin/events.py
@@ -3,7 +3,7 @@ from flask import render_template
 
 from app.helpers.data_getter import DataGetter
 from app.helpers.ticketing import TicketingManager
-from app.views.super_admin import EVENTS, check_accessible
+from app.views.super_admin import EVENTS, check_accessible, list_navbar
 
 sadmin_events = Blueprint('sadmin_events', __name__, url_prefix='/admin/events')
 
@@ -44,4 +44,5 @@ def index_view():
                            donation_ticket_count=donation_ticket_count,
                            max_free_ticket=max_free_ticket,
                            max_paid_ticket=max_paid_ticket,
-                           max_donation_ticket=max_donation_ticket)
+                           max_donation_ticket=max_donation_ticket,
+                           navigation_bar=list_navbar())

--- a/app/views/super_admin/messages.py
+++ b/app/views/super_admin/messages.py
@@ -6,7 +6,7 @@ from app.helpers.data import DataManager
 from app.helpers.data_getter import DataGetter
 from app.helpers.system_mails import MAILS
 from app.helpers.system_notifications import NOTIFS
-from app.views.super_admin import MESSAGES, check_accessible
+from app.views.super_admin import MESSAGES, check_accessible, list_navbar
 
 sadmin_messages = Blueprint('sadmin_messages', __name__, url_prefix='/admin/messages')
 
@@ -23,7 +23,8 @@ def index_view():
         'gentelella/admin/super_admin/messages/messages.html',
         mails=MAILS,
         notifications=NOTIFS,
-        message_settings=message_settings
+        message_settings=message_settings,
+        navigation_bar=list_navbar()
     )
 
 

--- a/app/views/super_admin/modules.py
+++ b/app/views/super_admin/modules.py
@@ -5,7 +5,7 @@ from flask import request
 from app.helpers.data import save_to_db
 from app.helpers.data_getter import DataGetter
 from app.models.modules import Module
-from app.views.super_admin import MODULES, check_accessible
+from app.views.super_admin import MODULES, check_accessible, list_navbar
 
 sadmin_modules = Blueprint('sadmin_modules', __name__, url_prefix='/admin/modules')
 
@@ -29,4 +29,4 @@ def index_view():
         module.donation_include = True if form.get('donations') == 'on' else False
         save_to_db(module)
 
-    return render_template('gentelella/admin/super_admin/modules/modules.html', module=module)
+    return render_template('gentelella/admin/super_admin/modules/modules.html', module=module,navigation_bar=list_navbar())

--- a/app/views/super_admin/my_sessions.py
+++ b/app/views/super_admin/my_sessions.py
@@ -3,7 +3,7 @@ from flask import Blueprint
 from flask import render_template
 
 from app.helpers.data_getter import DataGetter
-from app.views.super_admin import check_accessible, SESSIONS
+from app.views.super_admin import check_accessible, SESSIONS, list_navbar
 from app.views.super_admin.content import sadmin_content
 
 sadmin_sessions = Blueprint('sadmin_sessions', __name__, url_prefix='/admin/sessions')
@@ -29,4 +29,5 @@ def display_my_sessions_view():
                            all_pending=all_pending,
                            all_accepted=all_accepted,
                            all_rejected=all_rejected,
-                           all_trashed=all_trashed)
+                           all_trashed=all_trashed,
+                           navigation_bar=list_navbar())

--- a/app/views/super_admin/permissions.py
+++ b/app/views/super_admin/permissions.py
@@ -6,7 +6,7 @@ from app.helpers.data import DataManager
 from app.helpers.data_getter import DataGetter
 from app.models.system_role import CustomSysRole
 from app.models.user import SYS_ROLES_LIST
-from app.views.super_admin import PERMISSIONS, check_accessible, PANEL_LIST
+from app.views.super_admin import PERMISSIONS, check_accessible, PANEL_LIST, list_navbar
 
 sadmin_permissions = Blueprint('sadmin_permissions', __name__, url_prefix='/admin/permissions')
 
@@ -61,7 +61,8 @@ def index_view():
         custom_sys_perms=custom_sys_perms,
         builtin_sys_perms=builtin_sys_perms,
         user_perms=user_perms,
-        panel_list=PANEL_LIST)
+        panel_list=PANEL_LIST,
+        navigation_bar=list_navbar())
 
 
 @sadmin_permissions.route('/event-roles', methods=('POST', 'GET'))

--- a/app/views/super_admin/reports.py
+++ b/app/views/super_admin/reports.py
@@ -2,7 +2,7 @@ from flask import Blueprint
 from flask import render_template
 
 from app.helpers.data_getter import DataGetter
-from app.views.super_admin import REPORTS, check_accessible
+from app.views.super_admin import REPORTS, check_accessible, list_navbar
 from app.helpers.deployment.heroku import HerokuApi
 from app.helpers.deployment.kubernetes import KubernetesApi
 
@@ -40,7 +40,8 @@ def index_view():
         logplex_url=logplex_url,
         on_kubernetes=on_kubernetes,
         pods_info=pods_info,
-        activities=activities
+        activities=activities,
+        navigation_bar=list_navbar()
     )
 
 

--- a/app/views/super_admin/sales.py
+++ b/app/views/super_admin/sales.py
@@ -19,7 +19,7 @@ from app.helpers.ticketing import TicketingManager
 from app.models.system_role import CustomSysRole, UserSystemRole
 from app.models.user import User
 from app.views.super_admin import SALES
-from app.views.super_admin import check_accessible
+from app.views.super_admin import check_accessible, list_navbar
 
 display_currency = 'USD'
 
@@ -214,7 +214,8 @@ def sales_by_marketer_view(by_discount_code=False):
                            from_date=from_date,
                            to_date=to_date,
                            key_name='marketers' if not by_discount_code else 'discount codes',
-                           orders_summary=orders_summary)
+                           orders_summary=orders_summary,
+                           navigation_bar=list_navbar())
 
 
 @sadmin_sales.route('/discount_code/')
@@ -345,7 +346,8 @@ def sales_by_events_view(path):
                                from_date=from_date,
                                to_date=to_date,
                                path=path,
-                               orders_summary=orders_summary)
+                               orders_summary=orders_summary,
+                               navigation_bar=list_navbar())
     elif path == 'organizers':
         return render_template('gentelella/admin/super_admin/sales/by_organizer.html',
                                tickets_summary=tickets_summary_organizer_wise,
@@ -353,7 +355,8 @@ def sales_by_events_view(path):
                                from_date=from_date,
                                to_date=to_date,
                                path=path,
-                               orders_summary=orders_summary)
+                               orders_summary=orders_summary,
+                               navigation_bar=list_navbar())
     elif path == 'locations':
         return render_template('gentelella/admin/super_admin/sales/by_location.html',
                                tickets_summary=tickets_summary_location_wise,
@@ -361,7 +364,8 @@ def sales_by_events_view(path):
                                from_date=from_date,
                                to_date=to_date,
                                path=path,
-                               orders_summary=orders_summary)
+                               orders_summary=orders_summary,
+                               navigation_bar=list_navbar())
 
     else:
         abort(404)

--- a/app/views/super_admin/super_admin.py
+++ b/app/views/super_admin/super_admin.py
@@ -8,7 +8,7 @@ from app.helpers.deployment.kubernetes import KubernetesApi
 from app.helpers.deployment.heroku import HerokuApi
 from app.helpers.helpers import get_commit_info, get_count
 from app.models.user import ATTENDEE, TRACK_ORGANIZER, COORGANIZER, ORGANIZER
-from app.views.super_admin import BASE, check_accessible
+from app.views.super_admin import BASE, check_accessible, list_navbar
 
 sadmin = Blueprint('sadmin', __name__, url_prefix='/admin')
 
@@ -89,4 +89,5 @@ def index_view():
                            accepted_sessions=accepted_sessions,
                            rejected_sessions=rejected_sessions,
                            draft_sessions=draft_sessions,
-                           email_times=email_times)
+                           email_times=email_times,
+                           navigation_bar=list_navbar())

--- a/app/views/super_admin/users.py
+++ b/app/views/super_admin/users.py
@@ -7,7 +7,7 @@ from app.helpers.data import delete_from_db, DataManager, save_to_db
 from app.helpers.data import trash_user, restore_user
 from app.helpers.data_getter import DataGetter
 from app.models.event import Event
-from app.views.super_admin import USERS, check_accessible
+from app.views.super_admin import USERS, check_accessible, list_navbar
 
 sadmin_users = Blueprint('sadmin_users', __name__, url_prefix='/admin/users')
 
@@ -48,7 +48,8 @@ def index_view():
                            active_user_list=active_user_list,
                            trash_user_list=trash_user_list,
                            all_user_list=all_user_list,
-                           custom_sys_roles=custom_sys_roles)
+                           custom_sys_roles=custom_sys_roles,
+                           navigation_bar=list_navbar())
 
 
 @sadmin_users.route('/<user_id>/edit/', methods=('GET', 'POST'))


### PR DESCRIPTION
Fixes #2673 .
Generate `navigation_bar` list in the views itself instead of the template, according to accessible tabs. Previously the list was hardcoded causing #2763.

In this case, the user has access to `reports`,`modules` and `messages`, so only those tabs are being displayed.

After:
![selection_041](https://cloud.githubusercontent.com/assets/13910561/21545471/13817c12-cdfe-11e6-9934-f1ab579b892e.png)

Before:
![selection_040](https://cloud.githubusercontent.com/assets/13910561/21541264/fc278002-cdda-11e6-9a77-0c1502e0edbf.png)
