### PR TITLE
Custom roles:  Add link to the first-found accessible tab in dropdown

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -17,6 +17,7 @@ from .service import Service
 from .system_role import UserSystemRole
 from .user_permissions import UserPermission
 from .users_events_roles import UsersEventsRoles as UER
+from .panel_permissions import PanelPermission
 
 # System-wide
 ADMIN = 'admin'
@@ -212,6 +213,19 @@ class User(db.Model):
         """
         role = UserSystemRole.query.filter_by(user=self, role_id=role_id).first()
         return bool(role)
+
+    def first_access_panel(self):
+        """Check if the user is assigned a Custom Role or not
+        This checks if there is an entry containing the current user in the `user_system_roles` table
+        returns panel name if exists otherwise false
+        """
+        custom_role = UserSystemRole.query.filter_by(user=self).first()
+        if not custom_role:
+            return False
+        perm = PanelPermission.query.filter_by(role_id=custom_role.role_id, can_access=True).first()
+        if not perm:
+            return False
+        return perm.panel_name
 
     def can_access_panel(self, panel_name):
         """Check if user can access an Admin Panel

--- a/app/templates/gentelella/admin/menu.html
+++ b/app/templates/gentelella/admin/menu.html
@@ -68,6 +68,12 @@
                                 <li><a href="/settings"> {{ _("Settings") }}</a></li>
                                 {% if current_user.is_staff %}
                                     <li><a href="/admin"> {{ _("Admin") }}</a></li>
+                                {% elif current_user.first_access_panel() %}
+                                    {% if current_user.first_access_panel() == 'admin'  %}
+                                        <li><a href="/admin/">{{ _("Admin") }}</a></li>
+                                    {% else %}
+                                        <li><a href="/admin/{{ current_user.first_access_panel() }}">{{ _("Admin") }}</a></li>
+                                    {% endif %}
                                 {% endif %}
                                 <li class="divider"></li>
                                 <li><a href="/browse" class="user-profile hide-large">{{ _("Browse Events") }}</a></li>


### PR DESCRIPTION
fixes #2756 .
As highlighted in the screenshot, a link to `/admin/messages` was added to the dropdown as the user had access to `messages,`modules` and `reports` panels.

![screenshot from 2016-12-29 23-24-06](https://cloud.githubusercontent.com/assets/13910561/21550422/c8de4fe2-ce1f-11e6-9666-ad92976115ce.png)
