### PR TITLE
Pass session_type and microlocations in wizard template

### DIFF
--- a/app/views/users/events.py
+++ b/app/views/users/events.py
@@ -266,7 +266,9 @@ def edit_view(event_id, step=''):
                            current_timezone=current_timezone,
                            payment_countries=DataGetter.get_payment_countries(),
                            payment_currencies=DataGetter.get_payment_currencies(),
-                           included_settings=get_module_settings())
+                           included_settings=get_module_settings(),
+                           session_types=get_session_types_json(event_id),
+                           microlocations=get_microlocations_json(event_id))
 
 
 @events.route('/<event_id>/trash/', methods=('GET',))


### PR DESCRIPTION
fixes #2783 .
session_type and microlocations were not passed in the templates.
This was causing problems inenabling session types in "Collect Session Details".
Please review.

Result:

![selection_047](https://cloud.githubusercontent.com/assets/13910561/21572341/ed802e04-cefd-11e6-9cbd-90d5984acfe8.png)

![screenshot from 2016-12-31 02-02-46](https://cloud.githubusercontent.com/assets/13910561/21572328/d2c80776-cefd-11e6-99fe-98862e70bd9b.png)
