### PR TITLE
Issue #2821: Add link to Paypal payment method

### DIFF
--- a/app/templates/gentelella/admin/event/wizard/basic-details.html
+++ b/app/templates/gentelella/admin/event/wizard/basic-details.html
@@ -410,7 +410,7 @@
                                     <input type="checkbox" name="pay_by_stripe" v-model="event.pay_by_stripe">
                                     <strong style="font-weight: 400;">{{ _("YES, accept payment through Stripe") }} </strong><br>
                                     {{ _("Stripe accepts Visa, Master and Amex. To learn how it works click") }} <a
-                                        href="">{{ _("here.") }}</a>
+                                        href="https://www.paypal.com/us/webapps/mpp/popup/about-payment-methods">{{ _("here.") }}</a>
                                     {{ _("Find out more about Stripe") }} <a href="">{{ _("here.") }}</a>
                                 </label>
                             </div>


### PR DESCRIPTION
I added a link (https://www.paypal.com/us/webapps/mpp/popup/about-payment-methods) so that the "to learn how it works click here" link works.