### PR TITLE
change installing requirements command

### DIFF
--- a/docs/INSTALLATION_LOCAL.md
+++ b/docs/INSTALLATION_LOCAL.md
@@ -37,7 +37,7 @@ Make sure you have the dependencies mentioned above installed before proceeding 
 * **Step 1** - Install python requirements. You need to be present into the root directory of the project.
 
 ```sh
-pip install -r requirements.txt
+sudo -H pip install -r requirements.txt
 ```
 
 


### PR DESCRIPTION
change pip install -r requirements.txt to sudo -H pip install -r requirements.txt
Certain conflicts were arising using the previous command.
http://stackoverflow.com/questions/28619686/what-is-the-h-flag-for-pip
http://stackoverflow.com/questions/27870003/pip-install-please-check-the-permissions-and-owner-of-that-directory