### PR TITLE
Solves #2821: Add link to Paypal payment method

### DIFF
--- a/app/templates/gentelella/admin/event/wizard/basic-details.html
+++ b/app/templates/gentelella/admin/event/wizard/basic-details.html
@@ -388,7 +388,7 @@
                                     <input type="checkbox" name="pay_by_paypal" v-model="event.pay_by_paypal">
                                     <strong style="font-weight: 400;">{{ _("YES, accept payment through PayPal ") }}</strong><br>
                                     {{ _("Paypal accepts credit card, debit card and PayPal payments. To learn how it works click") }}
-                                    <a href="">{{ _("here.") }}</a>
+                                    <a href="https://www.paypal.com/us/webapps/mpp/popup/about-payment-methods">{{ _("here.") }}</a>
                                 </label>
                             </div>
                         </div>


### PR DESCRIPTION
I added a link (https://www.paypal.com/us/webapps/mpp/popup/about-payment-methods) so that the "to learn how it works click here" link works.