### PR TITLE
Save hidden ticket and display ticket description properly

### DIFF
--- a/app/templates/gentelella/admin/event/wizard/components/ticket.html
+++ b/app/templates/gentelella/admin/event/wizard/components/ticket.html
@@ -62,14 +62,14 @@
                     </div>
                     <div class="item form-group">
                         <label style="font-weight: normal; text-transform: none; font-size: 14px; line-height: 1; margin-top: 0;">
-                            <input type="checkbox" class="checkbox flat form-control" v-model="ticket.description_visibility">
+                            <input type="checkbox" class="checkbox form-control" style="display: inline-block;width: 14px;height: 14px;" v-model="ticket.description_visibility">
                             {{ _("Display Ticket description on Public Events page") }}
                         </label>
                     </div>
                     <div class="item form-group">
                         <div style="font-size: 15px;margin-bottom: 5px;">{{ _("Ticket visibility") }}</div>
                         <label style="font-weight: normal; text-transform: none; font-size: 14px; line-height: 1;  margin-top: 0;">
-                            <input type="checkbox" class="checkbox flat form-control" v-model="ticket.ticket_visibility">
+                            <input type="checkbox" class="checkbox form-control" style="display: inline-block;width: 14px;height: 14px;" v-model="ticket.ticket_visibility">
                             {{ _("Hide Ticket") }}
                         </label>
                         <div style="font-size: 13px;">


### PR DESCRIPTION
fixes #2854 
The error was due to `icheck.js`, which does not work with data-binding in vuejs. The `checkbox flat` class was associated with it. 
Except `/admin/messages`, default html checkbox is used everywhere else, so using the same here.

Reference: https://github.com/fronteed/icheck/issues/336 (P.S the proposed solution on the issue doesn't work, neither `icheck.js version 2 rc1` works and also `icheck.js` is pretty outdated )


![selection_054](https://cloud.githubusercontent.com/assets/13910561/21743983/0fe76710-d533-11e6-9410-a31e1504f0b4.png)