### PR TITLE
Add fields for session api

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -36,7 +36,11 @@ SESSION_TRACK = api.model('SessionTrack', {
 SESSION_SPEAKER = api.model('SessionSpeaker', {
     'id': fields.Integer(required=True),
     'name': fields.String(),
-    'organisation': fields.String()
+    'organisation': fields.String(),
+    'city' : fields.String(),
+    'heard_from' : fields.String(),
+    'speaking_experience' : fields.String(),
+    'sponsorship_required' : fields.String()
 })
 
 SESSION_MICROLOCATION = api.model('SessionMicrolocation', {
@@ -57,6 +61,7 @@ SESSION = api.model('Session', {
     'id': fields.Integer(required=True),
     'title': fields.String(required=True),
     'subtitle': fields.String(),
+    'level' : fields.String(),
     'short_abstract': fields.String(),
     'long_abstract': fields.String(),
     'comments': fields.String(),


### PR DESCRIPTION
Issue #2824
* 'level' in the session api
* 'city', 'speaker_experience', 'sponsorship_required' and
  'heard_from' in the session-speakers api.

![screenshot from 2017-01-08 15-31-26](https://cloud.githubusercontent.com/assets/10217535/21748914/90b22766-d5b7-11e6-8ced-e8591e2fbff1.png)
![screenshot from 2017-01-08 15-30-52](https://cloud.githubusercontent.com/assets/10217535/21748915/90b5b5fc-d5b7-11e6-804b-9517a41b0103.png)
