### PR TITLE
Sponsorship Information fixed

### DIFF
--- a/app/templates/gentelella/admin/event/wizard/sponsors.html
+++ b/app/templates/gentelella/admin/event/wizard/sponsors.html
@@ -30,7 +30,7 @@
                     </div>
                     <div class="col-md-2 form-group col-sm-12 col-xs-12">
                         <label>{{ _("Type") }}</label>
-                        <input title="sponsor type" class="form-control" v-model="sponsor.sponsor_type"/>
+                        <input title="sponsor type" class="form-control" v-model="sponsor.type"/>
                     </div>
                     <div class="col-md-5 form-group col-sm-12 col-xs-12"
                          v-bind:class="{ 'has-error': !isValidLinkEntry(sponsor.url) }">

--- a/app/templates/gentelella/guest/event/details.html
+++ b/app/templates/gentelella/guest/event/details.html
@@ -66,9 +66,9 @@
                     <h4>
                         {% if item[1][0].sponsor_type and item[0] != -1 %}
                             {{ item[1][0].sponsor_type | title }}
-                        {% elif item[0] == -1 and sponsors | length>1 %}
+                        {% elif item[0] == -1 and sponsors | length>1 and item[1] | length > 0 %}
                             {{ _("Other Sponsors") }}
-                        {% elif not item[1][0].sponsor_type %}
+                        {% elif not item[1][0].sponsor_type and item[1] | length > 0 %}
                             Level - {{ item[0] }}
                         {% endif %}
                     </h4>

--- a/app/templates/gentelella/guest/event/details.html
+++ b/app/templates/gentelella/guest/event/details.html
@@ -61,16 +61,22 @@
         {% endif %}
         {% if event.sponsor[0] %}
             <h3 id="sponsors">Sponsors</h3>
-            <div class="row">
-                <div class="col-sm-12">
-                    {% for sponsor in event.sponsor %}
+            {% for item in sponsors|dictsort|reverse %}
+                <div class="row" id="level-{{ item[0] }}">
+                    <h4>
+                        {% if item[1][0].sponsor_type and item[0] != -1 %}
+                            {{ item[1][0].sponsor_type|title }}
+                        {% elif item[0] == -1 and sponsors|length>1 %}
+                            {{ _("Other Sponsors") }}
+                        {% elif not item[1][0].sponsor_type %}
+                            Level - {{ item[0] }}
+                        {% endif %}
+                    </h4>
+                    {% for sponsor in item[1] %}
                         {{ sponsor_info(sponsor) }}
-                    {% else %}
-                        {{ _("Sponsors info unavailable") }}
                     {% endfor %}
                 </div>
-            </div>
-            <br>
+            {% endfor %}
         {% endif %}
         {% if event.organizer_name %}
             <h3 id="organizer">{{ _("Organized by") }} {{ event.organizer_name }}</h3>

--- a/app/templates/gentelella/guest/event/details.html
+++ b/app/templates/gentelella/guest/event/details.html
@@ -20,7 +20,7 @@
 
 {% macro sponsor_info(sponsor) %}
     <div class="col-md-4 col-sm-6 sponsor-column">
-        <div class="sponsor text-center">
+        <div class="sponsor text-center" data-toggle="tooltip" title="{{ sponsor.description }}">
             {% if sponsor.url %}
                 <a href="{{ sponsor.url }}" target="default">
                     <img alt="{{ sponsor.name }}" src="{{ sponsor.logo }}">
@@ -61,12 +61,12 @@
         {% endif %}
         {% if event.sponsor[0] %}
             <h3 id="sponsors">Sponsors</h3>
-            {% for item in sponsors|dictsort|reverse %}
+            {% for item in sponsors | dictsort | reverse %}
                 <div class="row" id="level-{{ item[0] }}">
                     <h4>
                         {% if item[1][0].sponsor_type and item[0] != -1 %}
-                            {{ item[1][0].sponsor_type|title }}
-                        {% elif item[0] == -1 and sponsors|length>1 %}
+                            {{ item[1][0].sponsor_type | title }}
+                        {% elif item[0] == -1 and sponsors | length>1 %}
                             {{ _("Other Sponsors") }}
                         {% elif not item[1][0].sponsor_type %}
                             Level - {{ item[0] }}

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -71,8 +71,19 @@ def display_event_detail_home(identifier):
     timenow_event_tz = datetime.now(pytz.timezone(event.timezone))
     module = DataGetter.get_module()
     tickets = DataGetter.get_sales_open_tickets(event.id, True)
+
+    '''Sponsor Levels'''
+    sponsors = {-1:[]}
+    for sponsor in event.sponsor:
+        if not sponsor.level:
+            sponsors[-1].append(sponsor)
+        elif int(sponsor.level) in sponsors.keys():
+            sponsors[int(sponsor.level)].append(sponsor)
+        else:
+            sponsors[int(sponsor.level)] = [sponsor]
     return render_template('gentelella/guest/event/details.html',
                            event=event,
+                           sponsors=sponsors,
                            placeholder_images=placeholder_images,
                            custom_placeholder=custom_placeholder,
                            accepted_sessions=accepted_sessions,


### PR DESCRIPTION
#2790 

Things done: 

- [x] Sponsorship type stored
- [x] Sponsors shown based on level and type in public page
- [x] Description shown in tooltip

![screenshot from 2017-01-08 15-49-18](https://cloud.githubusercontent.com/assets/9530293/21749009/1c78db26-d5ba-11e6-8432-ce96872d0b99.png)
