### PR TITLE
Fixed redirection to 404 page when arbitrary URL is entered

### DIFF
--- a/app/views/public/pages.py
+++ b/app/views/public/pages.py
@@ -1,5 +1,6 @@
 from flask import Blueprint
 from flask import render_template
+from flask import abort
 
 from app.helpers.data_getter import DataGetter
 
@@ -10,6 +11,8 @@ pages = Blueprint('basicpagesview', __name__)
 def url_view(url):
     from app import get_locale
     page = DataGetter.get_page_by_url('/' + url, get_locale())
+    if page == None:
+		return abort(404)
     return render_template('gentelella/guest/page.html', page=page)
 
 

--- a/app/views/public/pages.py
+++ b/app/views/public/pages.py
@@ -1,6 +1,5 @@
 from flask import Blueprint
 from flask import render_template
-from flask import abort
 
 from app.helpers.data_getter import DataGetter
 
@@ -12,7 +11,7 @@ def url_view(url):
     from app import get_locale
     page = DataGetter.get_page_by_url('/' + url, get_locale())
     if page == None:
-		return abort(404)
+		return render_template('gentelella/errors/404.html'), 404
     return render_template('gentelella/guest/page.html', page=page)
 
 

--- a/app/views/public/pages.py
+++ b/app/views/public/pages.py
@@ -1,5 +1,6 @@
 from flask import Blueprint
 from flask import render_template
+from flask import abort
 
 from app.helpers.data_getter import DataGetter
 
@@ -11,7 +12,7 @@ def url_view(url):
     from app import get_locale
     page = DataGetter.get_page_by_url('/' + url, get_locale())
     if page == None:
-		return render_template('gentelella/errors/404.html'), 404
+		return abort(404)
     return render_template('gentelella/guest/page.html', page=page)
 
 


### PR DESCRIPTION
Issue #2850
app/views/public/pages.py updated

Added an 'if' condition that returns 404 error message instead of displaying a blank page if the the query filter function cannot find the specified URL in the database.