### PR TITLE
Added tests for ical, fixed bugs in ical import/export

### DIFF
--- a/app/api/imports.py
+++ b/app/api/imports.py
@@ -25,7 +25,7 @@ class EventImportJson(Resource):
         elif source_type == 'pentabarf':
             file_path = get_file_from_request(['xml'])
         elif source_type == 'ical':
-            file_path = get_file_from_request(['ical'])
+            file_path = get_file_from_request(['ical', 'ics'])
         else:
             file_path = None
             abort(404)

--- a/app/helpers/importers/helpers.py
+++ b/app/helpers/importers/helpers.py
@@ -27,7 +27,6 @@ def own_event(event, user_id):
 
 
 def get_valid_event_name(value):
-    value = value.lower()
     name = None
     stop_words = ['ical', 'caldesc', 'calname', 'pentabarf']
     if value and value != '' and all(word not in value for word in stop_words):

--- a/app/helpers/importers/ical.py
+++ b/app/helpers/importers/ical.py
@@ -86,14 +86,12 @@ class ICalImporter:
                 attendees_dirty = session_block['attendee']
                 if hasattr(attendees_dirty, '__iter__'):
                     for attendee in attendees_dirty:
-                        attendees.append(attendee.params['CN'])
+                        attendees.append((attendee.params['CN'], attendee))
                 else:
-                    attendees.append(attendees_dirty.params['CN'])
+                    attendees.append((attendees_dirty.params['CN'], attendees_dirty))
 
             for attendee in attendees:
-                name_mix = attendee + ' ' + event.name
-                email = ''.join(x for x in name_mix.title() if not x.isspace()) + '@example.com'
-                speaker = Speaker(name=attendee, event_id=event.id, email=email,
+                speaker = Speaker(name=attendee[0], event_id=event.id, email=attendee[1].replace('MAILTO:', ''),
                                   country='Earth',
                                   organisation='')
                 db.session.add(speaker)

--- a/tests/unittests/api/test_export_import.py
+++ b/tests/unittests/api/test_export_import.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-
+"""
+Tests for core JSON import/export
+"""
 import json
 import logging
 import os
@@ -301,46 +303,6 @@ class TestImportOTS(ImportExportBase):
         resp = self._upload(file, upload_path, 'event.zip')
         self.assertEqual(resp.status_code, 200)
         self.assertIn('Open Tech Summit', resp.data)
-
-
-class TestPentabarf(ImportExportBase):
-    """
-    Test Pentabarf import/exports
-    """
-    def setUp(self):
-        self.app = Setup.create_app()
-        with app.test_request_context():
-            register(self.app, u'test@example.com', u'test')
-            create_event(creator_email='test@example.com', location_name='Science Centre, Singapore')
-            create_services(1, '1')
-            create_session(1, '2', state='accepted', track=1, microlocation=1, speakers=[1], session_type=1)
-
-    def _publishEvent(self, event_id):
-        resp = self._put(
-            '/api/v1/events/%s' % event_id,
-            {'state': 'Published', 'schedule_published_on': '2017-01-01 23:11:44', 'has_session_speakers': True}
-        )
-        self.assertEqual(resp.status_code, 200)
-
-    def test_export_import(self):
-        """
-        test export of pentabarf
-        """
-        self._publishEvent(1)
-        resp = self.app.get('/api/v1/events/1')
-        identifier = json.loads(resp.data).get('identifier')
-        resp = self.app.get('/api/v1/events/1/sessions')
-        # export
-        resp = self.app.get('/e/%s/schedule/pentabarf.xml' % identifier)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn('conference', resp.data)
-        print resp.data
-        # upload back
-        resp = self._upload(resp.data, '/api/v1/events/import/pentabarf', 'pb.xml')
-        self.assertEqual(resp.status_code, 200)
-        # this resp is celery task, sync so done already
-        data = json.loads(self.app.get('/api/v1/events/2').data)
-        self.assertEqual(data['id'], 2)
 
 
 if __name__ == '__main__':

--- a/tests/unittests/api/test_export_import_more.py
+++ b/tests/unittests/api/test_export_import_more.py
@@ -1,0 +1,88 @@
+"""
+Import/Export to other formats tests
+- pentabarf, ical, xcal
+"""
+import json
+import unittest
+
+from app import current_app as app
+from tests.unittests.api.utils import create_event, create_services, create_session
+from tests.unittests.auth_helper import register
+from tests.unittests.setup_database import Setup
+from test_export_import import ImportExportBase
+
+
+class ImportExportOtherBase(ImportExportBase):
+    """
+    Base class
+    """
+    def setUp(self):
+        self.app = Setup.create_app()
+        with app.test_request_context():
+            register(self.app, u'test@example.com', u'test')
+            create_event(
+                creator_email='test@example.com', location_name='Science Centre, Singapore',
+                latitude=87.5, longitude=88.5
+            )
+            create_services(1, '1')
+            create_session(1, '2', state='accepted', track=1, microlocation=1, speakers=[1], session_type=1)
+
+    def _publishEvent(self, event_id):
+        resp = self._put(
+            '/api/v1/events/%s' % event_id,
+            {'state': 'Published', 'schedule_published_on': '2017-01-01 23:11:44', 'has_session_speakers': True}
+        )
+        self.assertEqual(resp.status_code, 200)
+
+
+class TestPentabarf(ImportExportOtherBase):
+    """
+    Test Pentabarf import/exports
+    """
+    def test_export_import(self):
+        """
+        test export and import of pentabarf
+        """
+        self._publishEvent(1)
+        resp = self.app.get('/api/v1/events/1')
+        identifier = json.loads(resp.data).get('identifier')
+        # export
+        resp = self.app.get('/e/%s/schedule/pentabarf.xml' % identifier)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('conference', resp.data)
+        print resp.data
+        # upload back
+        resp = self._upload(resp.data, '/api/v1/events/import/pentabarf', 'pb.xml')
+        self.assertEqual(resp.status_code, 200)
+        # this resp is celery task, sync so done already
+        data = json.loads(self.app.get('/api/v1/events/2').data)
+        self.assertEqual(data['id'], 2)
+
+
+class TestIcal(ImportExportOtherBase):
+    """
+    Test ical import/exports
+    """
+    def test_export_import(self):
+        """
+        test export and import of ical
+        """
+        self._publishEvent(1)
+        resp = self.app.get('/api/v1/events/1')
+        identifier = json.loads(resp.data).get('identifier')
+        # export
+        resp = self.app.get('/e/%s/schedule/calendar.ics' % identifier)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('BEGIN:VEVENT', resp.data)
+        self.assertIn('TestSpeaker', resp.data)
+        # import back
+        resp = self._upload(resp.data, '/api/v1/events/import/ical', 'cal.ics')  # celery task response
+        self.assertEqual(resp.status_code, 200)
+        data = self.app.get('/api/v1/events/2').data
+        self.assertIn('TestEvent', data)
+        data = self.app.get('/api/v1/events/2/speakers').data
+        self.assertIn('TestSpeaker', data)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#2881 

* Fixed issue where exported ics won’t import back in orga-server
* Fixed ical import of event with speakers, won’t import earlier because of no CN property exported
* Fixed wrong event name of ical export (x-wr-calname)
* Fixed bug where duplicate speakers were exported with a session (in case session had more than one speakers)