### PR TITLE
Changed page title back to format {page name} - {app name}

### DIFF
--- a/app/templates/gentelella/admin/base.html
+++ b/app/templates/gentelella/admin/base.html
@@ -5,7 +5,12 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>{{ app_name }} - {% block title %}{% endblock %}</title>
+    <title>
+    {% block title %}{% endblock %}
+    {% if not is_home_page %}
+    - {{ app_name }}
+    {% endif %}
+    </title>
     {% block head_meta %}
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">

--- a/app/templates/gentelella/index.html
+++ b/app/templates/gentelella/index.html
@@ -96,11 +96,12 @@
         }
     </style>
 {% endblock %}
+{% set is_home_page = true %}
 {% block title %}
     {% if tagline %}
-        {{ tagline }}
+        {{ app_name }} - {{ tagline }}
     {% else %}
-        Event Management and Ticketing
+        {{ app_name }} - Event Management and Ticketing
     {% endif %}
 {% endblock %}
 {% macro event_box(event) %}

--- a/tests/robot/resource.robot
+++ b/tests/robot/resource.robot
@@ -17,7 +17,7 @@ ${WELCOME URL}     http://${SERVER}/
 
 *** Keywords ***
 Login Page Should Be Open
-    Title Should Be    Open Event - Login
+    Title Should Be    Login - Open Event
 
 Open Browser To Login Page
     Open Browser    ${LOGIN URL}    ${BROWSER}


### PR DESCRIPTION
Fixes #2949 

Homepage is still {app name} - {tagline}. 