### PR TITLE
Fixed access code message bug and discount bug on pre-payment page

### DIFF
--- a/app/helpers/ticketing.py
+++ b/app/helpers/ticketing.py
@@ -240,16 +240,24 @@ class TicketingManager(object):
         discount=None
         if ticket_discount:
             discount=TicketingManager.get_discount_code(form.get('event_id'), form.get('promo_code',''))
-            if not discount:
-                flash('The promotional code entered is not valid. No offer has been applied to this order.', 'danger')
-            else:
+            access_code = TicketingManager.get_access_code(form.get('event_id'), form.get('promo_code', ''))
+            if access_code and discount:
                 order.discount_code = discount
-                flash('The promotional code entered is valid.offer has been applied to this order.', 'success')
+                flash('Both access code and discount code has been applied. You can make this order now.', 'success')
+            elif discount:
+                order.discount_code = discount
+                flash('The promotional code entered is valid. Offer has been applied to this order.', 'success')
+            elif access_code:
+                flash('Your access code is applied and you can make this order now.', 'success')
+            else:
+                flash('The promotional code entered is not valid. No offer has been applied to this order.', 'danger')
+                
         ticket_subtotals = []
         if from_organizer:
             ticket_subtotals = form.getlist('ticket_subtotals[]')
 
         amount = 0
+        total_discount = 0
         fees = DataGetter.get_fee_settings_by_currency(DataGetter.get_event(order.event_id).payment_currency)
         for index, id in enumerate(ticket_ids):
             if not string_empty(id) and int(ticket_quantity[index]) > 0:
@@ -262,6 +270,13 @@ class TicketingManager(object):
                     if from_organizer:
                         amount += float(ticket_subtotals[index])
                     else:
+                        if discount and str(order_ticket.ticket.id) in discount.tickets.split(","):
+                            if discount.type == "amount":
+                                total_discount += discount.value * order_ticket.quantity
+                            else:
+                                total_discount += discount.value * order_ticket.ticket.price *\
+                                                 order_ticket.quantity/100.0
+
                         if order_ticket.ticket.absorb_fees or not fees:
                             amount += (order_ticket.ticket.price * order_ticket.quantity)
                         else:
@@ -271,8 +286,8 @@ class TicketingManager(object):
                             else:
                                 amount += (order_ticket.ticket.price * order_ticket.quantity) + order_fee
 
-        if discount and discount.type == "amount":
-            order.amount = max(amount-discount.value, 0)
+        if discount:
+            order.amount = max(amount - total_discount,0)
         elif discount:
             order.amount = amount-(discount.value*amount/100.0)
         else:


### PR DESCRIPTION
fixed #2972 

**Both Access And Discount Codes** Applied:
![screenshot from 2017-01-19 15-46-06](https://cloud.githubusercontent.com/assets/20799954/22103169/128bd786-de60-11e6-9141-b610d11b2340.png)

Only **Access Code** Applied:
![screenshot from 2017-01-19 16-18-25](https://cloud.githubusercontent.com/assets/20799954/22103920/fbaf13d6-de62-11e6-943f-12adab249bdb.png)


Only **Discount Code** Applied:
![screenshot from 2017-01-19 15-51-33](https://cloud.githubusercontent.com/assets/20799954/22103176/164f52da-de60-11e6-9919-c1df63f2dfcd.png)

**Invalid Code**:
![screenshot from 2017-01-19 15-47-53](https://cloud.githubusercontent.com/assets/20799954/22103177/1732125a-de60-11e6-9957-e81faa16024d.png)
