### PR TITLE
Fixes the issue #2999. Shows 'completed orders' and 'attendees with completed orders' first …

### DIFF
--- a/app/templates/gentelella/admin/event/tickets/attendees.html
+++ b/app/templates/gentelella/admin/event/tickets/attendees.html
@@ -46,9 +46,6 @@
     <div id="toolbar-holder" style="display: none;">
         <div class="btn-group pull-left" data-toggle="buttons">
             <label class="btn btn-default active btn-responsive">
-                <input type="radio" name="show_state" autocomplete="off" value="all" checked> {{ _("All") }}
-            </label>
-            <label class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Completed"> {{ _("Completed") }}
             </label>
             <label class="btn btn-default btn-responsive">
@@ -66,6 +63,9 @@
             <label class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off"
                        value="not_checked_in"> {{ _("Not Checked In") }}
+            </label>
+            <label class="btn btn-default btn-responsive">
+                <input type="radio" name="show_state" autocomplete="off" value="all" checked> {{ _("All") }}
             </label>
 
         </div>

--- a/app/templates/gentelella/admin/event/tickets/orders.html
+++ b/app/templates/gentelella/admin/event/tickets/orders.html
@@ -41,9 +41,6 @@
     <div id="toolbar-holder" style="display: none;">
         <div class="btn-group pull-left" data-toggle="buttons">
             <label class="btn btn-default active btn-responsive">
-                <input type="radio" name="show_state" autocomplete="off" value="all" checked> {{ _("All") }}
-            </label>
-            <label class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Completed"> {{ _("Completed") }}
             </label>
             <label class="btn btn-default btn-responsive">
@@ -54,6 +51,9 @@
             </label>
             <label class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Expired"> {{ _("Expired") }}
+            </label>
+            <label class="btn btn-default btn-responsive">
+                <input type="radio" name="show_state" autocomplete="off" value="all" checked> {{ _("All") }}
             </label>
         </div>
     </div>


### PR DESCRIPTION
…in ticketing dashboard. Here are the screenshots
![screenshot from 2017-01-21 11-56-24](https://cloud.githubusercontent.com/assets/8847265/22172616/26938cce-dfd2-11e6-985e-6b0899448649.png)
![screenshot from 2017-01-21 11-56-31](https://cloud.githubusercontent.com/assets/8847265/22172617/28b0cdf0-dfd2-11e6-8fdd-c3c7c09cf0a6.png)
Please review. Thanks!!