### PR TITLE
Added date and links to admin sales tab

### DIFF
--- a/app/templates/gentelella/admin/super_admin/sales/summary_base.html
+++ b/app/templates/gentelella/admin/super_admin/sales/summary_base.html
@@ -60,6 +60,11 @@
                     {{ _("Marketer") }}
                 </th>
             {% endif %}
+            {% if path and path == 'events' %}
+                <th rowspan="2">
+                    {{ _("Event Date") }}
+                </th>
+            {% endif %}
             <th colspan="2" class="success">
                 {{ _("Completed Orders") }}
             </th>
@@ -96,7 +101,15 @@
 
             <tr>
                 <td>
-                    {{ item.name }}
+                    {% if path and path == 'events' %}
+                        {% if item.event_url and item.live_url %}
+                            <a href={{ item.event_url }}>{{ item.name }}</a><a href={{ item.live_url }}>(View Live Site)<a>
+                        {% else %}
+                            {{ item.name }}
+                        {% endif%}
+                    {% else %}
+                        {{ item.name }}
+                    {% endif%}
                 </td>
                 {% if path and path == 'discounted-events' %}
                     <td>
@@ -104,6 +117,15 @@
                     </td>
                     <td>
                         {{ item.marketer }}
+                    </td>
+                {% endif %}
+                {% if path and path == 'events' %}
+                    <td style="font-size:13px">
+                        {% if item.start_time and item.end_time %}
+                            {{ item.start_time }}<br>to</font>  {{ item.end_time }}
+                        {% else %}
+                            {{ _("-") }}
+                        {% endif %}
                     </td>
                 {% endif %}
                 <td>
@@ -133,6 +155,11 @@
             <th colspan="{% if path and path == 'discounted-events' %}3{% else %}1{% endif %}">
                 {{ _("Total") }}
             </th>
+            {% if path and path == 'events' %}
+                <th >
+                {{ _("") }}
+                </th>
+            {% endif %}
             <th>
                 {{ orders_summary.completed.tickets_count }}
             </th>

--- a/app/views/super_admin/sales.py
+++ b/app/views/super_admin/sales.py
@@ -290,6 +290,10 @@ def sales_by_events_view(path):
             'payment_currency': event.payment_currency,
             'marketer': '',
             'discount_code': '',
+            'live_url': url_for('event_detail.display_event_detail_home', identifier=event.identifier).replace('events', 'e'),
+            'event_url': url_for('events.details_view', event_id=event.id),
+            'start_time': event.start_time,
+            'end_time': event.end_time,
             'completed': {
                 'tickets_count': 0,
                 'sales': 0
@@ -362,7 +366,6 @@ def sales_by_events_view(path):
                     tickets_summary_event_wise[str(order.event_id)][str(order.status)]['sales']  += order_ticket.quantity * ticket.price
                     tickets_summary_organizer_wise[str(order.event.creator_id)][str(order.status)]['sales']  += order_ticket.quantity * ticket.price
                     tickets_summary_location_wise[str(order.event.searchable_location_name)][str(order.status)]['sales']  += order_ticket.quantity * ticket.price
-
     if path == 'events' or path == 'discounted-events':
         return render_template('gentelella/admin/super_admin/sales/by_events.html',
                                tickets_summary=tickets_summary_event_wise,


### PR DESCRIPTION
Fixed #2980 
Live View Site takes to main event site.
And on clicking event-name takes to event dashboard
![screenshot from 2017-01-22 02-39-04](https://cloud.githubusercontent.com/assets/20799954/22177835/402ac34e-e04c-11e6-84aa-9d807162044a.png)


