### PR TITLE
Changes made in Event Knowledge field

### DIFF
--- a/app/templates/gentelella/admin/event/sessions/components/_speaker_component.html
+++ b/app/templates/gentelella/admin/event/sessions/components/_speaker_component.html
@@ -33,8 +33,8 @@
                 <select title="{% if name == 'heard_from' %}{{ "Where did you hear about our event?" }}{% else %}{{ pretty_name }}{% endif %}"
                         {% if require==1 or identifier=='track' %}required="required"{% endif %} name="{{ identifier }}"
                         class="form-control col-md-7 col-xs-12" id="heard-from">
-                    {% if name == 'heard_from' and not session %}
-                        <option value="" {% if not session %}selected{% endif %}>
+                    {% if name == 'heard_from' and not speaker and not session.speakers[0] %}
+                        <option value="" {% if not speaker and not session.speakers[0] %}selected{% endif %}>
                             Select {{ "knowledge of event" }}</option>
                     {% endif %}
                     {% if (speaker and speaker['heard_from'] in data_set) or (session and session.speakers[0]['heard_from'] in data_set) %}
@@ -45,19 +45,24 @@
                                 <option value="{{ data }}">{{ data }}</option>
                             {% endif %}
                         {% endfor %}
-                    {% else %}
+                    {% elif (speaker and speaker['heard_from'] not in data_set) or (session and session.speakers[0]['heard_from'] and session.speakers[0]['heard_from'] not in data_set) %}
                         {% for data in data_set %}
                             {% if data == "Other" %}
                                 <option value="{{ data }}" selected>{{ data }}</option>
+
                             {% else %}
                                 <option value="{{ data }}">{{ data }}</option>
                             {% endif %}
                         {% endfor %}
+                    {% else %}
+                        {% for data in data_set %}
+                            <option value="{{ data }}">{{ data }}</option>
+                        {% endfor %}
                     {% endif %}
                 </select>
                 <input class="form-control col-md-7 col-xs-12" name="other_text" id="other_text"
-                       placeholder="Enter where you heard" | required
-                       {% if (speaker and speaker['heard_from'] in data_set) or (session and session.speakers[0]['heard_from'] in data_set) %}type="hidden" {% endif %}
+                       placeholder="Enter where you heard"
+                       {% if not (speaker and speaker['heard_from'] in data_set) and not (session and session.speakers[0]['heard_from'] and session.speakers[0]['heard_from]'] in data_set) and (speaker or session.speakers[0]) %}type="text" {% else %}type="hidden"{% endif %}
                        value="{% if speaker and speaker['heard_from'] not in data_set %}{{ speaker['heard_from'] }}{% elif session.speakers and session.speakers[0]['heard_from'] not in data_set %}{{ session.speaker[0]['heard_from'] }} {% endif %}">
             {% elif identifier == 'gender' %}
                 {% set data_set = ['Male', 'Female', 'Other'] %}

--- a/app/templates/gentelella/admin/event/sessions/components/session_speaker_form.html
+++ b/app/templates/gentelella/admin/event/sessions/components/session_speaker_form.html
@@ -67,5 +67,12 @@
             selectableHeader: "<div style='margin: 10px 0;'><strong>Available Speakers</strong></div>",
             selectionHeader: "<div style='margin: 10px 0;'><strong>Selected Speakers</strong></div>"
         })
+        $("#heard-from").change(function(){
+            if (this.value == "Other") {
+                $("#other_text").attr("type", "text");
+            } else {
+                $("#other_text").attr("type", "hidden");
+            }
+        });
     });
 </script>


### PR DESCRIPTION
fixed #3058
Create session form:
![screenshot from 2017-01-30 03-48-30](https://cloud.githubusercontent.com/assets/20799954/22408496/e2224d9e-e69f-11e6-9ef4-f0d712cf668f.png)

Choice selection:
![screenshot from 2017-01-30 03-48-35](https://cloud.githubusercontent.com/assets/20799954/22408503/02366764-e6a0-11e6-9274-43263fecc1e7.png)

Speaker on edit:
![screenshot from 2017-01-30 03-49-47](https://cloud.githubusercontent.com/assets/20799954/22408510/23c3a752-e6a0-11e6-8c04-e34fd520087e.png)

Speaker on edit with option "other":
![screenshot from 2017-01-30 03-49-28](https://cloud.githubusercontent.com/assets/20799954/22408523/41714458-e6a0-11e6-95f3-819a304b9614.png)

