### PR TITLE
Allow both access code and discount code to be added on the same order.

### DIFF
--- a/app/templates/gentelella/guest/event/_ticketing_box.html
+++ b/app/templates/gentelella/guest/event/_ticketing_box.html
@@ -140,7 +140,7 @@
                         <div class="col-md-5 pull-right promo-code-box" style="padding-right:0;display:none;">
                             <div class="input-group" style="margin-bottom: 0;">
                                 <input type="text" name="promo_code" class="form-control" placeholder="Promotional code"
-                                       value="{{ dcode | default('', true) }}">
+                                       value="{{ discount_code | default('', true) }}">
                                 <span class="input-group-btn">
                                         <button class="btn btn-default " type="button" id="apply-discount"><i
                                                 class="fa fa-check"></i></button>
@@ -270,9 +270,9 @@
         var discount_amount = -1;
         var promo_code_status = 0;
         var discount_code = "";
-        {% if dcode %}
+        {% if discount_code %}
                 if (promo_code_status == 0) {
-                    var form_data = {"event_id": {{ event.id }}, "promo_code": "{{ dcode }}" }
+                    var form_data = {"event_id": {{ event.id }}, "promo_code": "{{ discount_code }}" }
                     $.ajax({
                         type: 'POST',
                         url: "{{ url_for('ticketing.apply_promo') }}",

--- a/app/templates/gentelella/guest/event/_ticketing_box.html
+++ b/app/templates/gentelella/guest/event/_ticketing_box.html
@@ -140,7 +140,7 @@
                         <div class="col-md-5 pull-right promo-code-box" style="padding-right:0;display:none;">
                             <div class="input-group" style="margin-bottom: 0;">
                                 <input type="text" name="promo_code" class="form-control" placeholder="Promotional code"
-                                       value="{{ code | default('', true) }}">
+                                       value="{{ dcode | default('', true) }}">
                                 <span class="input-group-btn">
                                         <button class="btn btn-default " type="button" id="apply-discount"><i
                                                 class="fa fa-check"></i></button>
@@ -270,9 +270,9 @@
         var discount_amount = -1;
         var promo_code_status = 0;
         var discount_code = "";
-        {% if code %}
+        {% if dcode %}
                 if (promo_code_status == 0) {
-                    var form_data = {"event_id": {{ event.id }}, "promo_code": "{{ code }}" }
+                    var form_data = {"event_id": {{ event.id }}, "promo_code": "{{ dcode }}" }
                     $.ajax({
                         type: 'POST',
                         url: "{{ url_for('ticketing.apply_promo') }}",

--- a/app/templates/gentelella/users/events/tickets/access_codes_create.html
+++ b/app/templates/gentelella/users/events/tickets/access_codes_create.html
@@ -227,7 +227,7 @@
 
         var host = (document.URL.split("//")[1].split("/"))[0];
         $("#code").change(function(){
-            $("#link").val(document.URL.split("/")[0]+"//"+host+"/e/"+"{{ event.identifier }}"+"/?acode="+$(this).val());
+            $("#link").val(document.URL.split("/")[0]+"//"+host+"/e/"+"{{ event.identifier }}"+"/?access_code="+$(this).val());
         });
 
     </script>

--- a/app/templates/gentelella/users/events/tickets/access_codes_create.html
+++ b/app/templates/gentelella/users/events/tickets/access_codes_create.html
@@ -227,9 +227,8 @@
 
         var host = (document.URL.split("//")[1].split("/"))[0];
         $("#code").change(function(){
-            $("#link").val(document.URL.split("/")[0]+"//"+host+"/e/"+"{{ event.identifier }}"+"/?code="+$(this).val());
+            $("#link").val(document.URL.split("/")[0]+"//"+host+"/e/"+"{{ event.identifier }}"+"/?acode="+$(this).val());
         });
 
     </script>
 {% endblock %}
-

--- a/app/templates/gentelella/users/events/tickets/discount_codes_create.html
+++ b/app/templates/gentelella/users/events/tickets/discount_codes_create.html
@@ -265,4 +265,3 @@
         });
     </script>
 {% endblock %}
-

--- a/app/templates/gentelella/users/events/tickets/discount_codes_create.html
+++ b/app/templates/gentelella/users/events/tickets/discount_codes_create.html
@@ -261,7 +261,7 @@
 
         var host = (document.URL.split("//")[1].split("/"))[0];
         $("#code").change(function(){
-            $("#link").val(document.URL.split("/")[0]+"//"+host+"/e/"+"{{ event.identifier }}"+"/?code="+$(this).val());
+            $("#link").val(document.URL.split("/")[0]+"//"+host+"/e/"+"{{ event.identifier }}"+"/?discount_code="+$(this).val());
         });
     </script>
 {% endblock %}

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -84,7 +84,9 @@ def display_event_detail_home(identifier):
             sponsors[int(sponsor.level)] = [sponsor]
 
     fees = DataGetter.get_fee_settings_by_currency(event.payment_currency)
-    code = request.args.get("code")
+    acode = request.args.get("acode")
+    dcode = request.args.get("dcode")
+    print(acode) #dcode testing
     return render_template('gentelella/guest/event/details.html',
                            event=event,
                            sponsors=sponsors,
@@ -100,8 +102,8 @@ def display_event_detail_home(identifier):
                            current_timezone=get_current_timezone(),
                            tickets=tickets if tickets else [],
                            fees=fees,
-                           code=code)
-
+                           acode=acode,
+                           dcode=dcode)
 
 @event_detail.route('/<identifier>/sessions/')
 def display_event_sessions(identifier):

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -84,9 +84,8 @@ def display_event_detail_home(identifier):
             sponsors[int(sponsor.level)] = [sponsor]
 
     fees = DataGetter.get_fee_settings_by_currency(event.payment_currency)
-    acode = request.args.get("acode")
-    dcode = request.args.get("dcode")
-    print(acode) #dcode testing
+    access_code = request.args.get("access_code")
+    discount_code = request.args.get("discount_code")
     return render_template('gentelella/guest/event/details.html',
                            event=event,
                            sponsors=sponsors,
@@ -102,8 +101,8 @@ def display_event_detail_home(identifier):
                            current_timezone=get_current_timezone(),
                            tickets=tickets if tickets else [],
                            fees=fees,
-                           acode=acode,
-                           dcode=dcode)
+                           access_code=access_code,
+                           discount_code=discount_code)
 
 @event_detail.route('/<identifier>/sessions/')
 def display_event_sessions(identifier):


### PR DESCRIPTION
Resolves #3046
If the user generates an access code, it is not possible to apply a discount code as well. Please implement as follows:

- Now user can apply discount code if access code is already applied.
- link is now `/?acode=ACCESS&dcode=DIS` -> combination of access and discount link