### PR TITLE
Show 50 speakers as standard on speakers dashboard

### DIFF
--- a/app/templates/gentelella/users/events/speakers/base_speaker_table.html
+++ b/app/templates/gentelella/users/events/speakers/base_speaker_table.html
@@ -163,7 +163,8 @@
         );
 
         var table = $('.with-datatable').DataTable({
-            "dom": '<"row"<"toolbar col-md-8"<"pull-left"l>><"col-md-3 pull-right"f>>tip'
+            "dom": '<"row"<"toolbar col-md-8"<"pull-left"l>><"col-md-3 pull-right"f>>tip',
+            "pageLength": 50
         });
 
         $("div.toolbar").prepend($("#toolbar-holder").html());


### PR DESCRIPTION
Fixes the issue #3073. 
Small fix:
Here are the screenshots
![screenshot from 2017-01-31 21-43-42](https://cloud.githubusercontent.com/assets/8847265/22473535/3b6551b6-e7ff-11e6-8ffc-153703f4127e.png)
![screenshot from 2017-01-31 21-43-48](https://cloud.githubusercontent.com/assets/8847265/22473549/4409aa10-e7ff-11e6-9046-8f56396d1dfd.png)
@SaptakS @niranjan94 @mariobehling Please review