### PR TITLE
handle sessions/speakers added by admin

### DIFF
--- a/app/helpers/sessions_speakers/speakers.py
+++ b/app/helpers/sessions_speakers/speakers.py
@@ -46,8 +46,17 @@ def save_speaker(request, event_id=None, speaker=None, user=None):
         )
         save_to_db(speaker)
 
-    if user and not speaker.user:
-        speaker.user = user
+    speaker.email = trim_get_form(request.form, 'email', None)
+    speaker.name = trim_get_form(request.form, 'name', None)
+
+    if not speaker.user:
+        if user:
+            speaker.user = user
+        else:
+            speaker.user = DataGetter.get_or_create_user_by_email(speaker.email, {
+                'firstname': speaker.name,
+                'lastname': ''
+            })
 
     if not event_id:
         event_id = speaker.event_id
@@ -68,10 +77,8 @@ def save_speaker(request, event_id=None, speaker=None, user=None):
         speaker.thumbnail = ''
         speaker.icon = ''
 
-    speaker.name = trim_get_form(request.form, 'name', None)
     speaker.short_biography = trim_get_form(request.form, 'short_biography', None)
     speaker.long_biography = trim_get_form(request.form, 'long_biography', None)
-    speaker.email = trim_get_form(request.form, 'email', None)
     speaker.mobile = trim_get_form(request.form, 'mobile', None)
     speaker.website = trim_get_form(request.form, 'website', None)
     speaker.twitter = trim_get_form(request.form, 'twitter', None)

--- a/app/views/users/sessions.py
+++ b/app/views/users/sessions.py
@@ -65,7 +65,7 @@ def create_view(event_id):
         return render_template('gentelella/users/events/info/enable_module.html', active_page='sessions',
                                title='Sessions', event=event)
     if request.method == 'POST':
-        DataManager.add_session_to_event(request, event_id)
+        DataManager.add_session_to_event(request, event_id, use_current_user=False)
         flash("The session and speaker have been saved")
         get_from = request.args.get("from")
         if get_from and get_from == 'speaker':


### PR DESCRIPTION
Resolves #3102

When an organizer adds a session or a speaker from `/events/<event_id>/sessions` or `/events/<event_id>/speakers`

The session/speaker is linked to the already existing user. (searched by email). if a user with that email, does not exisit, the user is created automatically and an email is sent with username and a temp. password.