### PR TITLE
Fixes #3145: Adds correct links to orders dashboard

### DIFF
--- a/app/templates/gentelella/users/events/tickets/attendees.html
+++ b/app/templates/gentelella/users/events/tickets/attendees.html
@@ -45,29 +45,29 @@
 {% block inner_content %}
     <div id="toolbar-holder" style="display: none;">
         <div class="btn-group pull-left" data-toggle="buttons">
-            <label class="btn btn-default active btn-responsive">
+            <label id="completed" class="btn btn-default  btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Completed" checked> {{ _("Completed") }}
             </label>
-            <label class="btn btn-default btn-responsive">
+            <label id="placed" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Placed"> {{ _("Placed") }}
             </label>
-            <label class="btn btn-default btn-responsive">
+            <label id="pending" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Pending"> {{ _("Pending") }}
             </label>
-            <label class="btn btn-default btn-responsive">
+            <label id="expired" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Expired"> {{ _("Expired") }}
             </label>
-            <label class="btn btn-default btn-responsive">
+            <label id="cancelled" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Cancelled"> {{ _("Cancelled") }}
             </label>
-            <label class="btn btn-default btn-responsive">
+            <label id="checked-in" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="checked_in"> {{ _("Checked In") }}
             </label>
-            <label class="btn btn-default btn-responsive">
+            <label id="not-checked-in" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off"
                        value="not_checked_in"> {{ _("Not Checked In") }}
             </label>
-            <label class="btn btn-default btn-responsive">
+            <label id="all" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="all"> {{ _("All") }}
             </label>
 
@@ -169,7 +169,7 @@
     <script src="{{ url_for('static', filename='vendor/datatables.net/js/jquery.dataTables.min.js') }}"></script>
     <script src="{{ url_for('static', filename='vendor/datatables.net-bs/js/dataTables.bootstrap.min.js') }}"></script>
     <script type="text/javascript">
-
+        var options = ['#completed', '#placed', '#pending', '#expired', '#cancelled', '#all'];  
         $.fn.dataTable.ext.search.push(
             function (settings, data, dataIndex) {
                 var user_option = $("input[name=show_state]:checked").val();
@@ -203,11 +203,20 @@
             "order": [[1, 'asc']],
             "scrollX": true
         });
-
-        $("div.toolbar").prepend($("#toolbar-holder").html());
-
+        if ($.inArray(window.location.hash, options) != -1)
+        {    
+            $(window.location.hash).button('toggle');
+            $("div.toolbar").prepend($("#toolbar-holder").html());
+        } 
+        else 
+        {           
+              $('#Completed').button('toggle');           
+              $("div.toolbar").prepend($("#toolbar-holder").html());          
+        }
         $("input[name=show_state]").change(function () {
             table.draw();
+            window.location.hash = $("input[name=show_state]:checked").val();   
+
         });
 
         table.on('draw', function () {

--- a/app/templates/gentelella/users/events/tickets/orders.html
+++ b/app/templates/gentelella/users/events/tickets/orders.html
@@ -40,19 +40,19 @@
 {% block inner_content %}
     <div id="toolbar-holder" style="display: none;">
         <div class="btn-group pull-left" data-toggle="buttons">
-            <label id="Completed" class="btn btn-default btn-responsive">
+            <label id="completed" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Completed"> {{ _("Completed") }}
             </label>
-            <label id="Placed" class="btn btn-default btn-responsive">
+            <label id="placed" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Placed"> {{ _("Placed") }}
             </label>
-            <label id="Pending" class="btn btn-default btn-responsive">
+            <label id="pending" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Pending"> {{ _("Pending") }}
             </label>
-            <label id="Expired" class="btn btn-default btn-responsive">
+            <label id="expired" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Expired"> {{ _("Expired") }}
             </label>
-            <label id="Cancelled" class="btn btn-default btn-responsive">
+            <label id="cancelled" class="btn btn-default btn-responsive">
                 <input type="radio" name="show_state" autocomplete="off" value="Cancelled"> {{ _("Cancelled") }}
             </label>
             <label id="all" class="btn btn-default btn-responsive">
@@ -186,7 +186,7 @@
     <script src="{{ url_for('static', filename='vendor/datatables.net/js/jquery.dataTables.min.js') }}"></script>
     <script src="{{ url_for('static', filename='vendor/datatables.net-bs/js/dataTables.bootstrap.min.js') }}"></script>
     <script type="text/javascript">
-        var options = ['#Completed', '#Placed', '#Pending', '#Expired', '#Cancelled', '#all'];
+        var options = ['#completed', '#placed', '#pending', '#expired', '#cancelled', '#all'];
 
         $.fn.dataTable.ext.search.push(
             function (settings, data, dataIndex) {

--- a/app/templates/gentelella/users/events/tickets/tickets.html
+++ b/app/templates/gentelella/users/events/tickets/tickets.html
@@ -140,7 +140,7 @@
                 {% if name!='deleted' %}
                 <tr>
                     <th>
-                        <a href="{{ url_for('event_ticket_sales.display_orders',event_id=event_id) + '#' + (name | capitalize) }}">
+                        <a href="{{ url_for('event_ticket_sales.display_orders',event_id=event_id) + '#' + (name) }}">
                             <span class="label label-{{ item.class }}">{{ name | capitalize }}</span>
                         </a>
                     </th>
@@ -154,8 +154,8 @@
                         {{ event.payment_currency | currency_symbol }}{{ item.total_sales | money }}
                     </td>
                     <td>
-                        <a href="./orders">{{ _("View orders") }}</a> / <a
-                            href="./attendees">{{ _("View attendees") }}</a>
+                        <a href="./orders#{{ name }}">{{ _("View orders") }}</a> / <a
+                            href="./attendees#{{ name }}">{{ _("View attendees") }}</a>
                     </td>
                 </tr>
                 {% endif %}


### PR DESCRIPTION
This fixes #3145. The links now point to the correct location.

Here is a preview: 

![giphy](https://cloud.githubusercontent.com/assets/17252805/22621457/330b0b0c-eb4a-11e6-9ceb-fbdb75e49071.gif)
