### PR TITLE
Issue #3078 :  Adds option of auto filling

### DIFF
--- a/app/static/js/guest/ticketing.js
+++ b/app/static/js/guest/ticketing.js
@@ -173,3 +173,25 @@ $payViaStripe.on('click', function (e) {
 $(window).on('popstate', function () {
     handler.close();
 });
+
+var checked = false;
+var checkboxes =  $('.autofill-checkbox');
+checkboxes.click(function(){
+        var firstName = $('#firstname').val();
+        var lastname =  $('#lastname').val();
+        var email =     $('#email').val();
+        var requiredId = this.id;
+        checkboxes.prop('disabled', true);
+        $(this).prop('disabled', false);
+        if($(this).is(':checked')) {
+            $('#' + requiredId + '-holders\\[firstname\\]').val(firstName);
+            $('#' + requiredId + '-holders\\[lastname\\]').val(lastname);
+            $('#' + requiredId + '-holders\\[email\\]').val(email);
+        }
+        else {
+            $('#' + requiredId + '-holders\\[firstname\\]').val("");
+            $('#' + requiredId + '-holders\\[lastname\\]').val("");
+            $('#' + requiredId + '-holders\\[email\\]').val("");
+            checkboxes.prop('disabled', false );
+        }
+});

--- a/app/templates/gentelella/guest/ticketing/order_pre_payment.html
+++ b/app/templates/gentelella/guest/ticketing/order_pre_payment.html
@@ -1,4 +1,4 @@
-{% extends 'gentelella/guest/ticketing/order_base.html' %}
+        {% extends 'gentelella/guest/ticketing/order_base.html' %}
 
 {% block title %}{{ _("Your Order") }}{% endblock %}
 
@@ -95,7 +95,7 @@
                     </h2>
                     <div id = "main-form" data-toggle="checkboxes" data-max="1">
                     {% for ticket_order in order.tickets %}
-
+                        {% set outer_loop = loop %}
                         {% for i in range(0, ticket_order.quantity) %}
 
                             <h4 class="col-sm-6 col-sm-push-4"
@@ -106,24 +106,24 @@
                             <div class="clearfix"></div>
                             <input type="hidden" name="holders[ticket_id]" value="{{ ticket_order.ticket_id }}">
                             <div class="form-group">
-                                <label for="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[firstname]"
+                                <label for="{{ outer_loop.index }}-{{ loop.index }}-holders[firstname]"
                                        class="col-sm-4 control-label">{{ _("First") }}
                                     {{ _("name") }} <span
                                             class="required">*</span></label>
                                 <div class="col-sm-6">
-                                    <input type="text" class="form-control" id="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[firstname]"
+                                    <input type="text" class="form-control" id="{{ outer_loop.index }}-{{ loop.index }}-holders[firstname]"
                                            name="holders[firstname]"
                                            required>
                                     <div class="help-block with-errors"></div>
                                 </div>
                             </div>
                             <div class="form-group">
-                                <label for="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[lastname]"
+                                <label for="{{ outer_loop.index }}-{{ loop.index }}-holders[lastname]"
                                        class="col-sm-4 control-label">{{ _("Last name") }}
                                     <span
                                             class="required">*</span></label>
                                 <div class="col-sm-6">
-                                    <input type="text" class="form-control" id="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[lastname]"
+                                    <input type="text" class="form-control" id="{{ outer_loop.index }}-{{ loop.index }}-holders[lastname]"
                                            name="holders[lastname]"
                                            required>
                                     <div class="help-block with-errors"></div>
@@ -131,13 +131,13 @@
                             </div>
 
                             <div class="form-group">
-                                <label for="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[email]"
+                                <label for="{{ outer_loop.index }}-{{ loop.index }}-holders[email]"
                                        class="col-sm-4 control-label">{{ _("Email") }} <span
                                         class="required">*</span></label>
                                 <div class="col-sm-6">
                                     <input type="email" class="form-control"
                                            name="holders[email]"
-                                           id="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[email]" required>
+                                           id="{{ outer_loop.index }}-{{ loop.index }}-holders[email]" required>
                                     <div class="help-block with-errors"></div>
                                 </div>
                             </div>
@@ -145,7 +145,7 @@
                              <div class="form-group">
                                 <label for="{{ loop.index }}" class="col-sm-4 control-label"> Autofill </label>
                                 <div class = "col-sm-4 ">
-                                    <input type="checkbox"  data-ticket-type="{{ ticket_order.ticket.name }}" class="form-control autofill-checkbox" id="{{ loop.index }}">
+                                    <input type="checkbox"  data-ticket-type="{{ ticket_order.ticket.name }}" class="form-control autofill-checkbox" id="{{ outer_loop.index}}-{{ loop.index }}">
                                 </div>
                              </div>
                         {% endif %}
@@ -313,8 +313,6 @@
     <script src="{{ url_for('static', filename='vendor/bootstrap-validator/dist/validator.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/vendor/jquery/jquery.codezero.js') }}"></script>
     <script src="{{ url_for('static', filename='js/guest/ticketing.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/vendor/jquery/jquery.checkboxes-1.2.0.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/tickets/prepay-tickets.js') }}"></script>
     <script type="text/javascript">
         $("input[name=pay_via_service]").click(function () {
             $(this).closest('.form-group').find("pre").hide();

--- a/app/templates/gentelella/guest/ticketing/order_pre_payment.html
+++ b/app/templates/gentelella/guest/ticketing/order_pre_payment.html
@@ -93,6 +93,7 @@
                         {{ _("Ticket Holders' Information") }}
                         <hr style="margin:0;border-width: 2px; border-color: #5bc0de;">
                     </h2>
+                    <div id = "main-form" data-toggle="checkboxes" data-max="1">
                     {% for ticket_order in order.tickets %}
 
                         {% for i in range(0, ticket_order.quantity) %}
@@ -105,24 +106,24 @@
                             <div class="clearfix"></div>
                             <input type="hidden" name="holders[ticket_id]" value="{{ ticket_order.ticket_id }}">
                             <div class="form-group">
-                                <label for="{{ loop.index }}-holders[firstname]"
+                                <label for="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[firstname]"
                                        class="col-sm-4 control-label">{{ _("First") }}
                                     {{ _("name") }} <span
                                             class="required">*</span></label>
                                 <div class="col-sm-6">
-                                    <input type="text" class="form-control" id="{{ loop.index }}-holders[firstname]"
+                                    <input type="text" class="form-control" id="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[firstname]"
                                            name="holders[firstname]"
                                            required>
                                     <div class="help-block with-errors"></div>
                                 </div>
                             </div>
                             <div class="form-group">
-                                <label for="{{ loop.index }}-holders[lastname]"
+                                <label for="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[lastname]"
                                        class="col-sm-4 control-label">{{ _("Last name") }}
                                     <span
                                             class="required">*</span></label>
                                 <div class="col-sm-6">
-                                    <input type="text" class="form-control" id="{{ loop.index }}-holders[lastname]"
+                                    <input type="text" class="form-control" id="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[lastname]"
                                            name="holders[lastname]"
                                            required>
                                     <div class="help-block with-errors"></div>
@@ -130,20 +131,27 @@
                             </div>
 
                             <div class="form-group">
-                                <label for="{{ loop.index }}-holders[email]"
+                                <label for="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[email]"
                                        class="col-sm-4 control-label">{{ _("Email") }} <span
                                         class="required">*</span></label>
                                 <div class="col-sm-6">
                                     <input type="email" class="form-control"
                                            name="holders[email]"
-                                           id="{{ loop.index }}-holders[email]" required>
+                                           id="{{ ticket_order.ticket.name }}-{{ loop.index }}-holders[email]" required>
                                     <div class="help-block with-errors"></div>
                                 </div>
                             </div>
-
+                         {% if loop.index == 1 %}
+                             <div class="form-group">
+                                <label for="{{ loop.index }}" class="col-sm-4 control-label"> Autofill </label>
+                                <div class = "col-sm-4 ">
+                                    <input type="checkbox"  data-ticket-type="{{ ticket_order.ticket.name }}" class="form-control autofill-checkbox" id="{{ loop.index }}">
+                                </div>
+                             </div>
+                        {% endif %}
                         {% endfor %}
                     {% endfor %}
-
+                </div>
                     {% if order.amount > 0 %}
                         <h2 style="font-weight:300; text-transform: uppercase; margin-top: 35px; color:#5bc0de;">
                             <i class="fa fa-ticket"></i>
@@ -305,6 +313,8 @@
     <script src="{{ url_for('static', filename='vendor/bootstrap-validator/dist/validator.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/vendor/jquery/jquery.codezero.js') }}"></script>
     <script src="{{ url_for('static', filename='js/guest/ticketing.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/vendor/jquery/jquery.checkboxes-1.2.0.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/tickets/prepay-tickets.js') }}"></script>
     <script type="text/javascript">
         $("input[name=pay_via_service]").click(function () {
             $(this).closest('.form-group').find("pre").hide();


### PR DESCRIPTION
The original IDs for various elements were repeated, hence they have been changed to distinguish individual text fields.
There may be multiple ticket types and the buyer might want to autofill anyone of them.
If the buyer choses any particular ticket type, the rest of the checkboxes automatically get disabled
The autofill box appears only once for a particular ticket type.

#3078

Preview: 
![image](https://cloud.githubusercontent.com/assets/17252805/22717109/3fe97d00-edbf-11e6-96c6-c8aa1246093d.png)

@niranjan94 
Please review.