### PR TITLE
Fixes #3113: Adds from name to email

### DIFF
--- a/app/helpers/helpers.py
+++ b/app/helpers/helpers.py
@@ -391,7 +391,11 @@ def send_email(to, action, subject, html):
     """
     if not string_empty(to):
         email_service = get_settings()['email_service']
-        email_from = get_settings()['email_from']
+        email_from_name = get_settings()['email_from_name']
+        if email_service == 'smtp':
+            email_from = email_from_name + '<' + get_settings()['email_from'] + '>'
+        else:
+            email_from = get_settings()['email_from']
         payload = {
             'to': to,
             'from': email_from,
@@ -422,6 +426,7 @@ def send_email(to, action, subject, html):
                 from tasks import send_mail_via_smtp_task
                 send_mail_via_smtp_task.delay(config, payload)
             else:
+                payload['fromname'] = email_from_name
                 key = get_settings()['sendgrid_key']
                 if not key and not current_app.config['TESTING']:
                     print 'Sendgrid key not defined'

--- a/app/templates/gentelella/super_admin/settings/_system.html
+++ b/app/templates/gentelella/super_admin/settings/_system.html
@@ -230,6 +230,13 @@
                            value="{{ settings.email_from|default('', True) }}">
                 </div>
             </div>
+            <div class="form-group">
+                 <label class="control-label col-md-3 col-sm-3 col-xs-12">{{ _("From Name") }}</label>
+                 <div class=" col-md-9 col-xs-12">
+                     <input name="email_from_name"  class="form-control col-md-6 col-xs-6"
+                            value="{{ settings.email_from_name|default('', True) }}">
+                 </div>
+            </div>
             <div class="radio">
                 <label>
                     <input type="radio" name="email_service" id="email_service_smtp" class="radio_email" value="smtp"


### PR DESCRIPTION
Fixes #3113 

Specifies from "Name" for emails in admin dashboard

![image](https://cloud.githubusercontent.com/assets/17252805/22820457/d9eaf6e8-ef9c-11e6-8b01-454402ec762b.png)
