### PR TITLE
Add option to resend order confirmation

### DIFF
--- a/app/helpers/ticketing.py
+++ b/app/helpers/ticketing.py
@@ -542,3 +542,16 @@ class TicketingManager(object):
                 save_to_db(order)
             return True
         return False
+
+    @staticmethod
+    def resend_confirmation(form):
+        order = TicketingManager.get_and_set_expiry(form.get('identifier'))
+        email = form.get('email')
+        event_id = order.event_id
+        invoice_id = order.get_invoice_number()
+        order_url = url_for('ticketing.view_order_after_payment', order_identifier=order.identifier, _external=True)
+        if login.current_user.is_organizer(event_id):
+            trigger_after_purchase_notifications(email, order.event_id, order.event, invoice_id, order_url)
+            send_email_for_after_purchase(email, invoice_id, order_url, order.event.name, order.event.organizer_name)
+            return True
+        return False

--- a/app/templates/gentelella/users/events/tickets/orders.html
+++ b/app/templates/gentelella/users/events/tickets/orders.html
@@ -152,6 +152,7 @@
                                         </div>
                                     </div>
                             </div>
+                            <br>
                             {% endif %}
                             {% if order.amount == 0 or order.status != "completed" %}
                                 <button data-toggle="modal" data-target="#delete-order-{{ order.identifier }}" title="Delete" class="btn btn-default delete-order"><i class="fa fa-trash fa-fw"></i></button>
@@ -167,6 +168,34 @@
                                                     <form action="{{ url_for('event_ticket_sales.delete_order', event_id=event_id) }}" method="post">
                                                         <input type="hidden" name="identifier" value="{{ order.identifier }}">
                                                         <button type="submit" class="btn btn-success ">{{ _("Delete Ticket") }}</button>
+                                                    </form>
+                                                </div>
+                                            </div>
+                                        </div>
+                                </div>
+                                <br>
+                            {% endif %}
+                            {% if order.status == "completed" or order.status == "placed" %}
+                            <button data-toggle="modal" data-target="#resend-order-{{ order.identifier }}" title="Resend" class="btn btn-default resend-order"><i class="fa fa-envelope fa-fw"></i></button>
+                                <div class="modal fade" id="resend-order-{{ order.identifier }}" role="dialog">
+                                        <div class="modal-dialog">
+                                            <div class="modal-content">
+                                                <div class="modal-header">
+                                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                                            aria-hidden="true">&times;</span></button>
+                                                    <h4 class="modal-title">{{ _("Resend Order Confirmation") }}</h4>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <form action="{{ url_for('event_ticket_sales.resend_confirmation', event_id=event_id) }}" method="post">
+                                                        <input type="hidden" name="identifier" value="{{ order.identifier }}">
+                                                        <div class="email">
+                                                            <label>
+                                                                {{ _("Send confirmation email to:") }}
+                                                            </label>
+                                                                <input type="email" name="email" style="margin-top: 5px; width: 60%;">
+                                                            <br>
+                                                            <button type="submit" class="btn btn-success" style="margin-top: 12px">{{ _("Resend") }}</button>
+                                                        </div>
                                                     </form>
                                                 </div>
                                             </div>

--- a/app/views/users/ticket_sales.py
+++ b/app/views/users/ticket_sales.py
@@ -405,3 +405,12 @@ def delete_order(event_id):
         return redirect(url_for('.display_orders', event_id=event_id))
     else:
         abort(403)
+
+
+@event_ticket_sales.route('/resend-confirmation/', methods=('POST',))
+def resend_confirmation(event_id):
+    return_status = TicketingManager.resend_confirmation(request.form)
+    if return_status:
+        return redirect(url_for('.display_orders', event_id=event_id))
+    else:
+        abort(403)


### PR DESCRIPTION
fixes #2998 
- Implemented modal similar to cancel order to resend email confirmation
- Option only available for completed and placed orders
![selection_121](https://cloud.githubusercontent.com/assets/13910561/22856084/b1c786a8-f0b0-11e6-953a-814288987e09.png)
![selection_120](https://cloud.githubusercontent.com/assets/13910561/22856090/c216f8cc-f0b0-11e6-9319-c6d26972a249.png)

