### PR TITLE
Fix: checkbox not visible on admin/messages

### DIFF
--- a/app/templates/gentelella/super_admin/messages/messages.html
+++ b/app/templates/gentelella/super_admin/messages/messages.html
@@ -9,7 +9,7 @@
 {% block head_css %}
     {{ super() }}
     <link rel="stylesheet"
-          href="{{ url_for('static', filename='css/bootstrap/green.css') }}"/>
+          href="{{ url_for('static', filename='css/vendor/bootstrap/green.css') }}"/>
     <style type="text/css">
         #secondary-tabs {
             position: absolute;


### PR DESCRIPTION
fixes #3181 
Reason: broken css link
![selection_123](https://cloud.githubusercontent.com/assets/13910561/22856666/d20ae9a4-f0bb-11e6-91b1-26bc56f004ed.png)
