### PR TITLE
Use proper event id while sending new proposal emails

### DIFF
--- a/app/helpers/notification_email_triggers.py
+++ b/app/helpers/notification_email_triggers.py
@@ -19,7 +19,7 @@ def trigger_new_session_notifications(session_id, event_id=None, event=None):
     admin_msg_setting = DataGetter.get_message_setting_by_action(NEW_SESSION)
     organizers = DataGetter.get_user_event_roles_by_role_name(event.id, 'organizer')
     for organizer in organizers:
-        email_notification_setting = DataGetter.get_email_notification_settings_by_event_id(organizer.user.id, event_id)
+        email_notification_setting = DataGetter.get_email_notification_settings_by_event_id(organizer.user.id, event.id)
         if not admin_msg_setting or \
             (email_notification_setting and email_notification_setting.new_paper == 1 and
              admin_msg_setting.user_control_status == 1) or admin_msg_setting.user_control_status == 0:


### PR DESCRIPTION
fixes #3082.

Emails now being sent on new proposals.

![selection_124](https://cloud.githubusercontent.com/assets/13910561/22856829/b634acb6-f0bf-11e6-876d-97c93ab33fa1.png)
