### PR TITLE
 Removes linespacing from ticket list

### DIFF
--- a/app/templates/gentelella/super_admin/events/events.html
+++ b/app/templates/gentelella/super_admin/events/events.html
@@ -83,9 +83,8 @@
                 {% if flag %}
                     {% for id, item in ticket_stats.iteritems() %}
                         <div>
-                            <span>{{ item.name }}</span> <span> ({{item.completed}}/{{item.total}}) </span> 
+                            <span>{{ item.name }}</span> <span> ({{item.completed}}/{{item.total}}) </span>
                         </div>
-                        <br>
                      {% endfor %}
                 {% else %}
                     {{ _("No Ticket Information") }}

--- a/app/templates/gentelella/users/events/_table.html
+++ b/app/templates/gentelella/users/events/_table.html
@@ -72,9 +72,8 @@
                         {% if flag %}
                             {% for id, item in ticket_stats.iteritems() %}
                                 <div>
-                                    <span>{{ item.name }}</span> <span> ({{item.completed}}/{{item.total}}) </span> 
+                                    <span>{{ item.name }}</span> <span> ({{item.completed}}/{{item.total}}) </span>
                                 </div>
-                                <br>
                              {% endfor %}
                         {% else %}
                             {{ _("No Ticket Information") }}


### PR DESCRIPTION
fixed #3107 

As per the discussion this completely removes the linespacing from the ticket list in events table for general user as well as admin.