### PR TITLE
Partly Solves #2803: Show facebook on applications page and aligned application fields

### DIFF
--- a/app/static/css/events/settings.css
+++ b/app/static/css/events/settings.css
@@ -1,3 +1,8 @@
+
+.input-group-addon.social-addon {
+	min-width: 135px;
+}
+
 #events-accordion > .panel > .panel-heading {
     background-color: #FFFFFF;
 }

--- a/app/templates/gentelella/users/settings/pages/applications.html
+++ b/app/templates/gentelella/users/settings/pages/applications.html
@@ -14,13 +14,12 @@
 {% block content %}
 
     <div style="display: block;">
-        {% if user.user_detail.facebook %}
         <div class="row" style="margin-bottom:20px">
 
             <div class="col-md-6 col-xs-6">
                 <label>Facebook:</label>
                 <div class="input-group">
-                    <span class="input-group-addon">facebook.com/</span>
+                    <span class="input-group-addon social-addon">facebook.com/</span>
                     <input type="text" name="facebook" class="form-control"
                            value="{{ user.user_detail.facebook|default('', true) | replace('https://facebook.com/', '') }}"
                            style="min-width: 400px"
@@ -37,13 +36,12 @@
             </div>
 
         </div>
-        {% endif %}
 
         <div class="row" style="margin-bottom:20px">
             <div class="col-md-6 col-xs-6">
                 <label>Twitter:</label>
                 <div class="input-group">
-                    <span class="input-group-addon" id="basic-addon3">twitter.com/</span>
+                    <span class="input-group-addon social-addon" id="basic-addon3">twitter.com/</span>
 
                     <input type="text" name="twitter" class="form-control"
                            value="{{ user.user_detail.twitter|default('', true) | replace('https://twitter.com/', '') }}"
@@ -62,7 +60,7 @@
             <div class="col-md-6 col-xs-6">
                 <label>Instagram:</label>
                 <div class="input-group">
-                    <span class="input-group-addon" id="basic-addon3">instagram.com/</span>
+                    <span class="input-group-addon social-addon" id="basic-addon3">instagram.com/</span>
 
                     <input type="text" name="instagram" class="form-control"
                            value="{{ user.user_detail.instagram|default('', true) | replace('https://instagram.com/', '') }}"
@@ -82,7 +80,7 @@
             <div class="col-md-6 col-xs-6">
                 <label>Google+:</label>
                 <div class="input-group">
-                    <span class="input-group-addon" id="basic-addon3">plus.google.com/</span>
+                    <span class="input-group-addon social-addon" id="basic-addon3">plus.google.com/</span>
 
                     <input type="text" name="google" class="form-control"
                            value="{{ user.user_detail.google|default('', true) | replace('https://plus.google.com/', '') }}"


### PR DESCRIPTION
This partly fixes issue #2803.
The facebook field was only showing up if user details were available so I removed the conditional statement and added the css attribute to align all the application fields.
![application](https://cloud.githubusercontent.com/assets/14943372/22862562/4cde3578-f157-11e6-9a02-7462d150390b.png)
