### PR TITLE
Adds colour to unscheduled sessions in assigned track colour

### DIFF
--- a/app/static/css/events/scheduler.css
+++ b/app/static/css/events/scheduler.css
@@ -28,6 +28,7 @@
 
 .unscheduled {
     margin-bottom: 3px;
+    color: white;
     cursor: all-scroll !important;
 }
 

--- a/app/static/js/events/scheduler.js
+++ b/app/static/js/events/scheduler.js
@@ -321,6 +321,7 @@ function addSessionToUnscheduled(sessionRef, isFiltering, shouldBroadcast) {
         "top": ""
     }).removeData("x").removeData("y");
 
+    updateColor(sessionRefObject.$sessionElement, sessionRefObject.session.track);
     sessionRefObject.$sessionElement.ellipsis().ellipsis();
     $noSessionsInfoBox.hide();
 


### PR DESCRIPTION
fixes #3198 

![image](https://cloud.githubusercontent.com/assets/17252805/22906517/d5d16b70-f26a-11e6-9734-d65fc1233d2e.png)

Now the unscheduled sessions show their assigned track colours too.