### PR TITLE
Albania added in payment countries #3204

### DIFF
--- a/app/helpers/static.py
+++ b/app/helpers/static.py
@@ -153,6 +153,7 @@ EVENT_TOPICS = {
 }
 PAYMENT_COUNTRIES = {
     'United States',
+    'Albania'
     'Argentina',
     'Australia',
     'Austria',


### PR DESCRIPTION
Fixes #3204 
Albania is added to the list of countries where payments are accepted.
PLease review.