### PR TITLE
Give co-organizer the same permissions as organizer for the wizard

### DIFF
--- a/app/views/users/events.py
+++ b/app/views/users/events.py
@@ -452,7 +452,7 @@ def save_event_from_wizard(what):
         event_id = None
     else:
         event_id = data['event_id']
-        if not current_user.is_staff and not current_user.is_organizer(event_id):
+        if not current_user.is_staff and not current_user.is_organizer(event_id) and not current_user.is_coorganizer(event_id):
             abort(403)
     if what == 'event':
         return jsonify(save_event_from_json(data, event_id))


### PR DESCRIPTION
modifications. Closes #3196.

* Gives the co-organizer the same permissions as the organizer for the wizard modifications step. This is a temporary fix and the proper solution will be implemented after a more thorough discussion.

Here is the test server: http://ancient-thicket-44821.herokuapp.com
The added items are now being saved.

Admin Credentials:

```
user-id: princu7@gmail.com
password: fossasia
```

Co-Organizer Credentials(of the event Hurry)

```
Event link: http://ancient-thicket-44821.herokuapp.com/events/8/
user-id: a@a.com
password: fossasia
```