### PR TITLE
Speaker and Session form separated for 'call for speakers'

### DIFF
--- a/app/helpers/sessions_speakers/speakers.py
+++ b/app/helpers/sessions_speakers/speakers.py
@@ -47,7 +47,8 @@ def save_speaker(request, event_id=None, speaker=None, user=None):
         save_to_db(speaker)
 
     speaker.email = trim_get_form(request.form, 'email', None)
-    speaker.name = trim_get_form(request.form, 'name', None)
+    if trim_get_form(request.form, 'name', None):
+        speaker.name = trim_get_form(request.form, 'name', None)
 
     if not speaker.user:
         if user:

--- a/app/templates/gentelella/guest/event/cfs.html
+++ b/app/templates/gentelella/guest/event/cfs.html
@@ -31,11 +31,9 @@
                 {{ call_for_speakers.announcement | safe }}
                 {% if state == "now" or via_hash %}
                     {% if current_user.is_authenticated %}
-                        <a href="/e/{{ event.identifier }}/cfs/new">
-                            <button class="btn btn-success" data-toggle="modal"
-                                data-target="#session-modal">{{ _("Submit Proposal") }}
-                            </button>
-                        </a>
+                        <button class="btn btn-success" data-toggle="modal"
+                                data-target="#speaker-session-modal">{{ _("Submit Proposal") }}
+                        </button>
                     {% else %}
                         <button class="btn btn-success" data-toggle="modal"
                                 data-target="#login-user-modal">{{ _("Submit Proposal") }}
@@ -51,6 +49,20 @@
                                 <div class="modal-footer">
                                     <a type="button" class="btn btn-default" data-dismiss="modal">{{ _("Cancel") }}</a>
                                     <a href="{{ url_for('admin.login_view', next=request.url) }}" type="button" class="btn btn-success" id = "login-signup-button">{{ _("Login/SignUp") }}</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="speaker-session-modal" class="modal fade" tabindex="-1" role="dialog">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"></button>
+                                    <h4 class="modal-title">{{ _("Submit Proposal") }} ? </h4>
+                                </div>
+                                <div class="modal-footer" style="padding:6px">
+                                    <a href="/e/{{ event.identifier }}/cfs/new_speaker" type="button" class="btn btn-info" id = "speaker-button">{{ _("Register as a Speaker") }}</a>
+                                    <a href="/e/{{ event.identifier }}/cfs/new_session" type="button" class="btn btn-primary" id = "session-button" style="margin-top:-6px">{{ _("Propose Session") }}</a>
                                 </div>
                             </div>
                         </div>

--- a/app/templates/gentelella/guest/event/cfs.html
+++ b/app/templates/gentelella/guest/event/cfs.html
@@ -53,20 +53,51 @@
                             </div>
                         </div>
                     </div>
-                    <div id="speaker-session-modal" class="modal fade" tabindex="-1" role="dialog">
-                        <div class="modal-dialog">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"></button>
-                                    <h4 class="modal-title">{{ _("Submit Proposal") }} ? </h4>
-                                </div>
-                                <div class="modal-footer" style="padding:6px">
-                                    <a href="/e/{{ event.identifier }}/cfs/new_speaker" type="button" class="btn btn-info" id = "speaker-button">{{ _("Register as a Speaker") }}</a>
-                                    <a href="/e/{{ event.identifier }}/cfs/new_session" type="button" class="btn btn-primary" id = "session-button" style="margin-top:-6px">{{ _("Propose Session") }}</a>
+                    {% if not user_speaker[0] %}
+                        <div id="speaker-session-modal" class="modal fade" tabindex="-1" role="dialog">
+                            <div class="modal-dialog">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"></button>
+                                        <h4 class="modal-title">{{ _("Submit Proposal") }}? </h4>
+                                    </div>
+                                    <div class="modal-footer" style="padding:6px">
+                                        <a href="/e/{{ event.identifier }}/cfs/new_speaker" type="button" class="btn btn-info" id = "speaker-button">{{ _("Register as a Speaker") }}</a>
+                                        <a href="/e/{{ event.identifier }}/cfs/new/" type="button" class="btn btn-primary" id = "session-button" style="margin-top:-6px">{{ _("Propose Session") }}</a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
+                    {% else %}
+                        <div id="speaker-session-modal" class="modal fade" tabindex="-1" role="dialog">
+                            <div class="modal-dialog">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"></button>
+                                        <h4 class="modal-title">{{ _("Add Speaker Information") }} </h4>
+                                    </div>
+                                    <div class="modal-footer">
+                                        <div class="existing-session" style="text-align:left"> 
+                                            <h4>{{ _("Existing Sessions") }} </h4>
+                                            {% for speaker in user_speaker %}
+                                                {% for session in speaker.sessions %}
+                                                    {% if not session.in_trash %} 
+                                                        {% if session.title %}
+                                                            {{ session }} <a href="{{ url_for('my_sessions.process_session_view',session_id=session.id) }}"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a><br>
+                                                        {% endif %}
+                                                    {% endif %}
+                                                {% endfor %}
+                                                <hr>
+                                            {% endfor %}
+                                        </div>
+                                        <div class="add_proposal">
+                                            <a href="/e/{{ event.identifier }}/cfs/new_session" type="button" class="btn btn-success" id = "session-button" style="margin-top:-6px">{{ _("Add Session Proposal") }}</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
                 {% endif %}
             </div>
         </div>

--- a/app/templates/gentelella/guest/event/cfs_new.html
+++ b/app/templates/gentelella/guest/event/cfs_new.html
@@ -1,0 +1,28 @@
+{% extends 'gentelella/guest/event/base.html' %}
+
+{% set active_page = 'cfs' %}
+
+{% block head_css %}
+    {{ super() }}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/events/event-wizard.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='vendor/multiselect/css/multi-select.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='vendor/Croppie/croppie.css') }}"/>
+{% endblock %}
+
+{% block content %}
+
+    {% include 'gentelella/users/events/sessions/components/session_speaker_form.html' %}
+
+{% endblock %}
+
+{% block tail_js %}
+    {{ super() }}
+    <script src="{{ url_for('static', filename='js/vendor/jquery/jquery.multi-select.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/events/session/new.js') }}"></script>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $("textarea").summernote(summernoteConfig);
+        });
+    </script>
+
+{% endblock %}

--- a/app/templates/gentelella/guest/event/cfs_new_session.html
+++ b/app/templates/gentelella/guest/event/cfs_new_session.html
@@ -11,7 +11,8 @@
 
 {% block content %}
 
-    {% include 'gentelella/users/events/sessions/components/session_speaker_form.html' %}
+    <h4 style="text-align: center">{{ _("Session Details") }}</h4>
+    {% include 'gentelella/users/events/sessions/components/session_form.html' %}
 
 {% endblock %}
 

--- a/app/templates/gentelella/guest/event/cfs_new_speaker.html
+++ b/app/templates/gentelella/guest/event/cfs_new_speaker.html
@@ -1,0 +1,29 @@
+{% extends 'gentelella/guest/event/base.html' %}
+
+{% set active_page = 'cfs' %}
+
+{% block head_css %}
+    {{ super() }}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/events/event-wizard.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='vendor/multiselect/css/multi-select.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='vendor/Croppie/croppie.css') }}"/>
+{% endblock %}
+
+{% block content %}
+    
+    <h4 style="text-align: center">{{ _("Speaker Details") }}</h4>
+    {% include 'gentelella/users/events/sessions/components/speaker_form.html' %}
+
+{% endblock %}
+
+{% block tail_js %}
+    {{ super() }}
+    <script src="{{ url_for('static', filename='js/vendor/jquery/jquery.multi-select.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/events/session/new.js') }}"></script>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $("textarea").summernote(summernoteConfig);
+        });
+    </script>
+
+{% endblock %}

--- a/app/templates/gentelella/users/events/sessions/base_session_table.html
+++ b/app/templates/gentelella/users/events/sessions/base_session_table.html
@@ -72,7 +72,7 @@
                 </thead>
                 <tbody>
                 {% for session in sessions %}
-                    {% if session.in_trash == False %}
+                    {% if session.title and session.in_trash == False %}
                         {% set versions_count = count_versions(session) %}
                         <tr>
                             <td>

--- a/app/templates/gentelella/users/events/sessions/components/session_form.html
+++ b/app/templates/gentelella/users/events/sessions/components/session_form.html
@@ -13,18 +13,23 @@
                 {{ _session_component.session_form_field(elem, session_form[elem].require) }}
             {% endif %}
         {% endfor %}
-        <div class="item form-group">
-            <label>{{ _("Modify Speakers") }}</label>
-            <select title="{{ _("Modify Speakers") }}" multiple="multiple" id="speakers" name="speakers[]">
-                {% for existing_speaker in speakers %}
-                    <option value="{{ existing_speaker.id }}"
+        {% if from_path != 'cfs' %}
+            <div class="item form-group">
+                <label>{{ _("Modify Speakers") }}</label>
+                <select title="{{ _("Modify Speakers") }}" multiple="multiple" id="speakers" name="speakers[]">
+                    {% for existing_speaker in speakers %}
+                        <option value="{{ existing_speaker.id }}"
                             {% if session and existing_speaker in session.speakers %}{{ _("selected") }}{% endif %}
                             data-html-addon="<img src='{{ existing_speaker.photo }}' onerror='imgError(this);' style='width: 2rem; height: 2rem;border-radius: 50%;'>">
-                        {{ existing_speaker.name }}
-                    </option>
-                {% endfor %}
-            </select>
-        </div>
+                            {{ existing_speaker.name }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+        {% endif %}
+        {% if from_path == 'cfs' %}
+            <input  name="email"  value="{{ current_user.email }}" type="hidden">
+        {% endif %}
 
         <br>
         <button type="submit" class="btn btn-success" name="state" value="save">{{ _("Save Session") }}</button>

--- a/app/templates/gentelella/users/events/speakers/base_speaker_table.html
+++ b/app/templates/gentelella/users/events/speakers/base_speaker_table.html
@@ -98,7 +98,9 @@
                             <ol style="padding-left: 14px;">
                                 {% for session in speaker.sessions %}
                                     {% if not session.in_trash %}
-                                        <li>{{ session.title }}</li>
+                                        {% if session.title %}
+                                            <li>{{ session.title }}</li>
+                                        {% endif %}
                                     {% endif %}
                                 {% endfor %}
                             </ol>

--- a/app/templates/gentelella/users/mysessions/mysessions_list.html
+++ b/app/templates/gentelella/users/mysessions/mysessions_list.html
@@ -122,9 +122,11 @@
                         <div class="tab-pane fade active in" id="upcoming-events-tab">
                             <div class="row">
                                 {% for session in upcoming_events_sessions %}
-                                    <div class="col-md-6 col-sm-12 col-xs-12">
-                                        {{ session_element(session) }}
-                                    </div>
+                                    {% if session.title %}
+                                        <div class="col-md-6 col-sm-12 col-xs-12">
+                                            {{ session_element(session) }}
+                                        </div>
+                                    {% endif %}
                                 {% else %}
                                     <span class="message">{{ _("No session proposals for upcoming events found") }}</span>
                                 {% endfor %}

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -189,6 +189,9 @@ def display_event_schedule_xcal(identifier):
 def display_event_cfs(identifier, via_hash=False):
     event = get_published_event_or_abort(identifier)
     placeholder_images = DataGetter.get_event_default_images()
+    if login.current_user.is_authenticated:
+        email = login.current_user.email
+        user_speaker = DataGetter.get_speaker_by_email(email)
     if event.sub_topic:
         custom_placeholder = DataGetter.get_custom_placeholder_by_name(event.sub_topic)
     elif event.topic:
@@ -218,12 +221,20 @@ def display_event_cfs(identifier, via_hash=False):
         state = "future"
     speakers = DataGetter.get_speakers(event.id).all()
     accepted_sessions_count = get_count(DataGetter.get_sessions(event.id))
-    return render_template('gentelella/guest/event/cfs.html', event=event,
+    if not login.current_user.is_authenticated:
+        return render_template('gentelella/guest/event/cfs.html', event=event,
                            speaker_form=speaker_form,
                            accepted_sessions_count=accepted_sessions_count,
                            session_form=session_form, call_for_speakers=call_for_speakers,
                            placeholder_images=placeholder_images, state=state, speakers=speakers,
                            via_hash=via_hash, custom_placeholder=custom_placeholder)
+    else:
+        return render_template('gentelella/guest/event/cfs.html', event=event,
+                           speaker_form=speaker_form,
+                           accepted_sessions_count=accepted_sessions_count,
+                           session_form=session_form, call_for_speakers=call_for_speakers,
+                           placeholder_images=placeholder_images, state=state, speakers=speakers,
+                           via_hash=via_hash, custom_placeholder=custom_placeholder, user_speaker=user_speaker)
 
 
 @event_detail.route('/cfs/<hash>/', methods=('GET', 'POST'))
@@ -269,6 +280,63 @@ def display_event_cfs_via_hash(hash):
                            session_form=session_form, call_for_speakers=call_for_speakers,
                            placeholder_images=placeholder_images, state=state, speakers=speakers,
                            via_hash=True, custom_placeholder=custom_placeholder)
+
+
+@event_detail.route('/<identifier>/cfs/new/', methods=('POST', 'GET'))
+def process_event_cfs(identifier, via_hash=False):
+    if request.method == 'GET':
+        event = get_published_event_or_abort(identifier)
+        placeholder_images = DataGetter.get_event_default_images()
+        if event.sub_topic:
+            custom_placeholder = DataGetter.get_custom_placeholder_by_name(event.sub_topic)
+        elif event.topic:
+            custom_placeholder = DataGetter.get_custom_placeholder_by_name(event.topic)
+        else:
+            custom_placeholder = DataGetter.get_custom_placeholder_by_name('Other')
+        if not event.has_session_speakers:
+            abort(404)
+
+        call_for_speakers = DataGetter.get_call_for_papers(event.id).first()
+
+        if not call_for_speakers or (not via_hash and call_for_speakers.privacy == 'private'):
+            abort(404)
+
+        form_elems = DataGetter.get_custom_form_elements(event.id)
+        speaker_form = json.loads(form_elems.speaker_form)
+        session_form = json.loads(form_elems.session_form)
+
+        now = datetime.now(pytz.timezone(event.timezone
+                                                  if (event.timezone and event.timezone != '') else 'UTC'))
+        start_date = pytz.timezone(event.timezone).localize(call_for_speakers.start_date)
+        end_date = pytz.timezone(event.timezone).localize(call_for_speakers.end_date)
+        state = "now"
+        if end_date < now:
+            state = "past"
+        elif start_date > now:
+            state = "future"
+        speakers = DataGetter.get_speakers(event.id).all()
+        accepted_sessions_count = get_count(DataGetter.get_sessions(event.id))
+        return render_template('gentelella/guest/event/cfs_new.html', event=event,
+                               speaker_form=speaker_form,
+                               accepted_sessions_count=accepted_sessions_count,
+                               session_form=session_form, call_for_speakers=call_for_speakers,
+                               placeholder_images=placeholder_images, state=state, speakers=speakers,
+                               via_hash=via_hash, custom_placeholder=custom_placeholder, from_path="cfs")
+
+    if request.method == 'POST':
+        email = request.form['email']
+        event = DataGetter.get_event_by_identifier(identifier)
+        if not event.has_session_speakers:
+            abort(404)
+        DataManager.add_session_to_event(request, event.id)
+        if login.current_user.is_authenticated:
+            flash("Your session proposal has been submitted", "success")
+            return redirect(url_for('my_sessions.display_my_sessions_view', event_id=event.id))
+        else:
+            flash(Markup(
+                "Your session proposal has been submitted. Please login/register with <strong><u>" + email + "</u></strong> to manage it."),
+                "success")
+            return redirect(url_for('admin.login_view', next=url_for('my_sessions.display_my_sessions_view')))
 
 
 @event_detail.route('/<identifier>/cfs/new_session/', methods=('POST', 'GET'))
@@ -376,11 +444,11 @@ def process_event_cfs_speaker(identifier, via_hash=False):
             abort(404)
         DataManager.add_session_to_event(request, event.id)
         if login.current_user.is_authenticated:
-            flash("Your session proposal has been submitted", "success")
-            return redirect(url_for('my_sessions.display_my_sessions_view', event_id=event.id))
+            flash("You have been registered as Speaker", "success")
+            return redirect(url_for('event_detail.display_event_cfs', identifier=identifier))
         else:
             flash(Markup(
-                "Your session proposal has been submitted. Please login/register with <strong><u>" + email + "</u></strong> to manage it."),
+                "You have been registered as Speaker. Please login/register with <strong><u>" + email + "</u></strong> to manage it."),
                 "success")
             return redirect(url_for('admin.login_view', next=url_for('my_sessions.display_my_sessions_view')))
 

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -271,8 +271,8 @@ def display_event_cfs_via_hash(hash):
                            via_hash=True, custom_placeholder=custom_placeholder)
 
 
-@event_detail.route('/<identifier>/cfs/new/', methods=('POST', 'GET'))
-def process_event_cfs(identifier, via_hash=False):
+@event_detail.route('/<identifier>/cfs/new_session/', methods=('POST', 'GET'))
+def process_event_cfs_session(identifier, via_hash=False):
     if request.method == 'GET':
         event = get_published_event_or_abort(identifier)
         placeholder_images = DataGetter.get_event_default_images()
@@ -305,7 +305,64 @@ def process_event_cfs(identifier, via_hash=False):
             state = "future"
         speakers = DataGetter.get_speakers(event.id).all()
         accepted_sessions_count = get_count(DataGetter.get_sessions(event.id))
-        return render_template('gentelella/guest/event/cfs_new.html', event=event,
+        return render_template('gentelella/guest/event/cfs_new_session.html', event=event,
+                               speaker_form=speaker_form,
+                               accepted_sessions_count=accepted_sessions_count,
+                               session_form=session_form, call_for_speakers=call_for_speakers,
+                               placeholder_images=placeholder_images, state=state, speakers=speakers,
+                               via_hash=via_hash, custom_placeholder=custom_placeholder, from_path="cfs")
+
+    if request.method == 'POST':
+        email = request.form['email']
+        event = DataGetter.get_event_by_identifier(identifier)
+        if not event.has_session_speakers:
+            abort(404)
+        DataManager.add_session_to_event(request, event.id)
+        if login.current_user.is_authenticated:
+            flash("Your session proposal has been submitted", "success")
+            return redirect(url_for('my_sessions.display_my_sessions_view', event_id=event.id))
+        else:
+            flash(Markup(
+                "Your session proposal has been submitted. Please login/register with <strong><u>" + email + "</u></strong> to manage it."),
+                "success")
+            return redirect(url_for('admin.login_view', next=url_for('my_sessions.display_my_sessions_view')))
+
+
+@event_detail.route('/<identifier>/cfs/new_speaker/', methods=('POST', 'GET'))
+def process_event_cfs_speaker(identifier, via_hash=False):
+    if request.method == 'GET':
+        event = get_published_event_or_abort(identifier)
+        placeholder_images = DataGetter.get_event_default_images()
+        if event.sub_topic:
+            custom_placeholder = DataGetter.get_custom_placeholder_by_name(event.sub_topic)
+        elif event.topic:
+            custom_placeholder = DataGetter.get_custom_placeholder_by_name(event.topic)
+        else:
+            custom_placeholder = DataGetter.get_custom_placeholder_by_name('Other')
+        if not event.has_session_speakers:
+            abort(404)
+
+        call_for_speakers = DataGetter.get_call_for_papers(event.id).first()
+
+        if not call_for_speakers or (not via_hash and call_for_speakers.privacy == 'private'):
+            abort(404)
+
+        form_elems = DataGetter.get_custom_form_elements(event.id)
+        speaker_form = json.loads(form_elems.speaker_form)
+        session_form = json.loads(form_elems.session_form)
+
+        now = datetime.now(pytz.timezone(event.timezone
+                                                  if (event.timezone and event.timezone != '') else 'UTC'))
+        start_date = pytz.timezone(event.timezone).localize(call_for_speakers.start_date)
+        end_date = pytz.timezone(event.timezone).localize(call_for_speakers.end_date)
+        state = "now"
+        if end_date < now:
+            state = "past"
+        elif start_date > now:
+            state = "future"
+        speakers = DataGetter.get_speakers(event.id).all()
+        accepted_sessions_count = get_count(DataGetter.get_sessions(event.id))
+        return render_template('gentelella/guest/event/cfs_new_speaker.html', event=event,
                                speaker_form=speaker_form,
                                accepted_sessions_count=accepted_sessions_count,
                                session_form=session_form, call_for_speakers=call_for_speakers,


### PR DESCRIPTION
fixes #3069 
No color check- https://github.com/fossasia/open-event-orga-server/issues/3069#issuecomment-279318801 not done (will create another issue and solve)

**What Has been Done:**
**_1)_** **If User Not logged in:** _Pop up to log in_ (already done in another PR)

**_2)_** **If User logged in:** Give option for _(a) Registering as speaker_ or _(b) Proposing Session._
        In case of **Register as Speaker** , he goes to only speaker form.
        In case of **Proposing Session**, The user gets to both Session and Speaker form (Since session is meaningless without speaker)
![screenshot from 2017-02-22 18-53-16](https://cloud.githubusercontent.com/assets/20799954/23213302/7b257622-f930-11e6-95b8-88e298475ae5.png)

**_3)_** **If User is registered as speaker**: _He/She can either edit his already existing session or add more sessions_
       In **Add more session** case, the user goes to session form only, not speaker form.
![screenshot from 2017-02-22 20-27-39](https://cloud.githubusercontent.com/assets/20799954/23217025/ecd50d5c-f93d-11e6-8c98-7259c72a90e2.png)

