### PR TITLE
Fixes #3264 :right sidebar not shown on sessions and schedule tab

### DIFF
--- a/app/templates/gentelella/guest/event/base.html
+++ b/app/templates/gentelella/guest/event/base.html
@@ -156,12 +156,20 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-md-8 col-sm-8 col-xs-12 col-md-push-1 col-sm-push-2 event-info-container-holder"
-             style="min-height: 600px;">
+        <div class = "col-xs-12 
+        {% if active_page =='sessions' or active_page == 'schedule' %}
+            col-md-10 col-sm-10 
+        {% else %}
+            col-md-8 col-sm-8
+        {% endif %}
+         col-md-push-1 col-sm-push-2 event-info-container-holder"
+        style="min-height: 600px;">
+
             {% block content %}
             {% endblock %}
         </div>
-        <div class="col-md-2 col-md-push-1 hidden-xs hidden-sm">
+        {% if active_page != 'sessions' and active_page != 'schedule' %}
+            <div class="col-md-2 col-md-push-1 hidden-xs hidden-sm">
             <div>
                 {% if event.event_url %}
                     <i class="fa fa-external-link-square fa-fw" style="color: #8d8d8d"></i>
@@ -212,9 +220,9 @@
                 {% for twitterLink in twitter %}
                     <a class="twitter-timeline" href="{{ twitterLink }}" data-height="500">Tweets</a>
                 {% endfor %}
-            </div>
         </div>
     </div>
+            {% endif %}
 {% endblock %}
 
 {% block tail_js %}


### PR DESCRIPTION
Fixes #3264 

Schedule page
![screenshot from 2017-02-27 01 59 23](https://cloud.githubusercontent.com/assets/15813932/23343386/95dc0a2c-fc90-11e6-8231-672281d5c850.png)

Sessions page

![screenshot from 2017-02-27 02 00 07](https://cloud.githubusercontent.com/assets/15813932/23343387/a780954a-fc90-11e6-91b6-f38dfac9f180.png)

Other pages (e.g. speakers)

![screenshot from 2017-02-27 02 00 24](https://cloud.githubusercontent.com/assets/15813932/23343391/b297e802-fc90-11e6-92b9-1de5d28090e9.png)




Kindly review :)