### PR TITLE
Add condition to send pending session emails (Fixes #3271 )

### DIFF
--- a/app/templates/gentelella/users/events/sessions/base_session_table.html
+++ b/app/templates/gentelella/users/events/sessions/base_session_table.html
@@ -162,8 +162,14 @@
                                         </a>
                                     {% endif %}
                                     {% if not session.state_email_sent and (session.state == 'accepted' or session.state == 'rejected') %}
-                                        <a href="{{ session.id }}/send-emails/" class="btn btn-sm btn-info"
-                                           data-toggle="tooltip" title="Sending pending email" data-placement="right">
+                                        <a class="btn btn-sm btn-info with-email-modal"
+                                           data-toggle="tooltip" 
+                                           title="Sending pending email" 
+                                           data-placement="right"
+                                           data-session-id="{{ session.id }}"
+                                           data-session-title="{{ session.title }}"
+                                           data-email-type="send-email"
+                                           data-session-state={{session.state}}>
                                             <i class="fa fa-envelope"></i>
                                         </a>
                                     {% endif %}
@@ -280,6 +286,11 @@
                 $mailModal.find('.subject').val("Your Session '" + sessionTitle + "' has been accepted");
                 $mailModal.find('.message').val("Hello,\n\nYour session '" + sessionTitle + "' has been " + emailType + "ed.\n\nVisit this link to view the session: http://" + window.location.hostname + "/events/mysessions/1/ .");
                 $mailModal.find('.form-horizontal').attr('action', sessionId + '/accept');
+            } else if (emailType === "send-email") {
+                var sessionState = button.data('session-state');
+                $mailModal.find('.subject').val("Your Session '" + sessionTitle + "' has been " + sessionState);
+                $mailModal.find('.message').val("Hello,\n\nYour session '" + sessionTitle + "' has been " + sessionState + ".\n\nVisit this link to view the session: http://" + window.location.hostname + "/events/mysessions/1/ .");
+                $mailModal.find('.form-horizontal').attr('action', sessionId + '/send-emails');
             } else {
                 $mailModal.find('.subject').val("Your Session '" + sessionTitle + "' has been rejected");
                 $mailModal.find('.message').val("Hello,\n\nYour session '" + sessionTitle + "' has been " + emailType + "ed.\n\nVisit this link to view the session: http://" + window.location.hostname + "/events/mysessions/1/ .");

--- a/app/views/users/sessions.py
+++ b/app/views/users/sessions.py
@@ -176,7 +176,9 @@ def reject_session(event_id, session_id):
 @can_accept_and_reject
 def send_emails_session(event_id, session_id):
     session = get_session_or_throw(session_id)
-    trigger_session_state_change_notifications(session, event_id)
+    message = request.form.get('message', None) if request.form else None
+    subject = request.form.get('subject', None) if request.form else None
+    trigger_session_state_change_notifications(session, event_id, message=message, subject=subject)
     return redirect(url_for('.index_view', event_id=event_id))
 
 


### PR DESCRIPTION
Fixes #3271

I have added a condition in javascript code to send pending emails for both accepted and rejected sessions. Now E-Mail modal will open with correct pre-filled text in subject and message box.

Screenshot : 

[![test.png](https://s4.postimg.org/aw7r5i2n1/test.png)](https://postimg.org/image/vgcl3zie1/)
 