### PR TITLE
Add the status 'Confirmed' in sessions view

### DIFF
--- a/app/api/helpers/special_fields.py
+++ b/app/api/helpers/special_fields.py
@@ -73,5 +73,5 @@ class SessionStateField(fields.ChoiceString):
 
     def __init__(self, **kwargs):
         super(SessionStateField, self).__init__(
-            choice_list=['pending', 'accepted', 'rejected'],
+            choice_list=['pending', 'accepted', 'rejected', 'confirmed'],
             **kwargs)

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -162,7 +162,8 @@ class SessionDAO(ServiceDAO):
                 trigger_new_session_notifications(session.id, event_id=event_id)
 
             if (data['state'] == 'accepted' and session.state != 'accepted') \
-                or (data['state'] == 'rejected' and session.state != 'rejected'):
+                or (data['state'] == 'rejected' and session.state != 'rejected') \
+                or (data['state'] == 'confirmed' and session.state != 'confirmed'):
                 trigger_session_state_change_notifications(obj, event_id=event_id, state=data['state'])
 
         if session.start_time != obj.start_time or session.end_time != obj.end_time:

--- a/app/helpers/data.py
+++ b/app/helpers/data.py
@@ -385,7 +385,7 @@ class DataManager(object):
             session.video = video_temp_url
 
             if form_state == 'pending' and session.state != 'pending' and \
-                    session.state != 'accepted' and session.state != 'rejected':
+                    session.state != 'accepted' and session.state != 'rejected' and session.state != 'confirmed':
                 session.state = 'pending'
                 trigger_new_session_notifications(session.id, event_id=event_id)
 

--- a/app/templates/gentelella/super_admin/events/events.html
+++ b/app/templates/gentelella/super_admin/events/events.html
@@ -27,6 +27,7 @@
         {# Calculate Session-Status counts #}
         {% set drafts = {'count': 0} %}
         {% set accepted = {'count': 0} %}
+        {% set confirmed = {'count': 0} %}
         {% set pending = {'count': 0} %}
         {% set rejected = {'count': 0} %}
         {% set ticket_stats = all_ticket_stats[event.id] %}
@@ -34,6 +35,8 @@
         {% for session in event.session %}
             {% if session.state == 'accepted' %}
                 {% if accepted.update({ 'count': accepted.count + 1 }) %} {% endif %}
+            {% elif session.state == 'confirmed'%}
+                {% if confirmed.update({ 'count': confirmed.count + 1 }) %} {% endif %}
             {% elif session.state == 'drafts' %}
                 {% if drafts.update({ 'count': drafts.count + 1 }) %} {% endif %}
             {% elif session.state == 'pending' %}
@@ -66,6 +69,7 @@
                     <li>{{ _("Drafts") }}: {{ drafts.count }}</li>
                     <li>{{ _("Submitted") }}: {{ event.session | length }}</li>
                     <li>{{ _("Accepted") }}: {{ accepted.count }}</li>
+                    <li>{{ _("Confirmed") }}: {{ confirmed.count }}</li>
                     <li>{{ _("Pending") }}: {{ pending.count }}</li>
                     <li>{{ _("Rejected") }}: {{ rejected.count }}</li>
                 </ol>

--- a/app/templates/gentelella/users/events/_table.html
+++ b/app/templates/gentelella/users/events/_table.html
@@ -22,6 +22,7 @@
                 {% set drafts = {'count': 0} %}
                 {% set accepted = {'count': 0} %}
                 {% set pending = {'count': 0} %}
+                {% set confirmed = {'count': 0} %}
                 {% set rejected = {'count': 0} %}
 
                 {% for session in event.session %}
@@ -31,6 +32,8 @@
                         {% if drafts.update({ 'count': drafts.count + 1 }) %} {% endif %}
                     {% elif session.state == 'pending' %}
                         {% if pending.update({ 'count': pending.count + 1 }) %} {% endif %}
+                    {% elif session.state == 'confirmed' %}
+                        {% if confirmed.update({ 'count': confirmed.count + 1 }) %} {% endif %}
                     {% elif session.state == 'rejected' %}
                         {% if rejected.update({ 'count': rejected.count + 1 }) %} {% endif %}
                     {% endif %}
@@ -57,6 +60,7 @@
                             <li>{{ _("Drafts") }}: {{ drafts.count }}</li>
                             <li>{{ _("Submitted") }}: {{ event.session | length }}</li>
                             <li>{{ _("Accepted") }}: {{ accepted.count }}</li>
+                            <li>{{ _("Confirmed") }}: {{ confirmed.count }}</li>
                             <li>{{ _("Pending") }}: {{ pending.count }}</li>
                             <li>{{ _("Rejected") }}: {{ rejected.count }}</li>
                         </ol>

--- a/app/templates/gentelella/users/events/sessions/base_session_table.html
+++ b/app/templates/gentelella/users/events/sessions/base_session_table.html
@@ -43,6 +43,9 @@
                         <input type="radio" name="show_state" autocomplete="off" value="accepted"> {{ _("Accepted") }}
                     </label>
                     <label class="btn btn-default btn-responsive">
+                        <input type="radio" name="show_state" autocomplete="off" value="confirmed"> {{ _("Confirmed") }}
+                    </label>
+                    <label class="btn btn-default btn-responsive">
                         <input type="radio" name="show_state" autocomplete="off" value="rejected"> {{ _("Rejected") }}
                     </label>
                 </div>
@@ -76,7 +79,7 @@
                         {% set versions_count = count_versions(session) %}
                         <tr>
                             <td>
-                                <span class="label label-{{ 'success' if session.state == 'accepted' else 'warning' }}">{{ session.state }}</span>
+                                <span class="label label-{{ 'success' if session.state == 'confirmed' else 'warning' }}">{{ session.state }}</span>
                             </td>
                             <td>{{ session.title }}</td>
                             <td>
@@ -122,12 +125,12 @@
                             </td>
                             <td>
                                 <div class="btn-group-vertical" role="group" aria-label="...">
-                                    {% if session.state != 'accepted' %}
-                                        <a href="{{ session.id }}/accept/?skip=email" class="btn btn-sm btn-success"
+                                    {% if session.state != 'accepted' and session.state != 'confirmed' %}
+                                        <a href="{{ session.id }}/accept/?skip=email" class="btn btn-sm btn-warning"
                                            data-toggle="tooltip" title="Approve" data-placement="right">
                                             <i class="fa fa-check"></i>
                                         </a>
-                                        <a type="button" class="btn btn-primary btn-success with-email-modal"
+                                        <a type="button" class="btn btn-primary btn-warning with-email-modal"
                                            data-toggle="tooltip"
                                            title="Approve & send acceptance email"
                                            data-placement="right"
@@ -153,6 +156,23 @@
                                            data-email-type="reject">
                                             <i class="fa fa-times fa-fw"></i> <i class="fa fa-envelope fa-fw"></i>
                                         </a>
+                                        
+                                    {% endif %}
+                                    {% if session.state == 'accepted' %}
+                                        <a href="{{ session.id }}/confirm/?skip=email" class="btn btn-success"
+                                           data-toggle="tooltip" title="Confirm" data-placement="right">
+                                            <i class="fa fa-check fa-fw"></i>
+                                        </a>
+                                        <a type="button" class="btn btn-success with-email-modal"
+                                           data-toggle="tooltip"
+                                           title="Confirm & send confirmation email"
+                                           data-placement="right"
+                                           data-session-id="{{ session.id }}"
+                                           data-session-title="{{ session.title }}"
+                                           data-email-type="confirm">
+                                            <i class="fa fa-check fa-fw"></i><i class="fa fa-envelope fa-fw"></i>
+                                        </a>
+
                                     {% endif %}
                                     {% if not session.state_email_sent and (session.state == 'accepted' or session.state == 'rejected') %}
                                         <a href="{{ session.id }}/send-emails/" class="btn btn-sm btn-info"
@@ -273,7 +293,11 @@
                 $mailModal.find('.subject').val("Your Session '" + sessionTitle + "' has been accepted");
                 $mailModal.find('.message').val("Hello,\n\nYour session '" + sessionTitle + "' has been " + emailType + "ed.\n\nVisit this link to view the session: http://" + window.location.hostname + "/events/mysessions/1/ .");
                 $mailModal.find('.form-horizontal').attr('action', sessionId + '/accept');
-            } else {
+            } else if(emailType === "confirm"){
+                $mailModal.find('.subject').val("Confirm your availability for '" + sessionTitle + "'");
+                $mailModal.find('.message').val("Hello,\n\nYour session '" + sessionTitle + "' has been accepted. \n\nTo " + emailType + " your availability visit this link: http://" + window.location.hostname + "/events/mysessions/1/ .");
+                $mailModal.find('.form-horizontal').attr('action', sessionId + '/confirm');
+            }else {
                 $mailModal.find('.subject').val("Your Session '" + sessionTitle + "' has been rejected");
                 $mailModal.find('.message').val("Hello,\n\nYour session '" + sessionTitle + "' has been " + emailType + "ed.\n\nVisit this link to view the session: http://" + window.location.hostname + "/events/mysessions/1/ .");
                 $mailModal.find('.form-horizontal').attr('action', sessionId + '/reject');

--- a/app/templates/gentelella/users/events/speakers/base_speaker_table.html
+++ b/app/templates/gentelella/users/events/speakers/base_speaker_table.html
@@ -108,7 +108,7 @@
                                 {% for session in speaker.sessions %}
                                     {% if not session.in_trash %}
                                         <li>
-                                            <span class="label label-{{ 'success' if session.state == 'accepted' else 'warning' }}">
+                                            <span class="label label-{{ 'success' if session.state == 'confirmed' else 'warning' }}">
                                                 {{ session.state }}
                                             </span>
                                         </li>

--- a/app/templates/gentelella/users/mysessions/mysession_detail.html
+++ b/app/templates/gentelella/users/mysessions/mysession_detail.html
@@ -25,11 +25,13 @@
                         <span class="detail-status label label-success">{{ _("Accepted") }}</span>
                     {% elif session.state == 'rejected' %}
                         <span class="detail-status label label-danger">{{ _("Rejected") }}</span>
+                    {% elif session.state == 'confirmed' %}
+                        <span class="detail-status label label-danger">{{ _("Confirmed") }}</span>
                     {% else %}
                         <span class="detail-status label label-info">N/A</span>
                     {% endif %}
                     <div class="btn-group pull-right">
-                        {% if session.state == 'pending' or session.state == 'accepted' or session.state == 'rejected' %}
+                        {% if session.state == 'pending' or session.state == 'accepted' or session.state == 'confirmed' or session.state == 'rejected' %}
                             <a href="{{ url_for('my_sessions.withdraw_session_view',session_id=session.id) }}"
                                class="btn btn-danger ">
                                 {{ _("Withdraw Proposal") }}

--- a/app/templates/gentelella/users/mysessions/mysessions_list.html
+++ b/app/templates/gentelella/users/mysessions/mysessions_list.html
@@ -75,6 +75,8 @@
                 <span class="status label label-success pull-right">{{ _("Accepted") }}</span>
             {% elif session.state == 'rejected' %}
                 <span class="status label label-danger pull-right">{{ _("Rejected") }}</span>
+            {% elif session.state == 'confirmed' %}
+                <span class="status label label-danger pull-right">{{ _("Confirmed") }}</span>
             {% else %}
                 <span class="status label label-info pull-right">N/A</span>
             {% endif %}

--- a/app/views/users/sessions.py
+++ b/app/views/users/sessions.py
@@ -170,6 +170,20 @@ def reject_session(event_id, session_id):
     DataManager.session_accept_reject(session, event_id, 'rejected', send_email, message=message, subject=subject)
     return redirect(url_for('.index_view', event_id=event_id))
 
+@event_sessions.route('/<int:session_id>/confirm/', methods=('POST', 'GET'))
+@belongs_to_event
+@can_accept_and_reject
+def confirm_session(event_id, session_id):
+    session = get_session_or_throw(session_id)
+    skip = request.args.get('skip')
+    send_email = True
+    if skip and skip == 'email':
+        send_email = False
+    message = request.form.get('message', None) if request.form else None
+    subject = request.form.get('subject', None) if request.form else None
+    DataManager.session_accept_reject(session, event_id, 'confirmed', send_email, message=message, subject=subject)
+    return redirect(url_for('.index_view', event_id=event_id))
+
 
 @event_sessions.route('/<int:session_id>/send-emails/')
 @belongs_to_event


### PR DESCRIPTION
#3085 need an additional state "Confirmed"
When the session is accepted the speaker receives the info that he is accepted.
The organizer still does not have any info if the speaker is really confirmed and has booked the travel. Therefore we need an additional state "Confirmed"

- Added a new value 'confirmed' to the choice_list in app/api/helpers/special_fields.py
- Trigger session state change in app/api/session.py for confirmed state -- line no. 166
- Added list element 'Confirmed' and maintain count confirmed.count in app/templates/gentelella/super_admin/events/events.html
- Added filter label in top row for confirmed, Add confirmed green button with and without email on click of both change status to confirmed, change accepted to yellow button in app/templates/gentlella/users/events/sessions/base_session_table.html
- Added green label for status 'confirmed' in details table app/templates/gentelella/users/mysessions/mysession_detail.html