### PR TITLE
Added extra 2 hours of time below to solve bottom info showing problem

### DIFF
--- a/app/static/js/events/scheduler.js
+++ b/app/static/js/events/scheduler.js
@@ -901,7 +901,7 @@ function loadMicrolocationsToTimeline(day) {
         window.dayLevelTime.start.hours = least_hours;
         window.dayLevelTime.start.minutes = 0;
 
-        window.dayLevelTime.end.hours = max_hours;
+        window.dayLevelTime.end.hours = max_hours + 2;
         window.dayLevelTime.end.minutes = max_minutes;
 
         var topTime = moment.utc({hour: dayLevelTime.start.hours, minute: dayLevelTime.start.minutes});


### PR DESCRIPTION
Fixes #3287

Solved by increasing the end time boundary in schedule by 2 hours. This allows for space to show the extra info which otherwise wasn't being shown. Other way of doing it is making the dropdown for bottom elements to appear on top but that would require too much computation. This is computationally simple and solves the purpose.

![screenshot from 2017-03-05 18-04-08](https://cloud.githubusercontent.com/assets/9530293/23587283/d6e48dee-01ce-11e7-8e0d-2fda6efaabbc.png)


@mariobehling @niranjan94 please review.