### PR TITLE
Reduces width of microlocation to 200px

### DIFF
--- a/app/static/css/events/scheduler.css
+++ b/app/static/css/events/scheduler.css
@@ -18,7 +18,7 @@
     color: #3d3d3d;
     height: 48px;
     overflow: hidden;
-    width: 216px;
+    width: 200px;
     white-space: normal;
     padding: 5px;
     font-size: 11px;
@@ -124,7 +124,7 @@
 .timeline .microlocations .microlocation {
     display: inline-block;
     position: relative;
-    width: 216px;
+    width: 200px;
     border-right: 1px solid rgb(221, 221, 221);
     margin-left: 0;
 }


### PR DESCRIPTION
Fixes #3317 

Decreases width of micro-locations  and it's header to 200px
<img width="872" alt="screen shot 2017-03-07 at 11 30 38 am" src="https://cloud.githubusercontent.com/assets/1812082/23643815/02b4e6d8-032a-11e7-83ef-0e6ec9bf667e.png">



