### PR TITLE
Public Schedule: show timings only on no-pop out version

### DIFF
--- a/app/templates/gentelella/guest/event/schedule.html
+++ b/app/templates/gentelella/guest/event/schedule.html
@@ -163,6 +163,10 @@
 
             </div>
         </div>
+
+        <div style="float: right; padding-right: 20px">
+            {{ _("All the timings are in") }} {{ event.timezone | default('UTC', true) }}
+        </div>
     </div>
     {% include 'gentelella/users/events/scheduler/components/timeline_templates.html' %}
 {% endblock %}

--- a/app/templates/gentelella/users/events/scheduler/components/timeline.html
+++ b/app/templates/gentelella/users/events/scheduler/components/timeline.html
@@ -30,6 +30,4 @@
 
 </div>
 
-<div style="float: right; margin-top: 10px;">
-    {{ _("All the timings are in") }} {{ event.timezone | default('UTC', true) }}
-</div>
+


### PR DESCRIPTION
Fixes: #3316 

This PR removes the timings from pop out and show only on no-pop out version and export version