### PR TITLE
Use librabbitmq 1.5.1 for compatibility on Fedora

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,7 +21,7 @@ celery>=3.1.23,<4
 redis>=2.10.5,<3
 apscheduler>=3.3.0,<4
 pillow>=3.4.2,<3.5
-librabbitmq>=1.6.1,<2
+librabbitmq==1.5.1
 gunicorn>=19.6.0,<20
 boto>=2.45.0,<3
 geoip2>=2.4.2,<3


### PR DESCRIPTION
librabbitmq 1.6.1 fails to build on Fedora (and possibly Fedora-
flavoured) systems. So switch back to librabbitmq 1.5.1.

More info:

 - https://github.com/fossasia/open-event-orga-server/pull/2443
 - https://github.com/celery/librabbitmq/issues/61

Fixes #3337