### PR TITLE
Fix DataTables breaking on Events Dashboard

### DIFF
--- a/app/static/js/events/event-dashboard.js
+++ b/app/static/js/events/event-dashboard.js
@@ -1,0 +1,64 @@
+// Function that initializes a DataTable on .tables inside $(element).
+function initDataTable(element) {
+    if (!$.fn.DataTable.isDataTable(element + ' .table')) {
+        // The table on 'Import' tab has a different number of columns.
+        if (element === '#import') {
+            return $(element + ' .table').DataTable();
+        }
+
+        return $(element + ' .table').DataTable({
+            "columnDefs": [
+                { "width": "8%", "targets": 0 },
+                { "width": "15%", "targets": 1 },
+                { "width": "23%", "targets": 2 },
+                { "width": "10%", "targets": 3 },
+                { "width": "10%", "targets": 4 },
+                { "width": "10%", "targets": 6 }
+            ]
+        });
+    }
+    return;
+}
+
+$(document).ready(function () {
+    $('.progress .progress-bar').progressbar({display_text: 'center', use_percentage: false});
+});
+
+$('.accordion-link').click(function () {
+    $('.accordion-link').removeClass('active');
+    $(this).addClass('active');
+});
+
+$(document).ready(function () {
+    // In case in tab is specified, the `Live` tab is shown by default.
+    // Update the hash accordingly.
+    if (location.hash === "" || location.hash === "#") {
+        location.replace("#!live");
+    }
+
+    if (location.hash.substr(0, 2) === "#!") {
+        $("a[href='#" + location.hash.substr(2) + "']").tab("show");
+        // Initialize the DataTable on the current tab on first load.
+        initDataTable('#' + location.hash.substr(2));
+    }
+
+    $("a[data-toggle='tab']").on("shown.bs.tab", function (e) {
+        var hash = $(e.target).attr("href");
+        // Initialize DataTables in a hidden tab only on swicthing to that tab.
+        initDataTable(hash);
+        if (hash.substr(0, 1) === "#") {
+            location.replace("#!" + hash.substr(1));
+        }
+    });
+});
+
+$(".small_tab_list").click(function () {
+    $(".small_tab_list").removeClass("active");
+    $(this).addClass("active");
+    var clicked_link = $(this).attr("value");
+    $(".drop_header").text(clicked_link);
+});
+
+$('.tabs_small a').click(function () {
+    $(this).tab('show');
+});

--- a/app/templates/gentelella/users/events/_table.html
+++ b/app/templates/gentelella/users/events/_table.html
@@ -1,6 +1,6 @@
 {% macro events_table(events) %}
     <div id="table-responsive">
-        <table  class="table table-striped">
+        <table  class="table table-striped" width="100%">
 
             <thead>
             <tr>

--- a/app/templates/gentelella/users/events/index.html
+++ b/app/templates/gentelella/users/events/index.html
@@ -90,48 +90,5 @@
     <script src="{{ url_for('static', filename='vendor/datatables.net/js/jquery.dataTables.min.js') }}"></script>
     <script src="{{ url_for('static', filename='vendor/datatables.net-bs/js/dataTables.bootstrap.min.js') }}"></script>
     <script src="{{ url_for('static', filename='vendor/bootstrap-progressbar/bootstrap-progressbar.min.js') }}"></script>
-    <script type="text/javascript">
-        $('.table').DataTable({
-        "columnDefs": [
-	         { "width" : "8%", "targets" : 0 },
-	         { "width" : "15%", "targets": 1 },
-            { "width" : "23%", "targets": 2 },
-	         { "width" : "10%", "targets": 3 },
-	         { "width" : "10%", "targets": 4 },
-	         { "width" : "10%", "targets": 6 }
-	      ]
-      });
-
-        $(document).ready(function () {
-            $('.progress .progress-bar').progressbar({display_text: 'center', use_percentage: false});
-        });
-
-        $('.accordion-link').click(function () {
-            $('.accordion-link').removeClass('active');
-            $(this).addClass('active');
-        });
-
-        $(document).ready(function () {
-            if (location.hash.substr(0, 2) == "#!") {
-                $("a[href='#" + location.hash.substr(2) + "']").tab("show");
-            }
-            $("a[data-toggle='tab']").on("shown.bs.tab", function (e) {
-                var hash = $(e.target).attr("href");
-                if (hash.substr(0, 1) == "#") {
-                    location.replace("#!" + hash.substr(1));
-                }
-            });
-        });
-
-        $(".small_tab_list").click(function () {
-            $(".small_tab_list").removeClass("active");
-            $(this).addClass("active");
-            var clicked_link = $(this).attr("value");
-            $(".drop_header").text(clicked_link);
-        });
-
-        $('.tabs_small a').click(function () {
-            $(this).tab('show');
-        });
-    </script>
+    <script src="{{ url_for('static', filename='js/events/event-dashboard.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Apparently, initializing DataTables on tables inside elements with
`display: none;` breaks their sizing. This is because DataTable is
unable to compute the size of such elements.

This was fixed by initializing DataTables only after the tab has
been opened. Also fixed updating the URL hash according to which
tab is open.

Fixes #3252