### PR TITLE
Fix: track view is not using full width of screen on mobile

### DIFF
--- a/app/static/css/events/scheduler.css
+++ b/app/static/css/events/scheduler.css
@@ -270,7 +270,6 @@
     background: rgba(0, 150, 136, 0.75);
     width: auto;
     margin-left: 4%;
-    max-width: 500px;
     color: #FFFFFF;
     padding: 5px;
     font-size: 15px;
@@ -279,18 +278,7 @@
 .session-track-details {
     width: auto;
     margin-left: 4%;
-    max-width: 500px;
     font-size: 15px;
-}
-
-@media (max-width: 660px) {
-    .event {
-        max-width: 270px;
-    }
-
-    .session-track-details {
-        max-width: 270px;
-    }
 }
 
 #track-list {

--- a/app/templates/gentelella/users/events/scheduler/components/timeline_templates.html
+++ b/app/templates/gentelella/users/events/scheduler/components/timeline_templates.html
@@ -54,7 +54,7 @@
 
             </h6>
         </div>
-        <div class="col-xs-8 col-sm-8 col-md-8">
+        <div class="col-xs-10 col-sm-10 col-md-10">
             <div class="event track-title name" data-toggle="collapse">
 
             </div>


### PR DESCRIPTION
![selection_139](https://cloud.githubusercontent.com/assets/13910561/23773765/bbc60a94-0546-11e7-8bab-b1c6ea14d24c.png)

fixes point 2 of #3323. Point one seems a vendor specific issue
