### PR TITLE
Fixed: Tickets show sold out even though capacity was increased, #3366

### DIFF
--- a/app/helpers/data_getter.py
+++ b/app/helpers/data_getter.py
@@ -733,7 +733,8 @@ class DataGetter(object):
             orders = OrderTicket.query.filter(OrderTicket.ticket_id == ticket.id)
             ticket_count = 0
             for order in orders:
-                ticket_count += order.quantity
+                if order.order.status == 'completed' or order.order.status == 'placed':
+                    ticket_count += order.quantity
             if ticket_count >= ticket.quantity:
                 status = "Sold"
             else:

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -45,7 +45,7 @@ class Order(db.Model):
     event = db.relationship('Event', backref='orders')
     user = db.relationship('User', backref='orders', foreign_keys=[user_id])
     marketer = db.relationship('User', backref='marketed_orders', foreign_keys=[marketer_id])
-    tickets = db.relationship("OrderTicket")
+    tickets = db.relationship("OrderTicket", backref='order')
 
     def __init__(self,
                  identifier=None,


### PR DESCRIPTION
Fixes #3366 

The main issue was, at the event page we were counting all tickets with all order status. Now counts only for completed and placed status