### PR TITLE
time iterations made to 15minutes

### DIFF
--- a/app/static/js/events/scheduler.js
+++ b/app/static/js/events/scheduler.js
@@ -32,7 +32,7 @@ var time = {
         minutes: 59
     },
     unit: {
-        minutes: 10,
+        minutes: 15,
         pixels: 48,
         minimum_duration: 5,
         count: 0


### PR DESCRIPTION
Fixes https://github.com/fossasia/open-event-orga-server/issues/3318

![screenshot from 2017-03-12 15-19-45](https://cloud.githubusercontent.com/assets/9530293/23830720/5f825ad8-0737-11e7-9d97-cc20ea8de3fa.png)

@mariobehling @niranjan94 please review. @mariobehling it shows two rows below because the session ends at 11.45 and 11.45 + 15minutes = 12.00. So, it shows rows belonging to both 12.00 and 11.45.