### PR TITLE
Hides scrollbars if there is nothing to scroll in public schedule

### DIFF
--- a/app/static/css/events/scheduler.css
+++ b/app/static/css/events/scheduler.css
@@ -115,7 +115,7 @@
 }
 
 .timeline .microlocations .microlocation-container {
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: hidden;
     white-space: nowrap;
     width: 654px;


### PR DESCRIPTION
Fixes #3377

- Hides the scroll bar if there is nothing to scroll.
- Shows the scroll bar if needed.

**When nothing to scroll**
![screen shot 2017-03-13 at 3 00 41 pm](https://cloud.githubusercontent.com/assets/12807846/23848603/11e5fdc6-07fe-11e7-8a51-02a777ea0f86.png)

**When there is something to scroll**
![screen shot 2017-03-13 at 3 01 05 pm](https://cloud.githubusercontent.com/assets/12807846/23848604/11efba64-07fe-11e7-985c-abb03b3adddf.png)


@mariobehling @SaptakS @niranjan94 Please review. Thanks