### PR TITLE
Fixes #3383 : microlocation name break added for long names

### DIFF
--- a/app/static/css/events/scheduler.css
+++ b/app/static/css/events/scheduler.css
@@ -139,7 +139,9 @@
 
 .timeline .microlocations.x1 .microlocation-header {
     height: 47px;
-    line-height: 47px;
+    display: flex;
+    align-items: center;
+    white-space: initial;
 }
 
 .timeline .microlocations .microlocation-header {


### PR DESCRIPTION
In header, the name for microlocation applied with line break.