### PR TITLE
Fix: Issue #3391Speaker editing form uses large image files for "second" speaker

### DIFF
--- a/app/templates/gentelella/users/events/sessions/components/session_form.html
+++ b/app/templates/gentelella/users/events/sessions/components/session_form.html
@@ -20,7 +20,7 @@
                     {% for existing_speaker in speakers %}
                         <option value="{{ existing_speaker.id }}"
                             {% if session and existing_speaker in session.speakers %}{{ _("selected") }}{% endif %}
-                            data-html-addon="<img src='{{ existing_speaker.photo }}' onerror='imgError(this);' style='width: 2rem; height: 2rem;border-radius: 50%;'>">
+                            data-html-addon="<img src='{{ existing_speaker.thumbnail }}' onerror='imgError(this);' style='width: 2rem; height: 2rem;border-radius: 50%;'>">
                             {{ existing_speaker.name }}
                         </option>
                     {% endfor %}


### PR DESCRIPTION
Changed From `existing_speaker.photo` **to** `existing_speaker.thumbnail` , thus replacing the large image being used. 

The new image being used is shown on the left side.

![image](https://cloud.githubusercontent.com/assets/17861054/23988511/867e38d0-0a54-11e7-8add-ff89a51f7bec.png)