### PR TITLE
Fix: Issue #3393 Resending ticket confirmation as an organizer shows "ticket bought in notifications"

### DIFF
--- a/app/helpers/helpers.py
+++ b/app/helpers/helpers.py
@@ -21,7 +21,8 @@ from app.models.notifications import (
     TICKET_PURCHASED as NOTIF_TICKET_PURCHASED,
     EVENT_EXPORT_FAIL as NOTIF_EVENT_EXPORT_FAIL,
     EVENT_EXPORTED as NOTIF_EVENT_EXPORTED,
-    TICKET_PURCHASED_ORGANIZER as NOTIF_TICKET_PURCHASED_ORGANIZER
+    TICKET_PURCHASED_ORGANIZER as NOTIF_TICKET_PURCHASED_ORGANIZER,
+    TICKET_RESEND_ORGANIZER as NOTIF_TICKET_RESEND_ORGANIZER
 
 )
 from app.settings import get_settings
@@ -497,6 +498,16 @@ def send_notif_for_after_purchase_organizer(user, invoice_id, order_url, event_n
         title=NOTIFS[NOTIF_TICKET_PURCHASED_ORGANIZER]['title'].format(invoice_id=invoice_id, event_name=event_name,
                                                                        buyer_email=buyer_email),
         message=NOTIFS[NOTIF_TICKET_PURCHASED_ORGANIZER]['message'].format(order_url=order_url)
+    )
+
+
+def send_notif_for_resend(user, invoice_id, order_url, event_name, buyer_email):
+    """Send notification with order invoice link after purchase"""
+    send_notification(
+        user=user,
+        action=NOTIF_TICKET_RESEND_ORGANIZER,
+        title=NOTIFS[NOTIF_TICKET_RESEND_ORGANIZER]['title'].format(invoice_id=invoice_id, event_name=event_name, buyer_email=buyer_email),
+        message=NOTIFS[NOTIF_TICKET_RESEND_ORGANIZER]['message'].format(order_url=order_url)
     )
 
 

--- a/app/helpers/system_notifications.py
+++ b/app/helpers/system_notifications.py
@@ -12,6 +12,7 @@ from app.models.notifications import (
     EVENT_PUBLISH,
     USER_CHANGE_EMAIL,
     TICKET_PURCHASED,
+    TICKET_RESEND_ORGANIZER,
     EVENT_EXPORT_FAIL,
     EVENT_EXPORTED,
     TICKET_PURCHASED_ORGANIZER
@@ -48,6 +49,13 @@ NOTIFS = {
         'message': (
             u"The order has been processed successfully."
             u"<br><br><a href='{order_url}' class='btn btn-info btn-sm'>View Invoice</a>"
+        )
+    },
+    TICKET_RESEND_ORGANIZER: {
+        'recipient': 'Organizer',
+        'title': u'Email resent for {event_name} by {buyer_email} ({invoice_id}) ',
+        'message': (
+            u"Email has been sent successfully."
         )
     },
     USER_CHANGE_EMAIL: {

--- a/app/models/notifications.py
+++ b/app/models/notifications.py
@@ -13,6 +13,7 @@ INVITE_PAPERS = 'Invitation For Papers'
 AFTER_EVENT = 'After Event'
 EVENT_PUBLISH = 'Event Published'
 TICKET_PURCHASED_ORGANIZER = 'Ticket(s) Purchased to Organizer'
+TICKET_RESEND_ORGANIZER = 'Ticket Resend'
 
 
 class Notification(db.Model):

--- a/app/templates/gentelella/users/events/tickets/orders.html
+++ b/app/templates/gentelella/users/events/tickets/orders.html
@@ -276,6 +276,7 @@
                                                 <div class="modal-body">
                                                     <form action="{{ url_for('event_ticket_sales.resend_confirmation', event_id=event_id) }}" method="post">
                                                         <input type="hidden" name="identifier" value="{{ order.identifier }}">
+                                                        <input type="hidden" name="resend" value="True">
                                                         <div class="email">
                                                             <label>
                                                                 {{ _("Send confirmation email to:") }}


### PR DESCRIPTION
Added function send_notif_for_resend
Added code to redirect to resend notification instead of purchased
Added a redirect notification
Added a hidden redirect value so that resend notification is called instead of purchase

**Result :**

![image](https://cloud.githubusercontent.com/assets/17861054/23942930/d10016d8-0993-11e7-9196-e11a0175a84a.png)
