### PR TITLE
Show running events on live page

### DIFF
--- a/app/helpers/data_getter.py
+++ b/app/helpers/data_getter.py
@@ -417,8 +417,7 @@ class DataGetter(object):
             events = Event.query.filter(Event.state == 'Published')
         else:
             events = Event.query.filter(Event.state == 'Published').filter(Event.privacy != 'private')
-        events = events.filter(Event.start_time >= datetime.datetime.now()).filter(
-            Event.end_time >= datetime.datetime.now()).filter(Event.in_trash == 'False')
+        events = events.filter(Event.end_time >= datetime.datetime.now()).filter(Event.in_trash == 'False')
         return events
 
     @staticmethod


### PR DESCRIPTION
Fixes #3402 
* Filter the events on basis of their end time rather than their start date

* Screenshot
![screenshot from 2017-03-17 21-15-54](https://cloud.githubusercontent.com/assets/8847265/24051215/7196b9c0-0b57-11e7-98cd-c26acdb6c2e1.png)

Here the event 'Princu' has start time of Mar 17, 8 AM and is showing on the front page.

@mariobehling @niranjan94 @SaptakS Please review. Thanks