### PR TITLE
guest/event/cfs: only show sessions from current event 

### DIFF
--- a/app/templates/gentelella/guest/event/cfs.html
+++ b/app/templates/gentelella/guest/event/cfs.html
@@ -53,7 +53,7 @@
                             </div>
                         </div>
                     </div>
-                    {% if not user_speaker[0] %}
+                    {% if not existing_sessions[0] %}
                         <div id="speaker-session-modal" class="modal fade" tabindex="-1" role="dialog">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -79,13 +79,9 @@
                                     <div class="modal-footer">
                                         <div class="existing-session" style="text-align:left">
                                             <h4>{{ _("Existing Sessions") }} </h4>
-                                            {% for speaker in user_speaker %}
-                                                {% for session in speaker.sessions %}
-                                                    {% if not session.in_trash %}
-                                                        {% if session.title %}
-                                                            {{ session }} <a href="{{ url_for('my_sessions.process_session_view',session_id=session.id) }}"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a><br>
-                                                        {% endif %}
-                                                    {% endif %}
+                                            {% for speaker_sessions in existing_sessions %}
+                                                {% for session in speaker_sessions %}
+                                                    {{ session }} <a href="{{ url_for('my_sessions.process_session_view',session_id=session.id) }}"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a><br>
                                                 {% endfor %}
                                                 <hr>
                                             {% endfor %}

--- a/app/templates/gentelella/guest/event/cfs.html
+++ b/app/templates/gentelella/guest/event/cfs.html
@@ -80,10 +80,10 @@
                                         <div class="existing-session" style="text-align:left">
                                             <h4>{{ _("Existing Sessions") }} </h4>
                                             {% for speaker_sessions in existing_sessions %}
+                                                {% if not loop.first %}<hr>{% endif %}
                                                 {% for session in speaker_sessions %}
                                                     {{ session }} <a href="{{ url_for('my_sessions.process_session_view',session_id=session.id) }}"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a><br>
                                                 {% endfor %}
-                                                <hr>
                                             {% endfor %}
                                         </div>
                                         <div class="add_proposal">

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -197,7 +197,7 @@ def display_event_cfs(identifier, via_hash=False):
         for speaker in user_speaker:
             current_session = []
             for session in speaker.sessions:
-                if not session.in_trash:
+                if session.event_id == event.id and not session.in_trash:
                     if session.title:
                         current_session.append(session)
             if current_session:

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -192,6 +192,15 @@ def display_event_cfs(identifier, via_hash=False):
     if login.current_user.is_authenticated:
         email = login.current_user.email
         user_speaker = DataGetter.get_speaker_by_email(email)
+
+        existing_sessions = []
+        for speaker in user_speaker:
+            current_session = []
+            for session in speaker.sessions:
+                if not session.in_trash:
+                    if session.title:
+                        current_session.append(session)
+            existing_sessions.append(current_session)
     if event.sub_topic:
         custom_placeholder = DataGetter.get_custom_placeholder_by_name(event.sub_topic)
     elif event.topic:
@@ -234,7 +243,8 @@ def display_event_cfs(identifier, via_hash=False):
                            accepted_sessions_count=accepted_sessions_count,
                            session_form=session_form, call_for_speakers=call_for_speakers,
                            placeholder_images=placeholder_images, state=state, speakers=speakers,
-                           via_hash=via_hash, custom_placeholder=custom_placeholder, user_speaker=user_speaker)
+                           via_hash=via_hash, custom_placeholder=custom_placeholder,
+                           existing_sessions=existing_sessions)
 
 
 @event_detail.route('/cfs/<hash>/', methods=('GET', 'POST'))

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -200,7 +200,8 @@ def display_event_cfs(identifier, via_hash=False):
                 if not session.in_trash:
                     if session.title:
                         current_session.append(session)
-            existing_sessions.append(current_session)
+            if current_session:
+                existing_sessions.append(current_session)
     if event.sub_topic:
         custom_placeholder = DataGetter.get_custom_placeholder_by_name(event.sub_topic)
     elif event.topic:


### PR DESCRIPTION
While we're at it, bump up templating stuff into view code, and improve `<hr>` printing, so we don't print `<hr>` when there's nothing to separate, eg: (notice the hr's but nothing follows the hr:

![image](https://cloud.githubusercontent.com/assets/61553/24084158/f88e0400-0d1f-11e7-8c37-d19a7834ebe1.png)


