### PR TITLE
add note about scheduled/unscheduled sessions

### DIFF
--- a/docs/general/api.md
+++ b/docs/general/api.md
@@ -140,6 +140,8 @@ Datatype, requirement and access-level has been defined for every model. Nested 
 
 ### 3. Session
 
+Note: If the `microlocation` field of the session is null, the session is unscheduled in the event scheduler.
+
 | Field | Datatype | Requirement | Access |
 | --- | --- | --- | --- |
 |**id** | integer | Required | Public |


### PR DESCRIPTION
fixes #3260.
If the microlocation field of the session is null, the session is unscheduled. Rather than adding an extra redundant field in the api, a note has been added about this in docs/general/api.md. The best practice would be to let the client side application handle it. e.g open-event-webapp can implement their own logic to see if the session is scheduled or not.