### PR TITLE
resending ticket confirmation shows resend message

### DIFF
--- a/app/helpers/ticketing.py
+++ b/app/helpers/ticketing.py
@@ -570,7 +570,7 @@ class TicketingManager(object):
         invoice_id = order.get_invoice_number()
         order_url = url_for('ticketing.view_order_after_payment', order_identifier=order.identifier, _external=True)
         if login.current_user.is_organizer(event_id):
-            trigger_after_purchase_notifications(email, order.event_id, order.event, invoice_id, order_url)
+            trigger_after_purchase_notifications(email, order.event_id, order.event, invoice_id, order_url, resend=True)
             send_email_for_after_purchase(email, invoice_id, order_url, order.event.name, order.event.organizer_name)
             return True
         return False


### PR DESCRIPTION
fixes: #3393 
Resending ticket confirmation still had issues: It still sent "ticket bought" notification due to resend parameter remaining false.
Fixed after function created on PR #3397 by @LuD1161
![screenshot from 2017-04-09 06-15-00](https://cloud.githubusercontent.com/assets/20799954/24833603/09901f96-1cec-11e7-9274-abce1f350c63.png)
