### PR TITLE
Pdf download of ticket order fixed for large ticket names

### DIFF
--- a/app/templates/gentelella/guest/ticketing/pdf/ticket.html
+++ b/app/templates/gentelella/guest/ticketing/pdf/ticket.html
@@ -9,21 +9,26 @@
             margin: 0;
 
             @frame col1_frame {             /* Content frame 1 */
-                left: 80pt;  top: 30pt; height: 140pt;
+                left: 80pt;  top: 30pt;
+                height: 250pt; width: 300pt;
+                -pdf-frame-content: main_content;
             }
 
             @frame qrcode {
                 left: 455pt;  top: 35pt;
                 width: 100pt; height: 120pt;
+                -pdf-frame-content: qrcode;
             }
             @frame number_frame {
                  left: 455pt;  top: 25pt;
                 width: 100pt; height: 30pt;
+                -pdf-frame-content: number_content;
             }
 
 
              @frame col2_frame {
                 left: 440pt; top: 170pt;
+                -pdf-frame-content: personal_content;
             }
         }
 
@@ -41,26 +46,28 @@
 </body>
 </html>
 {% for holder in order.ticket_holders %}
-        <span class="label">{{_("Event")}}</span><br>
-        <span style="font-size: 20px;">{{ order.event.name }}</span><br><br>
+        <div id="main_content">
+            <span class="label">{{_("Event")}}</span><br>
+            <span style="font-size: 20px;">{{ order.event.name }}</span><br><br>
 
-        <span class="label">{{_("Location")}}</span><br>
-        <span style="font-size: 15px;">{{ order.event.location_name }}</span><br><br>
+            <span class="label">{{_("Location")}}</span><br>
+            <span style="font-size: 15px;">{{ order.event.location_name }}</span><br><br>
 
-        <span class="label">{{_("Date and Time")}}</span><br>
-        <span  style="font-size: 15px;">{{ order.event.start_time | datetime }} to {{ order.event.end_time | datetime }}</span>
-        <br><br>
+            <span class="label">{{_("Date and Time")}}</span><br>
+            <span  style="font-size: 15px;">{{ order.event.start_time | datetime }} to {{ order.event.end_time | datetime }}</span>
+            <br><br>
 
-        <span class="label">{{_("Type")}}</span><br>
-        <span  style="font-size: 20px;">{{ holder.ticket.name }}</span>
-        <br><br>
+            <span class="label">{{_("Type")}}</span><br>
+            <span style="font-size: 20px;">{{ holder.ticket.name }}</span>
+            <br><br>
+        </div>
 
         <div id="qrcode">
             <img src="data:image/png;base64,{{ holder.qr_code }}" />
         </div>
-        <strong style="color: #ffffff; text-align: center">#{{ order.get_invoice_number() }}/{{ holder.id }}</strong>
+        <strong id="number_content" style="color: #ffffff; text-align: center">#{{ order.get_invoice_number() }}/{{ holder.id }}</strong>
 
-        <div>
+        <div id="personal_content">
             <span>{{ holder.name }}</span><br>
             <span>{{ holder.email }}</span>
         </div>


### PR DESCRIPTION
Fixes #3503 

@mariobehling this will solve the issue that was being faced in OSCAL for the supporter ticket. The issue was occurring because the length of the name of the ticket was overflowing the width, and the width of the frame in the pdf generation code wasn't correctly mentioned.