### PR TITLE
Eventlet disabled by default in production server

### DIFF
--- a/config.py
+++ b/config.py
@@ -75,13 +75,13 @@ class ProductionConfig(Config):
 
     MINIFY_PAGE = True
     PRODUCTION = True
-    INTEGRATE_SOCKETIO = True
+    INTEGRATE_SOCKETIO = False
     CACHING = True
 
-    # if force off
+    # if force on
     socketio_integration = os.environ.get('INTEGRATE_SOCKETIO')
-    if socketio_integration == 'false':
-        INTEGRATE_SOCKETIO = False
+    if socketio_integration == 'true':
+        INTEGRATE_SOCKETIO = True
 
 
 class StagingConfig(ProductionConfig):

--- a/kubernetes/run.sh
+++ b/kubernetes/run.sh
@@ -6,7 +6,7 @@ python manage.py initialize_db -c open_event_test_user@fossasia.org:fossasia
 python manage.py db upgrade > /dev/null 2>&1
 if [ "$DEPLOYMENT" == "web" ]
 then
-    gunicorn -b 0.0.0.0:8080 app:app --worker-class eventlet -w 1 --enable-stdio-inheritance --log-level "warning" --proxy-protocol
+    gunicorn -b 0.0.0.0:8080 app:app -w 1 --enable-stdio-inheritance --log-level "warning" --proxy-protocol
 fi
 if [ "$DEPLOYMENT" == "celery" ]
 then


### PR DESCRIPTION
#3528 

For the time it disables socket io integration by default instead of turning it on by default. Disabled eventlet as of now.