### PR TITLE
Event timezone datetime is used to filter tickets

### DIFF
--- a/app/helpers/data_getter.py
+++ b/app/helpers/data_getter.py
@@ -733,12 +733,10 @@ class DataGetter(object):
             return names
 
     @staticmethod
-    def get_sales_open_tickets(event_id, give_all=False):
-        if give_all:
-            tickets = Ticket.query.filter(Ticket.event_id == event_id)
+    def get_sales_open_tickets(event_id, event_timezone='UTC'):
         tickets = Ticket.query.filter(Ticket.event_id == event_id).filter(
-            Ticket.sales_start <= datetime.datetime.now()).filter(
-            Ticket.sales_end >= datetime.datetime.now())
+            Ticket.sales_start <= datetime.datetime.now(pytz.timezone(event_timezone))).filter(
+            Ticket.sales_end >= datetime.datetime.now(pytz.timezone(event_timezone)))
         open_tickets = []
         for ticket in tickets:
             orders = OrderTicket.query.filter(OrderTicket.ticket_id == ticket.id)

--- a/app/templates/gentelella/guest/event/_ticketing_box.html
+++ b/app/templates/gentelella/guest/event/_ticketing_box.html
@@ -71,7 +71,7 @@
 
                                     </td>
                                     {% endif %}
-                                    {% if (ticket.ticket.sales_start|localize_dt_obj(event.timezone)) <= timenow_event_tz and (ticket.ticket.sales_end|localize_dt_obj(event.timezone)) >= timenow_event_tz and ticket.status == "Available"%}
+                                    {% if ticket.status == "Available" %}
                                         <td>
                                             <input type="hidden" name="ticket_ids[]" value="{{ ticket.ticket.id }}">
                                             <select title="ticket quantity" name="ticket_quantities[]" class="quantity-select"
@@ -95,14 +95,7 @@
                                         <td class="subtotal">
                                             {{ event.payment_currency | currency_symbol }}{{ 0 | money }}</td>
                                     {% else %}
-                                        {% if (ticket.ticket.sales_end|localize_dt_obj(event.timezone)) < timenow_event_tz %}
-                                            <td colspan="2"
-                                                style="color: #adadad;">{{ _("This ticket's sale has ended") }}</td>
-                                        {% elif (ticket.ticket.sales_start|localize_dt_obj(event.timezone)) >= timenow_event_tz %}
-                                            <td colspan="2"
-                                                style="color: #adadad;">{{ _("This ticket's sale will start") }}
-                                                {{ _("on") }} {{ ((ticket.ticket.sales_start|localize_dt_obj(event.timezone))|as_timezone(current_timezone)) | datetime }}</td>
-                                        {% elif ticket.status == "Sold" %}
+                                        {% if ticket.status == "Sold" %}
                                             <td colspan="2"
                                                 style="color: #adadad;">{{ _("This ticket is sold out") }}</td>
                                         {% endif %}

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -71,7 +71,8 @@ def display_event_detail_home(identifier):
     timenow_event_tz = datetime.now(pytz.timezone(event.timezone
                                                   if (event.timezone and event.timezone != '') else 'UTC'))
     module = DataGetter.get_module()
-    tickets = DataGetter.get_sales_open_tickets(event.id, True)
+    tickets = DataGetter.get_sales_open_tickets(event.id, event.timezone
+                                                  if (event.timezone and event.timezone != '') else 'UTC')
 
     '''Sponsor Levels'''
     sponsors = {-1: []}


### PR DESCRIPTION
fixes #3526 

@niranjan94 please check the approach as I could not verify it on local server..

In `DataGetter.get_sales_open_tickets`, tickets were filtered comparing sales start time to `datetime.datetime.now()` which didn't guarantee the event timezone.. hence I have changed it to `datetime.datetime.now(timezone(event_timezone))`

**UPDATE:** verified on local server.