### PR TITLE
session-edit: add missing event-speakers 

### DIFF
--- a/app/views/users/my_sessions.py
+++ b/app/views/users/my_sessions.py
@@ -81,12 +81,14 @@ def process_session_view(session_id):
             return redirect(url_for('.display_my_sessions_view', event_id=session.event_id))
         session_form = json.loads(form_elems.session_form)
         event = DataGetter.get_event(session.event_id)
+        speakers = DataGetter.get_speakers(session.event_id).all()
         return render_template(
             'gentelella/users/mysessions/mysession_session_edit.html',
             session=session,
             speaker=speaker,
             session_form=session_form,
-            event=event)
+            event=event,
+            speakers=speakers)
 
     if request.method == 'POST':
         session = DataGetter.get_sessions_of_user_by_id(session_id)


### PR DESCRIPTION
Fixes #3538 .
I was able to reproduce this issue when editing the session proposal only, I could not recreate the issue when editing the speaker profile details
