### PR TITLE
CFS: Make addition of speaker details necessary before submitting ses…

### DIFF
--- a/app/templates/gentelella/guest/event/cfs.html
+++ b/app/templates/gentelella/guest/event/cfs.html
@@ -80,8 +80,8 @@
                                             {% endfor %}
                                             {% endif %}
                                         </div>
-                                        <a href="/e/{{ event.identifier }}/cfs/new_speaker" type="button" class="btn btn-info" id = "speaker-button">{{ _("Register as a Speaker") }}</a>
-                                        <a href="/e/{{ event.identifier }}/cfs/new/" type="button" class="btn btn-primary" id = "session-button" style="margin-top:-6px">{{ _("Propose Session") }}</a>
+                                        <a href="/e/{{ event.identifier }}/cfs/new_speaker" type="button" class="btn btn-info" id = "speaker-button">{{ _("Add Speaker Details") }}</a>
+                                        <a href="#" type="button" class="btn btn-primary" id = "session-button" style="margin-top:-6px" data-toggle="tooltip" title="Please add speaker details to propose a session!" disabled>{{ _("Add Session Proposal") }}</a>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
As discussed in https://github.com/fossasia/open-event-orga-server/issues/3560#issuecomment-298879182 implemented the workflow for the sessions. However previously submitted session which weren't implemented using this workflow still exists. 

So though doesn't exactly fix the issue, but I don't think we can do anything about already submitted session without registering speaker. We can pretty well delete or disable them from DB. @mariobehling @niranjan94 what do you think??