### PR TITLE
Timeline block on scheduler page is spread to full screen

### DIFF
--- a/app/static/css/events/scheduler.css
+++ b/app/static/css/events/scheduler.css
@@ -119,7 +119,6 @@
     overflow-x: auto;
     overflow-y: hidden;
     white-space: nowrap;
-    width: 654px;
 }
 
 .timeline .microlocations .microlocation {

--- a/app/templates/gentelella/guest/event/schedule.html
+++ b/app/templates/gentelella/guest/event/schedule.html
@@ -151,7 +151,7 @@
                     $('.overlay').addClass('visible');
                     $('.btn-pop-out').removeClass('fa-expand').addClass('fa-compress');
                     var width = $("#timeline").width() - $('.timeunits.x1').width();
-                    $('.microlocation-container').css("width", width + "px");
+                    $('.microlocation-container').css("max-width", width + "px");
                     $('.session.scheduled').popover('hide');
                 }
                 function close(){
@@ -159,7 +159,8 @@
                     $body.removeClass('noscroll');
                     $('.overlay').removeClass('visible');
                     $('.btn-pop-out').addClass('fa-expand').removeClass('fa-compress');
-                    $('.microlocation-container').css("width", "fit-content");
+                    var width = $("#timeline").width() - $('.timeunits.x1').width();
+                    $('.microlocation-container').css("max-width", width + "px");
                     $('.session.scheduled').popover('hide');
                     $('.scheduler-holder').height($('.timeline').height());
                 }


### PR DESCRIPTION
fixes #3589 

![screenshot from 2017-05-16 04-06-46](https://cloud.githubusercontent.com/assets/13533840/26082785/57cc7022-39ef-11e7-882b-c1707c2f3ca9.png)
