### PR TITLE
Allow only organizer of event to edit schedule

### DIFF
--- a/app/templates/gentelella/users/events/event_base.html
+++ b/app/templates/gentelella/users/events/event_base.html
@@ -20,7 +20,9 @@
 {% macro tabs() %}
     <ul class="nav nav-tabs bar_tabs" role="tablist" style="background: #FFFFFF;">
         {% for href, id, caption in navigation_bar %}
+        {% if not (current_user.is_coorganizer(event.id) and id == 'scheduler') %}
             <li{% if id == active_page %} class="active"{% endif %}><a href="{{ href|e }}" style="cursor: pointer;">{{ caption|e }}</a></li>
+        {% endif %}
         {% endfor %}
     </ul>
 {% endmacro %}

--- a/app/views/users/scheduler.py
+++ b/app/views/users/scheduler.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from flask import Blueprint
 from flask import render_template
 from flask import url_for, flash
+from flask.ext import login
+from flask.ext.restplus import abort
 from werkzeug.utils import redirect
 
 from app.helpers.data import save_to_db
@@ -15,6 +17,8 @@ event_scheduler = Blueprint('event_scheduler', __name__, url_prefix='/events/<ev
 @event_scheduler.route('/')
 @can_access
 def display_view(event_id):
+    if login.current_user.is_coorganizer(event_id):
+        abort(404)
     sessions = DataGetter.get_sessions_by_event_id(event_id)
     event = DataGetter.get_event(event_id)
     if not event.has_session_speakers:
@@ -26,6 +30,8 @@ def display_view(event_id):
 @event_scheduler.route('/publish/')
 @can_access
 def publish(event_id):
+    if login.current_user.is_coorganizer(event_id):
+        abort(404)
     event = DataGetter.get_event(event_id)
     event.schedule_published_on = datetime.now()
     save_to_db(event, "Event schedule published")
@@ -36,6 +42,8 @@ def publish(event_id):
 @event_scheduler.route('/unpublish/')
 @can_access
 def unpublish(event_id):
+    if login.current_user.is_coorganizer(event_id):
+        abort(404)
     event = DataGetter.get_event(event_id)
     event.schedule_published_on = None
     save_to_db(event, "Event schedule unpublished")


### PR DESCRIPTION
#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The unit tests pass locally with my changes 

#### Short description of what this resolves:
This pull request now allows only the organizer of an event to edit scheduler.

#### Changes proposed in this pull request:
Fixes #3613 . As reported, when scheduler is edited by more than one users/co-organizers, it gives error. So to prevent this, as suggested by @mariobehling we allow only main organizer of the event to edit the schedule. Thus I have removed the option for editing scheduler for everyone including admins and co-organizers.

Organizer:
![screenshot from 2017-05-18 17-23-27](https://cloud.githubusercontent.com/assets/9530293/26201354/37519266-3bf0-11e7-9edd-6d46d6ddadcb.png)

Co-organizer:
![screenshot from 2017-05-18 17-23-24](https://cloud.githubusercontent.com/assets/9530293/26201360/3d210e1a-3bf0-11e7-8af4-81b8a4be1838.png)

