### PR TITLE
Fixed error on clicking on invitation notification

### DIFF
--- a/app/helpers/system_notifications.py
+++ b/app/helpers/system_notifications.py
@@ -80,8 +80,8 @@ NOTIFS = {
         'title': u'Invitation to be {role_name} at {event_name}',
         'message': u"""You've been invited to be a <strong>{role_name}</strong>
             at <strong>{event_name}</strong>.<br><br>
-            <a href='{accept_link}' class='btn btn-success btn-sm'>Accept</a>
-            <a href='{decline_link}' class='btn btn-danger btn-sm'>Decline</a>""",
+            <a href='{accept_link}' class='btn btn-success btn-sm invite'>Accept</a>
+            <a href='{decline_link}' class='btn btn-danger btn-sm invite'>Decline</a>""",
         'recipient': 'User',
     },
     NEW_SESSION: {

--- a/app/static/js/global_tail.js
+++ b/app/static/js/global_tail.js
@@ -139,7 +139,8 @@ function setATagsInNotifMenuDropDown(notificationViewPath) {
                         $(li).remove();
                     });
                     var notif_count = $notifCount.text();
-                    $notifCount.text(parseInt(notif_count) - 1);
+                    notif_count = ((notif_count - 1) > 0 ) ? (notif_count - 1) : 0;
+                    $notifCount.text(parseInt(notif_count, 10));
                 }
             });
         });

--- a/app/templates/gentelella/users/profile/notifications.html
+++ b/app/templates/gentelella/users/profile/notifications.html
@@ -117,6 +117,12 @@
                     $(e.target).parents('.notification').removeClass('info'); // show notification as read
                     $(e.target).remove(); // delete mark as read button
                 });
+            } else if ($(e.target).is('.invite')) {
+                var read_button = $(e.target).parents(".notification").find('a.read-btn');
+                $.getJSON(read_button.attr('href'), function (data) {
+                    read_button.parents('.notification').removeClass('info'); // show notification as read
+                    read_button.remove(); // delete mark as read button
+                });
             } else if (e.target.class == "notification" || $(e.target).parents(".notification").size()) {
                 var read_button = $(e.target).parents(".notification").find('a.read-btn');
                 $.getJSON(read_button.attr('href'), function (data) { });
@@ -155,8 +161,8 @@
                     $(".notif-table tbody").prepend(html);
                 }
             });
-        });
 
+        });
     </script>
 
 {% endblock %}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->

#### Short description of what this resolves:
This PR fixes marking invitation notifications as read when they are read and preventing error which occurred when the link to an already accepted invitation was clicked again.

Fixes #3587 .
