### PR TITLE
Notification triggers only once per order, no resent notification

### DIFF
--- a/app/helpers/notification_email_triggers.py
+++ b/app/helpers/notification_email_triggers.py
@@ -91,8 +91,8 @@ def trigger_after_purchase_notifications(buyer_email, event_id, event, invoice_i
             (email_notification_setting and email_notification_setting.after_ticket_purchase == 1 and
                      admin_msg_setting.user_control_status == 1) or admin_msg_setting.user_control_status == 0:
             send_email_for_after_purchase_organizers(coorganizer.user.email, buyer_email, invoice_id, order_url, event.name, event.organizer_name)
-        if not resend:
-            send_notif_for_resend(organizer.user, invoice_id, order_url, event.name, buyer_email)
+        if resend:
+            send_notif_for_resend(coorganizer.user, invoice_id, order_url, event.name, buyer_email)
         else:
-            send_notif_for_after_purchase_organizer(organizer.user, invoice_id, order_url, event.name, buyer_email)
+            send_notif_for_after_purchase_organizer(coorganizer.user, invoice_id, order_url, event.name, buyer_email)
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Solves notification problem on ticket purchase.

#### Changes proposed in this pull request:

- After ticket purchase, organizer should get only one ticket purchase notification per order
- Resent notification should be got only on resend, not on purchase
- Both organizer and coorganizer gets the purchase notification (one time)

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3602 
![screenshot from 2017-05-22 01-52-33](https://cloud.githubusercontent.com/assets/20799954/26287149/ae367442-3e92-11e7-9225-3543e15c1959.png)

