### PR TITLE
PNG export shows entire schedule again

### DIFF
--- a/app/static/css/custom/common.css
+++ b/app/static/css/custom/common.css
@@ -459,6 +459,7 @@ span.twitter-typeahead {
 
 .fullwidth {
     width: 100% !important;
+    max-width: none !important;
 }
 .external_url{
     display: none;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes 

#### Short description of what this resolves:
The PNG export now shows the entire schedule.

![timeline](https://cloud.githubusercontent.com/assets/9530293/26417293/66d5f6a4-40d6-11e7-9914-2876df3801f9.png)


Fixes #3615 
