### PR TITLE
PNG Export from Full Screen Schedule showing whole schedule

### DIFF
--- a/app/static/css/custom/common.css
+++ b/app/static/css/custom/common.css
@@ -461,6 +461,18 @@ span.twitter-typeahead {
     width: 100% !important;
     max-width: none !important;
 }
+
+.blackscreen{
+    background-color: white; 
+    width:100%; 
+    height:100%; 
+    z-index:3000;
+    position: fixed;
+    top: 0;
+    left: 0;
+    display: none;
+}
+
 .external_url{
     display: none;
 }

--- a/app/templates/gentelella/guest/event/schedule.html
+++ b/app/templates/gentelella/guest/event/schedule.html
@@ -189,23 +189,47 @@
             e.preventDefault();
         });
 
+        $('.blackscreen').hide();
+        
         $(".export-png").click(function () {
-            var $timeline = $('.event-info-container-holder');
-            $('#microlocation-container').addClass('fullwidth');
-            var width = $('#microlocation-container').width() + 150;
-            var currentStyle = $timeline.attr('style');
-            $timeline.width(width);
-            html2canvas($timeline[0], {
-                onrendered: function (canvas) {
-                    canvas.id = "generated-canvas";
-                    canvas.toBlob(function (blob) {
-                        saveAs(blob, "timeline.png");
-                        $('#microlocation-container').removeClass('fullwidth');
-                        $timeline.attr('style', currentStyle);
-                    });
-                },
-            });
-
+            if($('.scheduler-pop')[0]){
+                $('.blackscreen').show();
+                $scheduler.removeClass('scheduler-pop');
+                var $timeline = $('.event-info-container-holder');
+                $('#microlocation-container').addClass('fullwidth');
+                var width = $('#microlocation-container').width() + 150;
+                var currentStyle = $timeline.attr('style');
+                $timeline.width(width);
+                html2canvas($timeline[0], {
+                    onrendered: function (canvas) {
+                        canvas.id = "generated-canvas";
+                        canvas.toBlob(function (blob) {
+                            saveAs(blob, "timeline.png");
+                            $('#microlocation-container').removeClass('fullwidth');
+                            $timeline.attr('style', currentStyle);
+                            $scheduler.addClass('scheduler-pop');
+                            $('.blackscreen').hide();
+                        });
+                    },
+                });
+            } else {
+                var $timeline = $('.event-info-container-holder');
+                $('#microlocation-container').addClass('fullwidth');
+                var width = $('#microlocation-container').width() + 150;
+                var currentStyle = $timeline.attr('style');
+                $timeline.width(width);
+                html2canvas($timeline[0], {
+                    onrendered: function (canvas) {
+                        canvas.id = "generated-canvas";
+                        canvas.toBlob(function (blob) {
+                            saveAs(blob, "timeline.png");
+                            $('#microlocation-container').removeClass('fullwidth');
+                            $timeline.attr('style', currentStyle);
+                        });
+                    },
+                });
+            } 
         });
     </script>
+    <div class="blackscreen">Downloading...</div>
 {% endblock %}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Fixes PNG Export from Full Screen Schedule .

#### Changes proposed in this pull request:

- print schedule in .png format  from full screen.
-
-

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3367 
.png from full-screen. Same as the one from normal view png export.

![timeline 15](https://cloud.githubusercontent.com/assets/20799954/26436972/f12e60dc-4137-11e7-8ebe-91ef8e5b9d95.png)

