### PR TITLE
Corrected the region in kubernetes docs to include only region info

### DIFF
--- a/docs/installation/gce-kubernetes.md
+++ b/docs/installation/gce-kubernetes.md
@@ -107,7 +107,7 @@ Repeat the same procedure and create another disk named `nfs-data-disk`.
 - Reserve a static external IP address 
 	
 	```bash
-	gcloud compute addresses create testip --region us-west1-a
+	gcloud compute addresses create testip --region us-west1
 	```
 	
 	The response would be similar to 


### PR DESCRIPTION

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:
Fixes the region info in the kubernetes installation docs.
