### PR TITLE
Fixed: A registrar of an event cannot go to the event page

### DIFF
--- a/app/helpers/permission_decorators.py
+++ b/app/helpers/permission_decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from flask import request
+from flask import request, redirect, url_for
 from flask.ext import login
 from flask.ext.restplus import abort
 
@@ -259,6 +259,8 @@ def can_access(f):
             if user.is_registrar(event_id):
                 if '/attendees' in url:
                     return f(*args, **kwargs)
+                elif not request.is_xhr:
+                    return redirect(url_for('event_ticket_sales.display_attendees', event_id=event_id))
                 else:
                     abort(403)
             if user.is_organizer(event_id) or user.is_coorganizer(event_id):


### PR DESCRIPTION
Now the registrar will be redirected to attendees section

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added necessary documentation (if appropriate)~

#### Short description of what this resolves:
A registrar of the event once accepted is redirected to events home page in control panel but it doesn't have access to view it. So now it will be redirected to attendee section.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Partially Fixes #3656
