### PR TITLE
Importing extensions via flask_* since flask.ext.* is deprecated

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,17 +12,17 @@ from app.helpers.scheduled_jobs import send_mail_to_expired_orders, empty_trash,
 
 from celery import Celery
 from celery.signals import after_task_publish
-from flask.ext.htmlmin import HTMLMIN
+from flask_htmlmin import HTMLMIN
 import logging
 import os.path
 from os import environ
 import sys
 from flask import Flask, session
 from app.settings import get_settings, get_setts
-from flask.ext.migrate import Migrate, MigrateCommand
-from flask.ext.script import Manager
-from flask.ext.login import current_user
-from flask.ext.jwt import JWT
+from flask_migrate import Migrate, MigrateCommand
+from flask_script import Manager
+from flask_login import current_user
+from flask_jwt import JWT
 from datetime import timedelta
 from flask_cors import CORS
 
@@ -48,7 +48,7 @@ from app.helpers.babel import babel
 from helpers.helpers import send_email_for_expired_orders
 from werkzeug.contrib.profiler import ProfilerMiddleware
 from app.views import BlueprintsManager
-from flask.ext.sqlalchemy import get_debug_queries
+from flask_sqlalchemy import get_debug_queries
 from app.helpers.auth import AuthManager
 
 from app.helpers.flask_ext.error_handlers import init_error_handlers

--- a/app/helpers/auth.py
+++ b/app/helpers/auth.py
@@ -1,7 +1,7 @@
 import flask_login as login
 from app.models import db
 from app.models.user import User
-from flask.ext.login import current_user
+from flask_login import current_user
 
 
 class AuthManager:

--- a/app/helpers/babel.py
+++ b/app/helpers/babel.py
@@ -1,3 +1,3 @@
-from flask.ext.babel import Babel
+from flask_babel import Babel
 
 babel = Babel()  # Babel Initialization

--- a/app/helpers/cache.py
+++ b/app/helpers/cache.py
@@ -1,3 +1,3 @@
-from flask.ext.cache import Cache
+from flask_cache import Cache
 
 cache = Cache()

--- a/app/helpers/data.py
+++ b/app/helpers/data.py
@@ -13,8 +13,8 @@ import PIL
 import oauth2
 from PIL import Image
 from flask import flash, url_for, g, current_app
-from flask.ext import login
-from flask.ext.scrypt import generate_password_hash, generate_random_salt
+import flask_login as login
+from flask_scrypt import generate_password_hash, generate_random_salt
 from flask_socketio import emit
 from requests_oauthlib import OAuth2Session
 

--- a/app/helpers/data_getter.py
+++ b/app/helpers/data_getter.py
@@ -8,7 +8,7 @@ import pytz
 import requests
 from flask import flash, abort, request
 from flask import url_for
-from flask.ext import login
+import flask_login as login
 from sqlalchemy import desc, asc, or_
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 

--- a/app/helpers/jwt.py
+++ b/app/helpers/jwt.py
@@ -1,4 +1,4 @@
-from flask.ext.scrypt import check_password_hash
+from flask_scrypt import check_password_hash
 
 from app.models.user import User
 

--- a/app/helpers/microservices.py
+++ b/app/helpers/microservices.py
@@ -1,6 +1,6 @@
 import requests
 from flask import request, flash
-from flask.ext import login
+import flask_login as login
 
 from app.helpers.data_getter import DataGetter
 from app.settings import get_settings

--- a/app/helpers/permission_decorators.py
+++ b/app/helpers/permission_decorators.py
@@ -1,8 +1,8 @@
 from functools import wraps
 
 from flask import request
-from flask.ext import login
-from flask.ext.restplus import abort
+import flask_login as login
+from flask_restplus import abort
 
 from app.helpers.helpers import get_count
 from app.models.discount_code import DiscountCode

--- a/app/helpers/storage.py
+++ b/app/helpers/storage.py
@@ -7,7 +7,7 @@ import magic
 from boto.gs.connection import GSConnection
 from boto.s3.connection import S3Connection, OrdinaryCallingFormat
 from boto.s3.key import Key
-from flask.ext.scrypt import generate_password_hash
+from flask_scrypt import generate_password_hash
 from werkzeug.utils import secure_filename
 from flask import current_app as app
 

--- a/app/helpers/ticketing.py
+++ b/app/helpers/ticketing.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import timedelta, datetime
 
 from flask import url_for, flash, abort
-from flask.ext import login
+import flask_login as login
 from sqlalchemy import desc
 from sqlalchemy import or_
 

--- a/app/helpers/wizard/clone.py
+++ b/app/helpers/wizard/clone.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import make_transient
-from flask.ext import login
+import flask_login as login
 
 from app.helpers.data import save_to_db
 from app.helpers.data_getter import DataGetter

--- a/app/helpers/wizard/event.py
+++ b/app/helpers/wizard/event.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from PIL import Image
 from flask import url_for, abort, current_app
-from flask.ext import login
+import flask_login as login
 
 from app.helpers.data import save_to_db, record_activity
 from app.helpers.cache import cache

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,4 @@
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy_continuum import make_versioned
 from sqlalchemy_continuum.plugins import FlaskPlugin
 

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -2,7 +2,7 @@ import binascii
 import os
 from datetime import datetime
 
-from flask.ext import login
+import flask_login as login
 from sqlalchemy import event
 
 from app.helpers.date_formatter import DateFormatter

--- a/app/old_api/__init__.py
+++ b/app/old_api/__init__.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, render_template
-from flask.ext.restplus import Api
+from flask_restplus import Api
 from flask_login import current_user
 
 from helpers.error_docs import api as error_models

--- a/app/old_api/attendees.py
+++ b/app/old_api/attendees.py
@@ -1,4 +1,4 @@
-from flask.ext.restplus import Namespace
+from flask_restplus import Namespace
 
 from app.api.tickets import ORDER, TICKET
 from app.helpers.ticketing import TicketingManager

--- a/app/old_api/events.py
+++ b/app/old_api/events.py
@@ -1,5 +1,5 @@
 from flask import g
-from flask.ext.restplus import Namespace, reqparse, marshal
+from flask_restplus import Namespace, reqparse, marshal
 
 from app.api.attendees import TICKET
 from app.api.microlocations import MICROLOCATION

--- a/app/old_api/exports.py
+++ b/app/old_api/exports.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import send_file, make_response, jsonify, url_for, current_app
-from flask.ext.restplus import Resource, Namespace, marshal
+from flask_restplus import Resource, Namespace, marshal
 
 from app.helpers.data import record_activity
 from helpers import custom_fields as fields

--- a/app/old_api/extras.py
+++ b/app/old_api/extras.py
@@ -7,7 +7,7 @@ that are not important to the end-user
 
 from celery.result import AsyncResult
 from flask import jsonify, current_app
-from flask.ext.restplus import Resource, Namespace
+from flask_restplus import Resource, Namespace
 
 from helpers.utils import TASK_RESULTS
 

--- a/app/old_api/helpers/custom_fields.py
+++ b/app/old_api/helpers/custom_fields.py
@@ -2,7 +2,7 @@ import re
 import colour
 from datetime import datetime
 from flask import request
-from flask.ext.restplus.fields import Raw, Nested, List
+from flask_restplus.fields import Raw, Nested, List
 from app.helpers.data_getter import DataGetter
 
 EMAIL_REGEX = re.compile(r'\S+@\S+\.\S+')

--- a/app/old_api/helpers/error_docs.py
+++ b/app/old_api/helpers/error_docs.py
@@ -1,5 +1,5 @@
-from flask.ext.restplus import Namespace, fields
-from flask.ext.restplus.fields import Raw
+from flask_restplus import Namespace, fields
+from flask_restplus.fields import Raw
 
 api = Namespace('errors', description='Error Responses')
 

--- a/app/old_api/helpers/helpers.py
+++ b/app/old_api/helpers/helpers.py
@@ -3,10 +3,10 @@ from datetime import datetime
 from functools import wraps, update_wrapper
 
 from flask import request, g, make_response
-from flask.ext import login
-from flask.ext.restplus import fields
-from flask.ext.restplus.utils import merge
-from flask.ext.scrypt import check_password_hash
+import flask_login as login
+from flask_restplus import fields
+from flask_restplus.utils import merge
+from flask_scrypt import check_password_hash
 from flask_jwt import jwt_required, JWTError, current_identity
 from sqlalchemy import func
 

--- a/app/old_api/helpers/utils.py
+++ b/app/old_api/helpers/utils.py
@@ -2,7 +2,7 @@ import json
 from hashlib import md5
 
 from flask import request
-from flask.ext.restplus import Resource as RestplusResource
+from flask_restplus import Resource as RestplusResource
 from flask_restplus import Model, fields, reqparse
 
 from app.helpers.data import update_version

--- a/app/old_api/imports.py
+++ b/app/old_api/imports.py
@@ -1,7 +1,7 @@
 from flask import g
 from flask import jsonify, url_for, current_app
-from flask.ext.restplus import Resource, Namespace, marshal
-from flask.ext.restplus import abort
+from flask_restplus import Resource, Namespace, marshal
+from flask_restplus import abort
 
 from app.helpers.data import record_activity
 from app.helpers.importers.ical import ICalImporter

--- a/app/old_api/login.py
+++ b/app/old_api/login.py
@@ -1,6 +1,6 @@
 import json
 
-from flask.ext.restplus import Resource, Namespace
+from flask_restplus import Resource, Namespace
 from flask_jwt import JWTError
 
 from app.api.helpers import custom_fields as fields

--- a/app/old_api/microlocations.py
+++ b/app/old_api/microlocations.py
@@ -1,4 +1,4 @@
-from flask.ext.restplus import Namespace
+from flask_restplus import Namespace
 
 from app.models.microlocation import Microlocation as MicrolocationModel
 from app.api.helpers import custom_fields as fields

--- a/app/old_api/notifications.py
+++ b/app/old_api/notifications.py
@@ -1,4 +1,4 @@
-from flask.ext.restplus import Namespace
+from flask_restplus import Namespace
 
 from app.helpers.data import DataManager
 from app.helpers.data_getter import DataGetter

--- a/app/old_api/sessions.py
+++ b/app/old_api/sessions.py
@@ -1,4 +1,4 @@
-from flask.ext.restplus import Namespace, reqparse
+from flask_restplus import Namespace, reqparse
 from sqlalchemy.orm.collections import InstrumentedList
 
 from app.helpers.data import record_activity, save_to_db

--- a/app/old_api/speakers.py
+++ b/app/old_api/speakers.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 from flask import g
-from flask.ext.restplus import Namespace, marshal_with
+from flask_restplus import Namespace, marshal_with
 from flask_login import current_user
 
 from app.helpers.data_getter import DataGetter

--- a/app/old_api/sponsors.py
+++ b/app/old_api/sponsors.py
@@ -1,4 +1,4 @@
-from flask.ext.restplus import Namespace
+from flask_restplus import Namespace
 
 from app.models.sponsor import Sponsor as SponsorModel
 from app.api.helpers import custom_fields as fields

--- a/app/old_api/tickets.py
+++ b/app/old_api/tickets.py
@@ -1,4 +1,4 @@
-from flask.ext.restplus import Namespace
+from flask_restplus import Namespace
 
 from app.helpers.ticketing import TicketingManager
 from app.api.helpers import custom_fields as fields

--- a/app/old_api/tracks.py
+++ b/app/old_api/tracks.py
@@ -1,4 +1,4 @@
-from flask.ext.restplus import Namespace
+from flask_restplus import Namespace
 
 from app.models.track import Track as TrackModel
 from app.api.helpers import custom_fields as fields

--- a/app/old_api/users.py
+++ b/app/old_api/users.py
@@ -1,5 +1,5 @@
 from flask import g
-from flask.ext.restplus import Resource, Namespace
+from flask_restplus import Resource, Namespace
 
 from app.api.events import EVENT
 from app.helpers.data import DataManager, record_activity

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -9,9 +9,9 @@ import geoip2.database
 from flask import Blueprint
 from flask import abort, render_template, current_app
 from flask import url_for, redirect, request, session, flash
-from flask.ext import login
-from flask.ext.login import login_required
-from flask.ext.scrypt import generate_password_hash
+import flask_login as login
+from flask_login import login_required
+from flask_scrypt import generate_password_hash
 
 from app.helpers.data import DataManager, save_to_db, get_google_auth, get_facebook_auth, create_user_password, \
     user_logged_in, record_activity

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -4,8 +4,8 @@ import pytz
 
 from flask import Blueprint
 from flask import request, url_for, flash, render_template, jsonify, make_response, current_app as app
-from flask.ext import login
-from flask.ext.restplus import abort
+import flask_login as login
+from flask_restplus import abort
 from markupsafe import Markup
 from werkzeug.utils import redirect
 

--- a/app/views/public/event_invoice.py
+++ b/app/views/public/event_invoice.py
@@ -4,7 +4,7 @@ import pycountry
 from flask import Blueprint
 from flask import redirect, url_for, request, jsonify, make_response, flash
 from flask import render_template
-from flask.ext.restplus import abort
+from flask_restplus import abort
 from xhtml2pdf import pisa
 
 from app.helpers.data import save_to_db

--- a/app/views/public/explore.py
+++ b/app/views/public/explore.py
@@ -4,7 +4,7 @@ import requests
 from flask import Blueprint
 from flask import render_template
 from flask import request, redirect, url_for, jsonify
-from flask.ext.restplus import abort
+from flask_restplus import abort
 from flask_restplus import marshal
 from requests import ConnectionError
 

--- a/app/views/public/ticketing.py
+++ b/app/views/public/ticketing.py
@@ -6,7 +6,7 @@ import stripe
 from flask import Blueprint
 from flask import redirect, url_for, request, jsonify, make_response, flash
 from flask import render_template
-from flask.ext.restplus import abort
+from flask_restplus import abort
 from xhtml2pdf import pisa
 
 from app import get_settings

--- a/app/views/super_admin/__init__.py
+++ b/app/views/super_admin/__init__.py
@@ -1,6 +1,6 @@
 from flask import request, url_for, redirect
-from flask.ext.login import current_user
-from flask.ext.restplus import abort
+from flask_login import current_user
+from flask_restplus import abort
 from app.helpers.auth import AuthManager
 
 # Admin Panels

--- a/app/views/super_admin/sales.py
+++ b/app/views/super_admin/sales.py
@@ -7,7 +7,7 @@ from flask import Blueprint
 from flask import render_template
 from flask import request
 from flask import url_for
-from flask.ext import login
+import flask_login as login
 from werkzeug.exceptions import abort
 from werkzeug.utils import redirect
 

--- a/app/views/super_admin/users.py
+++ b/app/views/super_admin/users.py
@@ -2,9 +2,9 @@ import unicodedata
 from flask import Blueprint
 from flask import request, jsonify
 from flask import url_for, redirect, flash, render_template
-from flask.ext.scrypt import generate_password_hash, generate_random_salt
-from flask.ext.login import current_user
-from flask.ext.restplus import abort
+from flask_scrypt import generate_password_hash, generate_random_salt
+from flask_login import current_user
+from flask_restplus import abort
 from sqlalchemy_continuum import transaction_class
 
 from app.helpers.data import delete_from_db, DataManager, save_to_db

--- a/app/views/users/events.py
+++ b/app/views/users/events.py
@@ -6,8 +6,8 @@ from uuid import uuid4
 
 from flask import Blueprint
 from flask import flash, url_for, redirect, request, jsonify, Markup, render_template, current_app
-from flask.ext.login import current_user
-from flask.ext.restplus import abort
+from flask_login import current_user
+from flask_restplus import abort
 
 from app import db
 from app.helpers.auth import AuthManager

--- a/app/views/users/my_sessions.py
+++ b/app/views/users/my_sessions.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from flask import Blueprint, jsonify
 from flask import flash, redirect, url_for, request
 from flask import render_template, current_app
-from flask.ext.restplus import abort
-from flask.ext import login
+from flask_restplus import abort
+import flask_login as login
 from markupsafe import Markup
 
 from app.helpers.data import DataManager, save_to_db

--- a/app/views/users/notifications.py
+++ b/app/views/users/notifications.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 from flask import url_for, redirect, abort, jsonify, render_template
-from flask.ext import login
+import flask_login as login
 
 from app.helpers.data import DataManager
 from app.helpers.data_getter import DataGetter

--- a/app/views/users/profile.py
+++ b/app/views/users/profile.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from flask import Blueprint
 from flask import render_template
 from flask import request, url_for, redirect, flash, jsonify
-from flask.ext import login
+import flask_login as login
 from markupsafe import Markup
 
 from app.helpers.auth import AuthManager

--- a/app/views/users/scheduler.py
+++ b/app/views/users/scheduler.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from flask import Blueprint
 from flask import render_template
 from flask import url_for, flash
-from flask.ext import login
-from flask.ext.restplus import abort
+import flask_login as login
+from flask_restplus import abort
 from werkzeug.utils import redirect
 
 from app.helpers.data import save_to_db

--- a/app/views/users/sessions.py
+++ b/app/views/users/sessions.py
@@ -4,7 +4,7 @@ import re
 from flask import Blueprint
 from flask import make_response
 from flask import url_for, redirect, flash, render_template
-from flask.ext import login
+import flask_login as login
 from app import db
 from app.helpers.data import DataManager, delete_from_db, trash_session as _trash_session, \
     restore_session as _restore_session

--- a/app/views/users/settings.py
+++ b/app/views/users/settings.py
@@ -2,8 +2,8 @@ import unicodedata
 
 from flask import Blueprint, render_template
 from flask import request, url_for, redirect, jsonify, flash
-from flask.ext import login
-from flask.ext.scrypt import generate_password_hash, generate_random_salt
+import flask_login as login
+from flask_scrypt import generate_password_hash, generate_random_salt
 
 from app.helpers.data import DataManager, save_to_db
 from app.helpers.data_getter import DataGetter

--- a/app/views/users/speakers.py
+++ b/app/views/users/speakers.py
@@ -2,7 +2,7 @@ import json
 
 from flask import Blueprint
 from flask import request, url_for, redirect, flash, jsonify, render_template, current_app
-from flask.ext.restplus import abort
+from flask_restplus import abort
 
 from app.helpers.data import delete_from_db, save_to_db
 from app.helpers.data_getter import DataGetter

--- a/app/views/utils_routes.py
+++ b/app/views/utils_routes.py
@@ -8,8 +8,8 @@ from flask import Blueprint, current_app
 from flask import flash
 from flask import jsonify, url_for, redirect, request, send_from_directory, \
     render_template, make_response
-from flask.ext import login
-from flask.ext.migrate import upgrade
+import flask_login as login
+from flask_migrate import upgrade
 from requests.exceptions import HTTPError
 
 from app.helpers.flask_ext.helpers import get_real_ip, slugify

--- a/create_db.py
+++ b/create_db.py
@@ -4,7 +4,7 @@ import getpass
 import eventlet
 
 from app import current_app
-from flask.ext.migrate import stamp
+from flask_migrate import stamp
 from app.helpers.data import DataManager
 from app.models import db
 from populate_db import populate

--- a/docs/general/amazon-s3.md
+++ b/docs/general/amazon-s3.md
@@ -113,7 +113,7 @@ Here is a basic example.
 ```python
 from flask import request, current_app as app
 from app.helpers.storage import upload
-from flask.ext import login
+import flask_login as login
 
 @app.route('/users/upload/', methods=('POST'))
 def view():

--- a/manage.py
+++ b/manage.py
@@ -9,7 +9,7 @@ from app.models.speaker import Speaker
 from app.helpers.data import DataManager
 from app.helpers.data_getter import DataGetter
 from populate_db import populate
-from flask.ext.migrate import stamp
+from flask_migrate import stamp
 from sqlalchemy.engine import reflection
 
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `nextgen` branch.
- [X] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [X] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Changes in flask extensions  import 

#### Changes proposed in this pull request:

-Import extensions via flask_* since flask.ext.* is deprecated
-
-

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
