### PR TITLE
Api framework upstream updated: remove old delete functions

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -44,18 +44,6 @@ class EventRelationship(ResourceRelationship):
 
 
 class EventDetail(ResourceDetail):
-
-    def delete(self, *args, **kwargs):
-        """
-        Function for soft-delete
-        :param args:
-        :param kwargs:
-        :return:
-        """
-        obj = self._data_layer.get_object(kwargs)
-        obj.deleted_at = datetime.now()
-        return {'meta': {'message': 'Object successfully deleted'}}
-
     decorators = (jwt_required, )
     schema = EventSchema
     data_layer = {'session': db.session,

--- a/app/api/tickets.py
+++ b/app/api/tickets.py
@@ -65,18 +65,6 @@ class TicketRelationship(ResourceRelationship):
 
 
 class TicketDetail(ResourceDetail):
-
-    def delete(self, *args, **kwargs):
-        """
-        Function for soft-delete
-        :param args:
-        :param kwargs:
-        :return:
-        """
-        obj = self._data_layer.get_object(kwargs)
-        obj.deleted_at = datetime.now()
-        return {'meta': {'message': 'Object successfully deleted'}}
-
     decorators = (jwt_required, )
     schema = TicketSchema
     data_layer = {'session': db.session,

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -59,17 +59,6 @@ class UserDetail(ResourceDetail):
     """
     User detail by id
     """
-    def delete(self, *args, **kwargs):
-        """
-        Function for soft-delete
-        :param args:
-        :param kwargs:
-        :return:
-        """
-        obj = self._data_layer.get_object(kwargs)
-        obj.deleted_at = datetime.now()
-        return {'meta': {'message': 'Object successfully deleted'}}
-
     decorators = (is_user_itself, )
     schema = UserSchema
     data_layer = {'session': db.session,

--- a/config.py
+++ b/config.py
@@ -52,6 +52,7 @@ class Config(object):
     CORS_HEADERS = 'Content-Type'
     SQLALCHEMY_DATABASE_URI =  env('DATABASE_URL', default=None)
     DATABASE_QUERY_TIMEOUT = 0.1
+    SOFT_DELETE = True
 
     if not SQLALCHEMY_DATABASE_URI:
         print '`DATABASE_URL` either not exported or empty'


### PR DESCRIPTION
Hard/soft deletes implemented on upstream

<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Api framework upstream updated: remove old delete functions

#### Changes proposed in this pull request:

- Api framework upstream updated: remove old delete functions
- Hard/soft deletes implemented on upstream
- For get methods, use `?get_trashed=true`
- For hard delete, use `?permanent=true`
- Here's the change: https://github.com/shubham-padia/flask-rest-jsonapi/commit/7b1b0865b5b2ac016333a33ab1999419a2bb13d1
- Set env variable `SOFT_DELETE=false` to turn off soft delete.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3694 and #3696 
