### PR TITLE
Add Orders API with permissions and relationships

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,7 +1,7 @@
 from flask import current_app as app, Blueprint
 from flask_rest_jsonapi import Api
 
-from app.api.users import UserList, UserDetail
+from app.api.users import UserList, UserDetail, UserRelationship
 from app.api.tickets import AllTicketList, TicketDetail, TicketRelationship
 from app.api.events import EventList, EventDetail, EventRelationship
 from app.api.microlocations import MicrolocationList, MicrolocationDetail, MicrolocationRelationship
@@ -9,6 +9,7 @@ from app.api.sessions import SessionList, SessionDetail, SessionRelationship
 from app.api.social_links import SocialLinkList, SocialLinkDetail, SocialLinkRelationship
 from app.api.sponsors import SponsorList, SponsorDetail, SponsorRelationship
 from app.api.tracks import TrackList, TrackDetail, TrackRelationship
+from app.api.orders import OrderList, OrderDetail, OrderRelationship
 
 
 api_v1 = Blueprint('v1', __name__, url_prefix='/v1')
@@ -16,23 +17,26 @@ api = Api(app, api_v1)
 
 # users
 api.route(UserList, 'user_list', '/users')
-api.route(UserDetail, 'user_detail', '/users/<int:id>')
+api.route(UserDetail, 'user_detail', '/users/<int:id>', '/orders/<int:order_id>/user')
+api.route(UserRelationship, 'user_order', '/users/<int:id>/relationships/order')
 
 # tickets
 api.route(AllTicketList, 'all_ticket_list', '/tickets', '/events/<int:id>/tickets')
-api.route(TicketDetail, 'ticket_detail', '/tickets/<int:id>', '/events/<int:event_id>/tickets')
+api.route(TicketDetail, 'ticket_detail', '/tickets/<int:id>')
 api.route(TicketRelationship, 'ticket_event', '/tickets/<int:id>/relationships/event')
 
 # events
 api.route(EventList, 'event_list', '/events')
 api.route(EventDetail, 'event_detail', '/events/<int:id>', '/tickets/<int:ticket_id>/event',
           '/microlocations/<int:microlocation_id>/event', '/social_links/<int:social_link_id>/event',
-          '/sponsors/<int:sponsor_id>/event', '/tracks/<int:track_id>/event')
+          '/sponsors/<int:sponsor_id>/event', '/tracks/<int:track_id>/event',
+          '/orders/<int:order_id>/event')
 api.route(EventRelationship, 'event_ticket', '/events/<int:id>/relationships/ticket')
 api.route(EventRelationship, 'event_microlocation', '/events/<int:id>/relationships/microlocation')
 api.route(EventRelationship, 'event_social_link', '/events/<int:id>/relationships/social_link')
 api.route(EventRelationship, 'event_sponsor', '/events/<int:id>/relationships/sponsor')
 api.route(EventRelationship, 'event_tracks', '/events/<int:id>/relationships/tracks')
+api.route(EventRelationship, 'event_order', '/events/<int:id>/relationships/order')
 
 # microlocations
 api.route(MicrolocationList, 'microlocation_list', '/microlocations',
@@ -69,3 +73,11 @@ api.route(TrackList, 'track_list', '/tracks', '/events/<int:event_id>/tracks')
 api.route(TrackDetail, 'track_detail', '/tracks/<int:id>', '/sessions/<int:session_id>/track')
 api.route(TrackRelationship, 'track_sessions', '/tracks/<int:id>/relationships/sessions')
 api.route(TrackRelationship, 'track_event', '/tracks/<int:id>/relationships/event')
+
+# Orders
+api.route(OrderList, 'order_list', '/orders', 
+     '/events/<int:event_id>/orders', '/users/<int:user_id>/orders')
+# one last option can be done as /eevnts/event_id/orders?user=[1,3] in filtering
+api.route(OrderDetail, 'order_detail', '/orders/<int:id>')
+api.route(OrderRelationship, 'order_event', '/orders/<int:id>/relationships/event')
+api.route(OrderRelationship, 'order_user', '/orders/<int:id>/relationships/user')

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -62,8 +62,16 @@ class EventSchema(Schema):
                            related_view_kwargs={'event_id': '<id>'},
                            schema='SponsorSchema',
                            many=True,
-                           type_='sponsor')
+                           type_='order')
 
+    order = Relationship(attribute='order',
+                           self_view='v1.event_order',
+                           self_view_kwargs={'id': '<id>'},
+                           related_view='v1.order_list',
+                           related_view_kwargs={'id': '<id>'},
+                           schema='OrderSchema',
+                           many=True,
+                           type_='order')
 
 class EventList(ResourceList):
     decorators = (jwt_required, )
@@ -103,6 +111,17 @@ class EventDetail(ResourceDetail):
             else:
                 if track.event_id is not None:
                     view_kwargs['id'] = track.event_id
+                else:
+                    view_kwargs['id'] = None
+        if view_kwargs.get('order_id') is not None:
+            try:
+                order = self.session.query(Order).filter_by(id=view_kwargs['order_id']).one()
+            except NoResultFound:
+                raise ObjectNotFound({'parameter': 'order_id'},
+                                     "Order: {} not found".format(view_kwargs['order_id']))
+            else:
+                if order.event_id is not None:
+                    view_kwargs['id'] = order.event_id
                 else:
                     view_kwargs['id'] = None
 

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -1,0 +1,80 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
+
+from app.api.helpers.permissions import jwt_required
+from app.models import db
+from app.models.order import Order
+from app.models.event import Event
+
+
+class OrderSchema(Schema):
+
+    class Meta:
+        type_ = 'order'
+        self_view = 'v1.order_detail'
+        self_view_kwargs = {'id': '<id>'}
+
+    id = fields.Str(dump_only=True)
+    status = fields.boolean()
+
+    event = Relationship(attribute='event',
+                         self_view='v1.order_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    user = Relationship(attribute='user',
+                         self_view='v1.order_user',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.user_detail',
+                         related_view_kwargs={'id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+
+
+class OrderList(ResourceList):
+
+    def query(self, view_kwargs):
+        query_ = self.session.query(Sponsor)
+        if view_kwargs.get('event_id') is not None:
+            query_ = query_.filter_by(event_id=view_kwargs['event_id'])
+        if view_kwargs.get('user_id') is not None:
+            query_ = query_.filter_by(user_id=view_kwargs['user_id'])
+        return query_
+
+    def before_create_object(self, data, view_kwargs):
+        if view_kwargs.get('event_id') is not None:
+            event = self.session.query(Event).filter_by(id=view_kwargs['event_id']).one()
+            data['event_id'] = event.id
+        if view_kwargs.get('order_id') is not None:
+            order = self.session.query(Order).filter_by(id=view_kwargs['order_id']).one()
+            data['order_id'] = order.id
+
+    decorators = (jwt_required, can_access_orders, )
+    schema = OrderSchema
+    data_layer = {'session': db.session,
+                  'model': Order,
+                  'methods': {
+                      'query': query,
+                      'before_create_object': before_create_object
+                  }}
+
+
+class OrderRelationship(ResourceRelationship):
+
+    decorators = (jwt_required, )
+    schema = OrderSchema
+    data_layer = {'session': db.session,
+                  'model': Order}
+
+
+class OrderDetail(ResourceDetail):
+    """
+    Order Detail by id
+    """
+    decorators = (jwt_required, can_access_orders, )
+    schema = OrderSchema
+    data_layer = {'session': db.session,
+                  'model': Order}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Implements the basic API structure of Orders API

#### Changes proposed in this pull request:

Endpoints added
- /orders  => Only Admins can access this endpoint
- /events/<int:event_id>/orders  => Organizers and Admins can access this endpoint
- /users/<int:user_id>/orders => A user can access only its own orders.

- /orders/<int:id> => Only Admin and Organizers can access. As per current implementation, I guess only tickets can be seen by order users not the order records.

- /orders/<int:id>/relationships/event => Relationships with event, No extra permissions added yet on this

- /orders/<int:id>/relationships/user => Relationship with user, No extra permission added on this yet

No extra permission added on these
- '/orders/<int:id>/user' => To get the user associated with order.
- '/users/<int:id>/relationships/order'
- '/orders/<int:id>/event'
- '/events/<int:id>/relationships/order'

Fixes #3700 