### PR TITLE
Implementing Speakers api with proper permission and relationship

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,4 +1,5 @@
 from app.api.bootstrap import api
+from app.api.speakers import SpeakerList, SpeakerDetail, SpeakerRelationship
 from app.api.users import UserList, UserDetail, UserRelationship
 from app.api.notifications import NotificationList, NotificationDetail, NotificationRelationship
 from app.api.tickets import AllTicketList, TicketDetail, TicketRelationship
@@ -24,9 +25,10 @@ from app.api.attendees import AttendeeList, AttendeeDetail, AttendeeRelationship
 # users
 api.route(UserList, 'user_list', '/users')
 api.route(UserDetail, 'user_detail', '/users/<int:id>', '/notifications/<int:notification_id>/user',
-          '/event-invoices/<int:event_invoice_id>/user')
+          '/event-invoices/<int:event_invoice_id>/user', '/speakers/<int:speaker_id>/user')
 api.route(UserRelationship, 'user_notification', '/users/<int:id>/relationships/notifications')
 api.route(UserRelationship, 'user_event_invoices', '/users/<int:id>/relationships/event-invoices')
+api.route(UserRelationship, 'user_speaker', '/users/<int:id>/relationships/speaker')
 
 # notifications
 api.route(NotificationList, 'notification_list', '/users/<int:id>/notifications')
@@ -66,7 +68,8 @@ api.route(EventDetail, 'event_detail', '/events/<int:id>', '/events/<identifier>
           '/speakers-calls/<int:speakers_call_id>/event', '/session-types/<int:session_type_id>/event',
           '/event-copyright/<int:copyright_id>/event', '/tax/<int:tax_id>/event',
           '/event-invoices/<int:event_invoice_id>/event', '/discount-codes/<int:discount_code_id>/event',
-          '/sessions/<int:session_id>/event', '/ticket-tags/<int:ticket_tag_id>/event')
+          '/sessions/<int:session_id>/event', '/ticket-tags/<int:ticket_tag_id>/event', '/speakers/<int:speaker_id>/event')
+
 api.route(EventRelationship, 'event_ticket', '/events/<int:id>/relationships/tickets',
           '/events/<identifier>/relationships/tickets')
 api.route(EventRelationship, 'event_ticket_tag', '/events/<int:id>/relationships/ticket-tags',
@@ -94,6 +97,8 @@ api.route(EventRelationship, 'event_discount_code', '/events/<int:id>/relationsh
 api.route(EventRelationship, 'event_session', '/events/<int:id>/relationships/sessions',
           '/events/<identifier>/relationships/sessions')
 api.route(EventRelationship, 'event_event_type', '/events/<int:id>/relationships/event-type')
+api.route(EventRelationship, 'event_speaker', '/events/<int:id>/relationships/speakers',
+          '/events/<identifier>/relationships/speakers')
 
 # microlocations
 api.route(MicrolocationList, 'microlocation_list', '/microlocations', '/sessions/<int:id>/microlocations',
@@ -108,15 +113,14 @@ api.route(MicrolocationRelationship, 'microlocation_event',
 # sessions
 api.route(SessionList, 'session_list', '/sessions', '/events/<int:event_id>/sessions', '/events/<event_identifier>/sessions',
           '/tracks/<int:track_id>/sessions', '/session_types/<int:session_type_id>/sessions',
-          '/microlocations/<int:microlocation_id>/sessions')
-api.route(SessionDetail, 'session_detail', '/sessions/<int:id>')
-api.route(SessionRelationship, 'session_microlocation',
-          '/sessions/<int:id>/relationships/microlocation')
+          '/microlocations/<int:microlocation_id>/sessions', '/speakers/<int:speaker_id>/sessions')
+api.route(SessionDetail, 'session_detail', '/sessions/<int:id>', '/microlocations/<int:microlocation_id>/sessions',
+          '/events/<int:event_id>/microlocations')
+api.route(SessionRelationship, 'session_microlocation', '/sessions/<int:id>/relationships/microlocation')
 api.route(SessionRelationship, 'session_track', '/sessions/<int:id>/relationships/track')
-api.route(SessionRelationship, 'session_session_type',
-          '/sessions/<int:id>/relationships/session-type')
-api.route(SessionRelationship, 'session_event',
-          '/sessions/<int:id>/relationships/event')
+api.route(SessionRelationship, 'session_session_type', '/sessions/<int:id>/relationships/session-type')
+api.route(SessionRelationship, 'session_event', '/sessions/<int:id>/relationships/event')
+api.route(SessionRelationship, 'session_speaker', '/sessions/<int:id>/relationships/speaker')
 
 # social_links
 api.route(SocialLinkList, 'social_link_list', '/events/<int:id>/social-links', '/events/<identifier>/social-links')
@@ -170,10 +174,8 @@ api.route(TaxRelationship, 'tax_event', '/tax/<int:id>/relationships/event')
 api.route(EventInvoiceList, 'event_invoice_list', '/events/<int:event_id>/event-invoices',
           '/events/<event_identifier>/event-invoices', '/users/<int:user_id>/event-invoices')
 api.route(EventInvoiceDetail, 'event_invoice_detail', '/event-invoices/<int:id>')
-api.route(EventInvoiceRelationship, 'event_invoice_user',
-          '/event-invoices/<int:id>/relationships/user')
-api.route(EventInvoiceRelationship, 'event_invoice_event',
-          '/event-invoices/<int:id>/relationships/event')
+api.route(EventInvoiceRelationship, 'event_invoice_user', '/event-invoices/<int:id>/relationships/user')
+api.route(EventInvoiceRelationship, 'event_invoice_event', '/event-invoices/<int:id>/relationships/event')
 api.route(EventInvoiceRelationship, 'event_invoice_discount_code',
           '/event-invoices/<int:id>/relationships/discount-codes')
 
@@ -181,8 +183,7 @@ api.route(EventInvoiceRelationship, 'event_invoice_discount_code',
 api.route(DiscountCodeList, 'discount_code_list', '/events/<int:event_id>/discount-codes',
           '/events/<event_identifier>/discount-codes')
 api.route(DiscountCodeDetail, 'discount_code_detail', '/discount-codes/<int:id>')
-api.route(DiscountCodeRelationship, 'discount_code_event',
-          '/discount-codes/<int:id>/relationships/event')
+api.route(DiscountCodeRelationship, 'discount_code_event', '/discount-codes/<int:id>/relationships/event')
 
 # attendees
 api.route(AttendeeList, 'attendee_list', '/attendees', '/orders/<int:order_id>/tickets/<int:ticket_id>/attendees')
@@ -193,3 +194,10 @@ api.route(AttendeeRelationship, 'attendee_ticket', '/attendees/<int:id>/relation
 api.route(EventTypeList, 'event_type_list', '/event-types')
 api.route(EventTypeDetail, 'event_type_detail', '/event-types/<int:id>', '/events/<int:event_id>/event-type')
 api.route(EventTypeRelationship, 'event_type_event', '/event-types/<int:id>/relationships/events')
+# speakers
+api.route(SpeakerList, 'speaker_list', '/events/<int:event_id>/speakers', '/events/<identifier>/speakers')
+api.route(SpeakerDetail, 'speaker_detail', '/speakers/<int:id>', '/sessions/<int:session_id>/speakers',
+          '/users/<int:user_id>/speakers')
+api.route(SpeakerRelationship, 'speaker_event', '/speakers/<int:id>/relationships/event')
+api.route(SpeakerRelationship, 'speaker_user', '/speakers/<int:id>/relationships/user')
+api.route(SpeakerRelationship, 'speaker_session', '/speakers/<int:id>/relationships/sessions')

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -196,8 +196,8 @@ api.route(EventTypeDetail, 'event_type_detail', '/event-types/<int:id>', '/event
 api.route(EventTypeRelationship, 'event_type_event', '/event-types/<int:id>/relationships/events')
 # speakers
 api.route(SpeakerList, 'speaker_list', '/events/<int:event_id>/speakers', '/events/<identifier>/speakers')
-api.route(SpeakerDetail, 'speaker_detail', '/speakers/<int:id>', '/sessions/<int:session_id>/speakers',
-          '/users/<int:user_id>/speakers')
+api.route(SpeakerDetail, 'speaker_detail', '/speakers/<int:id>', '/sessions/<int:session_id>/speaker',
+          '/users/<int:user_id>/speaker')
 api.route(SpeakerRelationship, 'speaker_event', '/speakers/<int:id>/relationships/event')
 api.route(SpeakerRelationship, 'speaker_user', '/speakers/<int:id>/relationships/user')
 api.route(SpeakerRelationship, 'speaker_session', '/speakers/<int:id>/relationships/sessions')

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -17,6 +17,7 @@ from app.models.event import Event
 from app.models.sponsor import Sponsor
 from app.models.track import Track
 from app.models.session import Session
+from app.models.speaker import Speaker
 from app.models.session_type import SessionType
 from app.models.discount_code import DiscountCode
 from app.models.event_invoice import EventInvoice
@@ -214,6 +215,14 @@ class EventSchema(Schema):
                               related_view_kwargs={'event_id': '<id>'},
                               schema='EventTypeSchema',
                               type_='event-type')
+    speakers = Relationship(attribute='speaker',
+                            self_view='v1.event_speaker',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.speaker_list',
+                            related_view_kwargs={'event_id': '<id>'},
+                            schema='SpeakerSchema',
+                            many=True,
+                            type_='speaker')
 
 
 class EventList(ResourceList):
@@ -325,15 +334,15 @@ class EventDetail(ResourceDetail):
                 else:
                     view_kwargs['id'] = None
 
-        if view_kwargs.get('user_id') is not None:
+        if view_kwargs.get('speaker_id'):
             try:
-                discount_code = self.session.query(DiscountCode).filter_by(id=view_kwargs['discount_code_id']).one()
+                speaker = self.session.query(Speaker).filter_by(id=view_kwargs['speaker_id']).one()
             except NoResultFound:
-                raise ObjectNotFound({'parameter': 'discount_code_id'},
-                                     "DiscountCode: {} not found".format(view_kwargs['discount_code_id']))
+                raise ObjectNotFound({'parameter': 'speaker_id'},
+                                     "Speaker: {} not found".format(view_kwargs['speaker_id']))
             else:
-                if discount_code.event_id is not None:
-                    view_kwargs['id'] = discount_code.event_id
+                if speaker.event_id:
+                    view_kwargs['id'] = speaker.event_id
                 else:
                     view_kwargs['id'] = None
 

--- a/app/api/microlocations.py
+++ b/app/api/microlocations.py
@@ -70,7 +70,6 @@ class MicrolocationList(ResourceList):
             event = self.session.query(Event).filter_by(identifier=view_kwargs['identifier']).one()
             data['event_id'] = event.id
 
-
     view_kwargs = True
     decorators = (jwt_required,)
     schema = MicrolocationSchema

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -13,6 +13,7 @@ from app.api.helpers.utilities import dasherize
 from app.api.helpers.permissions import jwt_required
 from app.models import db
 from app.models.session import Session
+from app.models.speaker import Speaker
 from app.models.track import Track
 from app.models.session_type import SessionType
 from app.models.microlocation import Microlocation
@@ -86,6 +87,13 @@ class SessionSchema(Schema):
                          related_view_kwargs={'session_id': '<id>'},
                          schema='EventSchema',
                          type_='event')
+    speaker = Relationship(attribute='speakers',
+                           self_view='v1.session_speaker',
+                           self_view_kwargs={'id': '<id>'},
+                           related_view='v1.speaker_detail',
+                           related_view_kwargs={'session_id': '<id>'},
+                           schema='SpeakerSchema',
+                           type_='speaker')
 
 
 class SessionList(ResourceList):
@@ -107,6 +115,9 @@ class SessionList(ResourceList):
             query_ = query_.join(Event).filter(Event.id == view_kwargs['event_id'])
         elif view_kwargs.get('event_identifier'):
             query_ = query_.join(Event).filter(Event.identifier == view_kwargs['event_identifier'])
+        if view_kwargs.get('speaker_id') is not None:
+            query_ = query_.join(Speaker).filter(
+                Speaker.id == view_kwargs['speaker_id'])
         return query_
 
     def before_create_object(self, data, view_kwargs):
@@ -118,6 +129,11 @@ class SessionList(ResourceList):
                                      "Event: {} not found".format(view_kwargs['event_id']))
             else:
                 data['event_id'] = event.id
+
+        if view_kwargs.get('speaker_id'):
+            speaker = self.session.query(Speaker).filter_by(
+                id=view_kwargs['speaker_id']).one()
+            data['speaker_id'] = speaker.id
 
     view_kwargs = True
     decorators = (api.has_permission('is_coorganizer', fetch="event_id",
@@ -136,7 +152,7 @@ class SessionDetail(ResourceDetail):
     """
     Session detail by id
     """
-    def before_get_object(self, view_kwargs):
+    def before_get_object(self, data, view_kwargs):
         if view_kwargs.get('event_identifier'):
             try:
                 event = self.session.query(Event).filter_by(identifier=view_kwargs['event_identifier']).one()
@@ -146,11 +162,15 @@ class SessionDetail(ResourceDetail):
             else:
                 view_kwargs['event_id'] = event.id
 
+        if view_kwargs.get('speaker_id'):
+            speaker = self.session.query(Speaker).filter_by(
+                id=view_kwargs['speaker_id']).one()
+            data['speaker_id'] = speaker.id
+
     decorators = (api.has_permission('is_coorganizer', fetch="event_id",
                                                        fetch_as="event_id",
                                                        model=Session,
-                                                       methods="PATCH,DELETE"),)
-    schema = SessionSchema
+                                                       methods="PATCH,DELETE"),)    schema = SessionSchema
     data_layer = {'session': db.session,
                   'model': Session,
                   'methods': {
@@ -160,6 +180,7 @@ class SessionRelationship(ResourceRelationship):
     """
     Session Relationship
     """
+    decorators = (jwt_required,)
     schema = SessionSchema
     data_layer = {'session': db.session,
                   'model': Session}

--- a/app/api/speakers.py
+++ b/app/api/speakers.py
@@ -1,0 +1,133 @@
+from flask_rest_jsonapi.exceptions import ObjectNotFound
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
+from sqlalchemy.orm.exc import NoResultFound
+
+from app.api.helpers.utilities import dasherize
+from app.api.helpers.permissions import jwt_required, is_coorganizer
+from app.models import db
+from app.models.speaker import Speaker
+from app.models.session import Session
+from app.models.user import User
+from app.models.event import Event
+
+
+class SpeakerSchema(Schema):
+    class Meta:
+        type_ = 'speaker'
+        self_view = 'v1.speaker_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    email = fields.Str(required=True)
+    photo_url = fields.Str()
+    thumbnail_image_url = fields.Str()
+    small_image_url = fields.Str()
+    icon_image_url = fields.Str()
+    short_biography = fields.Str()
+    long_biography = fields.Str()
+    speaking_experience = fields.Str()
+    mobile = fields.Str()
+    website = fields.Url()
+    twitter = fields.Url()
+    facebook = fields.Url()
+    github = fields.Url()
+    linkedin = fields.Url()
+    organisation = fields.Str()
+    is_featured = fields.Boolean(default=False)
+    position = fields.Str()
+    country = fields.Str()
+    city = fields.Str()
+    gender = fields.Str()
+    heard_from = fields.Str()
+    sponsorship_required = fields.Str()
+    event = Relationship(attribute='event',
+                         self_view='v1.speaker_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'speaker_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    user = Relationship(attribute='user',
+                        self_view='v1.speaker_user',
+                        self_view_kwargs={'id': '<id>'},
+                        related_view='v1.user_detail',
+                        related_view_kwargs={'speaker_id': '<id>'},
+                        schema='UserSchema',
+                        type_='user')
+    sessions = Relationship(attribute='sessions',
+                            self_view='v1.speaker_session',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.session_list',
+                            related_view_kwargs={'speaker_id': '<id>'},
+                            schema='SessionSchema',
+                            type_='session')
+
+
+class SpeakerList(ResourceList):
+    def query(self, view_kwargs):
+        query_ = self.session.query(Speaker)
+        if view_kwargs.get('event_id'):
+            query_ = query_.join(Event).filter(Event.id == view_kwargs['event_id'])
+        return query_
+
+    def before_create_object(self, data, view_kwargs):
+        if view_kwargs.get('event_id'):
+            event = self.session.query(Event).filter_by(id=view_kwargs['event_id']).one()
+            data['event_id'] = event.id
+        elif view_kwargs.get('identifier'):
+            event = self.session.query(Event).filter_by(identifier=view_kwargs['identifier']).one()
+            data['event_id'] = event.id
+
+    view_kwargs = True
+    decorators = (jwt_required,)
+    schema = SpeakerSchema
+    data_layer = {'session': db.session,
+                  'model': Speaker,
+                  'methods': {
+                      'query': query,
+                      'before_create_object': before_create_object
+                  }}
+
+
+class SpeakerDetail(ResourceDetail):
+    def before_get_object(self, view_kwargs):
+        if view_kwargs.get('session_id'):
+            try:
+                sessions = self.session.query(Session).filter_by(id=view_kwargs['session_id']).one()
+            except NoResultFound:
+                raise ObjectNotFound({'parameter': 'session_id'},
+                                     "Session: {} not found".format(view_kwargs['session_id']))
+            else:
+                if sessions.id:
+                    view_kwargs['id'] = sessions.id
+                else:
+                    view_kwargs['id'] = None
+
+        if view_kwargs.get('user_id'):
+            try:
+                user = self.session.query(User).filter_by(id=view_kwargs['user_id']).one()
+            except NoResultFound:
+                raise ObjectNotFound({'parameter': 'user_id'},
+                                     "User: {} not found".format(view_kwargs['user_id']))
+            else:
+                if user.id:
+                    view_kwargs['id'] = user.id
+                else:
+                    view_kwargs['id'] = None
+
+    decorators = (jwt_required,)
+    schema = SpeakerSchema
+    data_layer = {'session': db.session,
+                  'model': Speaker,
+                  'methods': {'before_get_object': before_get_object}}
+
+
+class SpeakerRelationship(ResourceRelationship):
+    decorators = (jwt_required,)
+    schema = SpeakerSchema
+    data_layer = {'session': db.session,
+                  'model': Speaker}

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -90,7 +90,6 @@ class UserDetail(ResourceDetail):
     """
     User detail by id
     """
-
     def before_get_object(self, view_kwargs):
         if view_kwargs.get('notification_id') is not None:
             try:
@@ -130,11 +129,12 @@ class UserDetail(ResourceDetail):
                 else:
                     view_kwargs['id'] = None
 
-    decorators = (is_user_itself,)
+    decorators = (api.has_permission('is_user_itself', methods="PATCH,DELETE", fetch="id", fetch_as="user_id"),)
     schema = UserSchema
     data_layer = {'session': db.session,
                   'model': User,
-                  'methods': {'before_get_object': before_get_object}}
+                  'methods': {'before_get_object': before_get_object
+                              }}
 
 
 class UserRelationship(ResourceRelationship):

--- a/app/models/speaker.py
+++ b/app/models/speaker.py
@@ -23,7 +23,7 @@ class Speaker(db.Model):
     github = db.Column(db.String)
     linkedin = db.Column(db.String)
     organisation = db.Column(db.String)
-    featured = db.Column(db.Boolean, default=False)
+    is_featured = db.Column(db.Boolean, default=False)
     position = db.Column(db.String)
     country = db.Column(db.String)
     city = db.Column(db.String)

--- a/app/models/speaker.py
+++ b/app/models/speaker.py
@@ -59,7 +59,7 @@ class Speaker(db.Model):
                  heard_from=None,
                  sponsorship_required=None,
                  event_id=None,
-                 user=None):
+                 user_id=None):
         self.name = name
         self.photo = photo
         self.thumbnail = thumbnail
@@ -86,7 +86,7 @@ class Speaker(db.Model):
         self.event_id = event_id
         # ensure links are in social fields
         self.ensure_social_links()
-        self.user = user
+        self.user_id = user_id
 
     @staticmethod
     def get_service_name():

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -4429,8 +4429,431 @@ Delete a single track.
           }
         }
 
+
 # Group Notifications
 Notifications related to the various users about invites, ticket purchase, session proposal etc.
+
+# Group Speakers
+Data related to the various tracks (e.g, python, AI, etc.) associated with the various sessions in the event.
+
+## Speakers Collection [/events/{event_id}/speakers, /events/{event_identifier}/speakers]
++ Parameters
+    + event_id (integer) - ID of the event in the form of an integer
+    + event_identifier (string) - ID of the event in the form of a string
+
+### List All Speakers [GET]
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
+            Authorization: JWT <Auth Key>
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "meta": {
+                "count": 2
+            },
+            "data": [
+                {
+                    "relationships": {
+                        "user": {
+                            "links": {
+                                "self": "/v1/speakers/3/relationships/user",
+                                "related": "/v1/speakers/3/user"
+                            }
+                        },
+                        "event": {
+                            "links": {
+                                "self": "/v1/speakers/3/relationships/event",
+                                "related": "/v1/speakers/3/event"
+                            }
+                        },
+                        "sessions": {
+                            "links": {
+                                "self": "/v1/speakers/3/relationships/session",
+                                "related": "/v1/speakers/3/sessions"
+                            }
+                        }
+                    },
+                    "attributes": {
+                        "website": "https://firstSpeaker.com",
+                        "city": "Delhi",
+                        "short-biography": "",
+                        "name": "firstSpeaker",
+                        "speaking-experience": "",
+                        "country": "India",
+                        "twitter": null,
+                        "is-featured": false,
+                        "linkedin": null,
+                        "email": "firstSpeaker@gmail.com",
+                        "long-biography": "",
+                        "mobile": null,
+                        "github": null,
+                        "facebook": null,
+                        "gender": "Male",
+                        "position": null,
+                        "organisation": null,
+                        "sponsorship-required": "",
+                        "heard-from": null
+                    },
+                    "type": "speaker",
+                    "id": "3",
+                    "links": {
+                        "self": "/v1/speakers/3"
+                    }
+                },
+                {
+                    "relationships": {
+                        "user": {
+                            "links": {
+                                "self": "/v1/speakers/1/relationships/user",
+                                "related": "/v1/speakers/1/user"
+                            }
+                        },
+                        "event": {
+                            "links": {
+                                "self": "/v1/speakers/1/relationships/event",
+                                "related": "/v1/speakers/1/event"
+                            }
+                        },
+                        "sessions": {
+                            "links": {
+                                "self": "/v1/speakers/1/relationships/session",
+                                "related": "/v1/speakers/1/sessions"
+                            }
+                        }
+                    },
+                    "attributes": {
+                        "website": "https://firstSpeaker-Patched.com",
+                        "city": "Delhi",
+                        "short-biography": "",
+                        "name": "firstSpeaker-Patched",
+                        "speaking-experience": "",
+                        "country": "India",
+                        "twitter": null,
+                        "is-featured": false,
+                        "linkedin": null,
+                        "email": "firstSpeaker_Patched@gmail.com",
+                        "long-biography": "",
+                        "mobile": null,
+                        "github": null,
+                        "facebook": null,
+                        "gender": "Male",
+                        "position": null,
+                        "organisation": null,
+                        "sponsorship-required": "",
+                        "heard-from": null
+                    },
+                    "type": "speaker",
+                    "id": "1",
+                    "links": {
+                        "self": "/v1/speakers/1"
+                    }
+                }
+            ],
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/events/1/speakers"
+            }
+        }
+
+### Create Speaker [POST]
+
++ name (string) - The name of the speaker **(required)**
++ email (string) - The email of the speaker **(required)**
++ photo_url (string) - URL of the photo of the speaker
++ thumbnail_image_url (string) - Thumbnail image's URL of the speaker
++ small_image_url (string) - Small image's URL of the speaker
++ icon_image_url (string) - Icon image's URL of the speaker
++ short_biography (string) - Short biography of the speaker
++ long_biography (string) - Long biography of the speaker
++ speaking_experience (string) - Speaking experience of the speaker
++ mobile (string) - Mobile number of the speaker
++ location (string) - Name of the location of track
++ website (url) - Personal website of the speaker
++ twitter (url) - Twitter profile link of the speaker
++ facebook (url) - Facebook profile link of the speaker
++ github (url) - Github profile link of the speaker
++ linkedin (url) -  Linkedin profile link of the speakers
++ organisation (string) - Name of the organisation which the speaker belongs to
++ is_featured (boolean) - To state whether a speaker is a featured speaker in an event, default: false
++ position (string) - The speaker's position in his/her organisation
++ country (string) - Country where the speaker lives
++ city (string) - City where the speaker lives
++ gender (string) - Gender of the speaker
++ heard_from (string) - How did the speaker get info about the event
++ sponsorship_required (string) - If any kind of sponsorship is required by the speaker
+
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Authorization: JWT <Auth Key>
+
+    + Body
+
+            {
+              "data": {
+              "type": "speaker",
+                "attributes": {
+                        "name":"firstSpeaker",
+                        "email":"firstSpeaker@gmail.com",
+                        "website":"https://firstSpeaker.com",
+                        "city":"Delhi",
+                        "gender":"Male",
+                        "country":"India"
+                    }
+                }
+            }
+
++ Response 201 (application/vnd.api+json)
+
+        {
+            "data": {
+                "relationships": {
+                    "user": {
+                        "links": {
+                            "self": "/v1/speakers/11/relationships/user",
+                            "related": "/v1/speakers/11/user"
+                        }
+                    },
+                    "event": {
+                        "links": {
+                            "self": "/v1/speakers/11/relationships/event",
+                            "related": "/v1/speakers/11/event"
+                        }
+                    },
+                    "sessions": {
+                        "links": {
+                            "self": "/v1/speakers/11/relationships/session",
+                            "related": "/v1/speakers/11/sessions"
+                        }
+                    }
+                },
+                "attributes": {
+                    "website": "https://firstSpeaker.com",
+                    "city": "Delhi",
+                    "short-biography": "",
+                    "name": "firstSpeaker",
+                    "speaking-experience": "",
+                    "country": "India",
+                    "twitter": null,
+                    "is-featured": false,
+                    "linkedin": null,
+                    "email": "firstSpeaker@gmail.com",
+                    "long-biography": "",
+                    "mobile": null,
+                    "github": null,
+                    "facebook": null,
+                    "gender": "Male",
+                    "position": null,
+                    "organisation": null,
+                    "sponsorship-required": "",
+                    "heard-from": null
+                },
+                "type": "speaker",
+                "id": "11",
+                "links": {
+                    "self": "/v1/speakers/11"
+                }
+            },
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/speakers/11"
+            }
+        }
+
+
+### Speaker Detail [/speakers/{speaker_id}]
++ Parameters
+    + speaker_id (integer) - ID of the Speaker in the form of an integer
+
+### Get Details [GET]
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
+            Authorization: JWT <Auth Key>
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "data": {
+                "relationships": {
+                    "user": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/user",
+                            "related": "/v1/speakers/1/user"
+                        }
+                    },
+                    "event": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/event",
+                            "related": "/v1/speakers/1/event"
+                        }
+                    },
+                    "sessions": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/session",
+                            "related": "/v1/speakers/1/sessions"
+                        }
+                    }
+                },
+                "attributes": {
+                    "website": "https://firstSpeaker.com",
+                    "city": "Delhi",
+                    "short-biography": "",
+                    "name": "firstSpeaker",
+                    "speaking-experience": "",
+                    "country": "India",
+                    "twitter": null,
+                    "is-featured": false,
+                    "linkedin": null,
+                    "email": "firstSpeaker@gmail.com",
+                    "long-biography": "",
+                    "mobile": null,
+                    "github": null,
+                    "facebook": null,
+                    "gender": "Male",
+                    "position": null,
+                    "organisation": null,
+                    "sponsorship-required": "",
+                    "heard-from": null
+                },
+                "type": "speaker",
+                "id": "1",
+                "links": {
+                    "self": "/v1/speakers/1"
+                }
+            },
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/speakers/1"
+            }
+        }
+
+
+### Update Speaker [PATCH]
+
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Authorization: JWT <Auth Key>
+
+    + Body
+
+
+            {
+              "data": {
+              "id":"1",
+              "type": "speaker",
+                "attributes": {
+                        "name":"firstSpeaker-Patched",
+                        "email":"firstSpeaker_Patched@gmail.com",
+                        "website":"https://firstSpeaker-Patched.com",
+                        "city":"Delhi",
+                        "gender":"Male",
+                        "country":"India"
+                    }
+                }
+            }
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "data": {
+                "relationships": {
+                    "user": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/user",
+                            "related": "/v1/speakers/1/user"
+                        }
+                    },
+                    "event": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/event",
+                            "related": "/v1/speakers/1/event"
+                        }
+                    },
+                    "sessions": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/session",
+                            "related": "/v1/speakers/1/sessions"
+                        }
+                    }
+                },
+                "attributes": {
+                    "website": "https://firstSpeaker-Patched.com",
+                    "city": "Delhi",
+                    "short-biography": "",
+                    "name": "firstSpeaker-Patched",
+                    "speaking-experience": "",
+                    "country": "India",
+                    "twitter": null,
+                    "is-featured": false,
+                    "linkedin": null,
+                    "email": "firstSpeaker_Patched@gmail.com",
+                    "long-biography": "",
+                    "mobile": null,
+                    "github": null,
+                    "facebook": null,
+                    "gender": "Male",
+                    "position": null,
+                    "organisation": null,
+                    "sponsorship-required": "",
+                    "heard-from": null
+                },
+                "type": "speaker",
+                "id": "1",
+                "links": {
+                    "self": "/v1/speakers/1"
+                }
+            },
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/speakers/1"
+            }
+        }
+
+### Delete Speaker [DELETE]
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
+            Authorization: JWT <Auth Key>
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "meta": {
+                "message": "Object successfully deleted"
+            },
+            "jsonapi": {
+                "version": "1.0"
+            }
+        }
+
+# Group Image Size
+
+**ADMIN**
 
 | Parameter | Description | Type | Required |
 |:----------|-------------|------|----------|

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -3343,6 +3343,426 @@ Delete a single speakers call.
           }
         }
 
+# Group Speakers
+Data related to the various speakers associated with the various sessions in the event.
+
+## Speakers Collection [/events/{event_id}/speakers, /events/{event_identifier}/speakers]
++ Parameters
+    + event_id (integer) - ID of the event in the form of an integer
+    + event_identifier (string) - ID of the event in the form of a string
+
+### List All Speakers [GET]
+Get a list of all speakers.
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
+            Authorization: JWT <Auth Key>
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "meta": {
+                "count": 2
+            },
+            "data": [
+                {
+                    "relationships": {
+                        "user": {
+                            "links": {
+                                "self": "/v1/speakers/3/relationships/user",
+                                "related": "/v1/speakers/3/user"
+                            }
+                        },
+                        "event": {
+                            "links": {
+                                "self": "/v1/speakers/3/relationships/event",
+                                "related": "/v1/speakers/3/event"
+                            }
+                        },
+                        "sessions": {
+                            "links": {
+                                "self": "/v1/speakers/3/relationships/session",
+                                "related": "/v1/speakers/3/sessions"
+                            }
+                        }
+                    },
+                    "attributes": {
+                        "website": "https://firstSpeaker.com",
+                        "city": "Delhi",
+                        "short-biography": "",
+                        "name": "firstSpeaker",
+                        "speaking-experience": "",
+                        "country": "India",
+                        "twitter": null,
+                        "is-featured": false,
+                        "linkedin": null,
+                        "email": "firstSpeaker@gmail.com",
+                        "long-biography": "",
+                        "mobile": null,
+                        "github": null,
+                        "facebook": null,
+                        "gender": "Male",
+                        "position": null,
+                        "organisation": null,
+                        "sponsorship-required": "",
+                        "heard-from": null
+                    },
+                    "type": "speaker",
+                    "id": "3",
+                    "links": {
+                        "self": "/v1/speakers/3"
+                    }
+                },
+                {
+                    "relationships": {
+                        "user": {
+                            "links": {
+                                "self": "/v1/speakers/1/relationships/user",
+                                "related": "/v1/speakers/1/user"
+                            }
+                        },
+                        "event": {
+                            "links": {
+                                "self": "/v1/speakers/1/relationships/event",
+                                "related": "/v1/speakers/1/event"
+                            }
+                        },
+                        "sessions": {
+                            "links": {
+                                "self": "/v1/speakers/1/relationships/session",
+                                "related": "/v1/speakers/1/sessions"
+                            }
+                        }
+                    },
+                    "attributes": {
+                        "website": "https://firstSpeaker-Patched.com",
+                        "city": "Delhi",
+                        "short-biography": "",
+                        "name": "firstSpeaker-Patched",
+                        "speaking-experience": "",
+                        "country": "India",
+                        "twitter": null,
+                        "is-featured": false,
+                        "linkedin": null,
+                        "email": "firstSpeaker_Patched@gmail.com",
+                        "long-biography": "",
+                        "mobile": null,
+                        "github": null,
+                        "facebook": null,
+                        "gender": "Male",
+                        "position": null,
+                        "organisation": null,
+                        "sponsorship-required": "",
+                        "heard-from": null
+                    },
+                    "type": "speaker",
+                    "id": "1",
+                    "links": {
+                        "self": "/v1/speakers/1"
+                    }
+                }
+            ],
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/events/1/speakers"
+            }
+        }
+
+### Create Speaker [POST]
+
+| Parameter | Description | Type | Required |
+|:----------|-------------|------|----------|
+| `name` | The name of the speaker | string | **yes** |
+| `email` | The email of the speaker | string | **yes** |
+| `photo-url` | URL of the photo of the speaker | string | - |
+| `thumbnail-image-url` | Thumbnail image's URL of the speaker | string | - |
+| `small-image-url` | Small image's URL of the speaker | string | - |
+| `icon-image-url` | Icon image's URL of the speaker | string | - |
+| `short-biography` | Short biography of the speaker | string | - |
+| `long-biography` | Long biography of the speaker | string | - |
+| `speaking-experience` | Speaking experience of the speaker | string | - |
+| `mobile` | Mobile number of the speaker | string | - |
+| `location` | Name of the location of track | string | - |
+| `website` | Personal website of the speaker | string | - |
+| `twitter` | Twitter profile link of the speaker | string | - |
+| `facebook` | Facebook profile link of the speaker | string | - |
+| `github` | Github profile link of the speaker | string | - |
+| `linkedin` |  Linkedin profile link of the speakers | string | - |
+| `organisation` | Name of the organisation which the speaker belongs to | string | - |
+| `is-featured` | To state whether a speaker is a featured speaker in an event | boolean (default: `false`) | - |
+| `position` | The speaker's position in his/her organisation | string | - |
+| `country` | Country where the speaker lives | string | - |
+| `city` | City where the speaker lives | string | - |
+| `gender` | Gender of the speaker | string | - |
+| `heard-from` | How did the speaker get info about the event | string | - |
+| `sponsorship-required` | If any kind of sponsorship is required by the speaker | string | - |
+
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Authorization: JWT <Auth Key>
+
+    + Body
+
+            {
+              "data": {
+              "type": "speaker",
+                "attributes": {
+                        "name":"firstSpeaker",
+                        "email":"firstSpeaker@gmail.com",
+                        "website":"https://firstSpeaker.com",
+                        "city":"Delhi",
+                        "gender":"Male",
+                        "country":"India"
+                    }
+                }
+            }
+
++ Response 201 (application/vnd.api+json)
+
+        {
+            "data": {
+                "relationships": {
+                    "user": {
+                        "links": {
+                            "self": "/v1/speakers/11/relationships/user",
+                            "related": "/v1/speakers/11/user"
+                        }
+                    },
+                    "event": {
+                        "links": {
+                            "self": "/v1/speakers/11/relationships/event",
+                            "related": "/v1/speakers/11/event"
+                        }
+                    },
+                    "sessions": {
+                        "links": {
+                            "self": "/v1/speakers/11/relationships/session",
+                            "related": "/v1/speakers/11/sessions"
+                        }
+                    }
+                },
+                "attributes": {
+                    "website": "https://firstSpeaker.com",
+                    "city": "Delhi",
+                    "short-biography": "",
+                    "name": "firstSpeaker",
+                    "speaking-experience": "",
+                    "country": "India",
+                    "twitter": null,
+                    "is-featured": false,
+                    "linkedin": null,
+                    "email": "firstSpeaker@gmail.com",
+                    "long-biography": "",
+                    "mobile": null,
+                    "github": null,
+                    "facebook": null,
+                    "gender": "Male",
+                    "position": null,
+                    "organisation": null,
+                    "sponsorship-required": "",
+                    "heard-from": null
+                },
+                "type": "speaker",
+                "id": "11",
+                "links": {
+                    "self": "/v1/speakers/11"
+                }
+            },
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/speakers/11"
+            }
+        }
+
+
+### Speaker Detail [/speakers/{speaker_id}]
++ Parameters
+    + speaker_id (integer) - ID of the Speaker in the form of an integer
+
+### Get Details [GET]
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
+            Authorization: JWT <Auth Key>
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "data": {
+                "relationships": {
+                    "user": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/user",
+                            "related": "/v1/speakers/1/user"
+                        }
+                    },
+                    "event": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/event",
+                            "related": "/v1/speakers/1/event"
+                        }
+                    },
+                    "sessions": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/session",
+                            "related": "/v1/speakers/1/sessions"
+                        }
+                    }
+                },
+                "attributes": {
+                    "website": "https://firstSpeaker.com",
+                    "city": "Delhi",
+                    "short-biography": "",
+                    "name": "firstSpeaker",
+                    "speaking-experience": "",
+                    "country": "India",
+                    "twitter": null,
+                    "is-featured": false,
+                    "linkedin": null,
+                    "email": "firstSpeaker@gmail.com",
+                    "long-biography": "",
+                    "mobile": null,
+                    "github": null,
+                    "facebook": null,
+                    "gender": "Male",
+                    "position": null,
+                    "organisation": null,
+                    "sponsorship-required": "",
+                    "heard-from": null
+                },
+                "type": "speaker",
+                "id": "1",
+                "links": {
+                    "self": "/v1/speakers/1"
+                }
+            },
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/speakers/1"
+            }
+        }
+
+
+### Update Speaker [PATCH]
+
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Authorization: JWT <Auth Key>
+
+    + Body
+
+            {
+              "data": {
+              "id":"1",
+              "type": "speaker",
+                "attributes": {
+                        "name":"firstSpeaker-Patched",
+                        "email":"firstSpeaker_Patched@gmail.com",
+                        "website":"https://firstSpeaker-Patched.com",
+                        "city":"Delhi",
+                        "gender":"Male",
+                        "country":"India"
+                    }
+                }
+            }
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "data": {
+                "relationships": {
+                    "user": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/user",
+                            "related": "/v1/speakers/1/user"
+                        }
+                    },
+                    "event": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/event",
+                            "related": "/v1/speakers/1/event"
+                        }
+                    },
+                    "sessions": {
+                        "links": {
+                            "self": "/v1/speakers/1/relationships/session",
+                            "related": "/v1/speakers/1/sessions"
+                        }
+                    }
+                },
+                "attributes": {
+                    "website": "https://firstSpeaker-Patched.com",
+                    "city": "Delhi",
+                    "short-biography": "",
+                    "name": "firstSpeaker-Patched",
+                    "speaking-experience": "",
+                    "country": "India",
+                    "twitter": null,
+                    "is-featured": false,
+                    "linkedin": null,
+                    "email": "firstSpeaker_Patched@gmail.com",
+                    "long-biography": "",
+                    "mobile": null,
+                    "github": null,
+                    "facebook": null,
+                    "gender": "Male",
+                    "position": null,
+                    "organisation": null,
+                    "sponsorship-required": "",
+                    "heard-from": null
+                },
+                "type": "speaker",
+                "id": "1",
+                "links": {
+                    "self": "/v1/speakers/1"
+                }
+            },
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/speakers/1"
+            }
+        }
+
+### Delete Speaker [DELETE]
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
+            Authorization: JWT <Auth Key>
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "meta": {
+                "message": "Object successfully deleted"
+            },
+            "jsonapi": {
+                "version": "1.0"
+            }
+        }
+
 # Group Sponsors
 Data related to the various sponsors with their level, url and images associated with a specific event.
 
@@ -4429,431 +4849,8 @@ Delete a single track.
           }
         }
 
-
 # Group Notifications
 Notifications related to the various users about invites, ticket purchase, session proposal etc.
-
-# Group Speakers
-Data related to the various tracks (e.g, python, AI, etc.) associated with the various sessions in the event.
-
-## Speakers Collection [/events/{event_id}/speakers, /events/{event_identifier}/speakers]
-+ Parameters
-    + event_id (integer) - ID of the event in the form of an integer
-    + event_identifier (string) - ID of the event in the form of a string
-
-### List All Speakers [GET]
-
-+ Request
-
-    + Headers
-
-            Accept: application/vnd.api+json
-
-            Authorization: JWT <Auth Key>
-
-+ Response 200 (application/vnd.api+json)
-
-        {
-            "meta": {
-                "count": 2
-            },
-            "data": [
-                {
-                    "relationships": {
-                        "user": {
-                            "links": {
-                                "self": "/v1/speakers/3/relationships/user",
-                                "related": "/v1/speakers/3/user"
-                            }
-                        },
-                        "event": {
-                            "links": {
-                                "self": "/v1/speakers/3/relationships/event",
-                                "related": "/v1/speakers/3/event"
-                            }
-                        },
-                        "sessions": {
-                            "links": {
-                                "self": "/v1/speakers/3/relationships/session",
-                                "related": "/v1/speakers/3/sessions"
-                            }
-                        }
-                    },
-                    "attributes": {
-                        "website": "https://firstSpeaker.com",
-                        "city": "Delhi",
-                        "short-biography": "",
-                        "name": "firstSpeaker",
-                        "speaking-experience": "",
-                        "country": "India",
-                        "twitter": null,
-                        "is-featured": false,
-                        "linkedin": null,
-                        "email": "firstSpeaker@gmail.com",
-                        "long-biography": "",
-                        "mobile": null,
-                        "github": null,
-                        "facebook": null,
-                        "gender": "Male",
-                        "position": null,
-                        "organisation": null,
-                        "sponsorship-required": "",
-                        "heard-from": null
-                    },
-                    "type": "speaker",
-                    "id": "3",
-                    "links": {
-                        "self": "/v1/speakers/3"
-                    }
-                },
-                {
-                    "relationships": {
-                        "user": {
-                            "links": {
-                                "self": "/v1/speakers/1/relationships/user",
-                                "related": "/v1/speakers/1/user"
-                            }
-                        },
-                        "event": {
-                            "links": {
-                                "self": "/v1/speakers/1/relationships/event",
-                                "related": "/v1/speakers/1/event"
-                            }
-                        },
-                        "sessions": {
-                            "links": {
-                                "self": "/v1/speakers/1/relationships/session",
-                                "related": "/v1/speakers/1/sessions"
-                            }
-                        }
-                    },
-                    "attributes": {
-                        "website": "https://firstSpeaker-Patched.com",
-                        "city": "Delhi",
-                        "short-biography": "",
-                        "name": "firstSpeaker-Patched",
-                        "speaking-experience": "",
-                        "country": "India",
-                        "twitter": null,
-                        "is-featured": false,
-                        "linkedin": null,
-                        "email": "firstSpeaker_Patched@gmail.com",
-                        "long-biography": "",
-                        "mobile": null,
-                        "github": null,
-                        "facebook": null,
-                        "gender": "Male",
-                        "position": null,
-                        "organisation": null,
-                        "sponsorship-required": "",
-                        "heard-from": null
-                    },
-                    "type": "speaker",
-                    "id": "1",
-                    "links": {
-                        "self": "/v1/speakers/1"
-                    }
-                }
-            ],
-            "jsonapi": {
-                "version": "1.0"
-            },
-            "links": {
-                "self": "/v1/events/1/speakers"
-            }
-        }
-
-### Create Speaker [POST]
-
-+ name (string) - The name of the speaker **(required)**
-+ email (string) - The email of the speaker **(required)**
-+ photo_url (string) - URL of the photo of the speaker
-+ thumbnail_image_url (string) - Thumbnail image's URL of the speaker
-+ small_image_url (string) - Small image's URL of the speaker
-+ icon_image_url (string) - Icon image's URL of the speaker
-+ short_biography (string) - Short biography of the speaker
-+ long_biography (string) - Long biography of the speaker
-+ speaking_experience (string) - Speaking experience of the speaker
-+ mobile (string) - Mobile number of the speaker
-+ location (string) - Name of the location of track
-+ website (url) - Personal website of the speaker
-+ twitter (url) - Twitter profile link of the speaker
-+ facebook (url) - Facebook profile link of the speaker
-+ github (url) - Github profile link of the speaker
-+ linkedin (url) -  Linkedin profile link of the speakers
-+ organisation (string) - Name of the organisation which the speaker belongs to
-+ is_featured (boolean) - To state whether a speaker is a featured speaker in an event, default: false
-+ position (string) - The speaker's position in his/her organisation
-+ country (string) - Country where the speaker lives
-+ city (string) - City where the speaker lives
-+ gender (string) - Gender of the speaker
-+ heard_from (string) - How did the speaker get info about the event
-+ sponsorship_required (string) - If any kind of sponsorship is required by the speaker
-
-+ Request (application/vnd.api+json)
-
-    + Headers
-
-            Authorization: JWT <Auth Key>
-
-    + Body
-
-            {
-              "data": {
-              "type": "speaker",
-                "attributes": {
-                        "name":"firstSpeaker",
-                        "email":"firstSpeaker@gmail.com",
-                        "website":"https://firstSpeaker.com",
-                        "city":"Delhi",
-                        "gender":"Male",
-                        "country":"India"
-                    }
-                }
-            }
-
-+ Response 201 (application/vnd.api+json)
-
-        {
-            "data": {
-                "relationships": {
-                    "user": {
-                        "links": {
-                            "self": "/v1/speakers/11/relationships/user",
-                            "related": "/v1/speakers/11/user"
-                        }
-                    },
-                    "event": {
-                        "links": {
-                            "self": "/v1/speakers/11/relationships/event",
-                            "related": "/v1/speakers/11/event"
-                        }
-                    },
-                    "sessions": {
-                        "links": {
-                            "self": "/v1/speakers/11/relationships/session",
-                            "related": "/v1/speakers/11/sessions"
-                        }
-                    }
-                },
-                "attributes": {
-                    "website": "https://firstSpeaker.com",
-                    "city": "Delhi",
-                    "short-biography": "",
-                    "name": "firstSpeaker",
-                    "speaking-experience": "",
-                    "country": "India",
-                    "twitter": null,
-                    "is-featured": false,
-                    "linkedin": null,
-                    "email": "firstSpeaker@gmail.com",
-                    "long-biography": "",
-                    "mobile": null,
-                    "github": null,
-                    "facebook": null,
-                    "gender": "Male",
-                    "position": null,
-                    "organisation": null,
-                    "sponsorship-required": "",
-                    "heard-from": null
-                },
-                "type": "speaker",
-                "id": "11",
-                "links": {
-                    "self": "/v1/speakers/11"
-                }
-            },
-            "jsonapi": {
-                "version": "1.0"
-            },
-            "links": {
-                "self": "/v1/speakers/11"
-            }
-        }
-
-
-### Speaker Detail [/speakers/{speaker_id}]
-+ Parameters
-    + speaker_id (integer) - ID of the Speaker in the form of an integer
-
-### Get Details [GET]
-+ Request
-
-    + Headers
-
-            Accept: application/vnd.api+json
-
-            Authorization: JWT <Auth Key>
-
-+ Response 200 (application/vnd.api+json)
-
-        {
-            "data": {
-                "relationships": {
-                    "user": {
-                        "links": {
-                            "self": "/v1/speakers/1/relationships/user",
-                            "related": "/v1/speakers/1/user"
-                        }
-                    },
-                    "event": {
-                        "links": {
-                            "self": "/v1/speakers/1/relationships/event",
-                            "related": "/v1/speakers/1/event"
-                        }
-                    },
-                    "sessions": {
-                        "links": {
-                            "self": "/v1/speakers/1/relationships/session",
-                            "related": "/v1/speakers/1/sessions"
-                        }
-                    }
-                },
-                "attributes": {
-                    "website": "https://firstSpeaker.com",
-                    "city": "Delhi",
-                    "short-biography": "",
-                    "name": "firstSpeaker",
-                    "speaking-experience": "",
-                    "country": "India",
-                    "twitter": null,
-                    "is-featured": false,
-                    "linkedin": null,
-                    "email": "firstSpeaker@gmail.com",
-                    "long-biography": "",
-                    "mobile": null,
-                    "github": null,
-                    "facebook": null,
-                    "gender": "Male",
-                    "position": null,
-                    "organisation": null,
-                    "sponsorship-required": "",
-                    "heard-from": null
-                },
-                "type": "speaker",
-                "id": "1",
-                "links": {
-                    "self": "/v1/speakers/1"
-                }
-            },
-            "jsonapi": {
-                "version": "1.0"
-            },
-            "links": {
-                "self": "/v1/speakers/1"
-            }
-        }
-
-
-### Update Speaker [PATCH]
-
-+ Request (application/vnd.api+json)
-
-    + Headers
-
-            Authorization: JWT <Auth Key>
-
-    + Body
-
-
-            {
-              "data": {
-              "id":"1",
-              "type": "speaker",
-                "attributes": {
-                        "name":"firstSpeaker-Patched",
-                        "email":"firstSpeaker_Patched@gmail.com",
-                        "website":"https://firstSpeaker-Patched.com",
-                        "city":"Delhi",
-                        "gender":"Male",
-                        "country":"India"
-                    }
-                }
-            }
-
-+ Response 200 (application/vnd.api+json)
-
-        {
-            "data": {
-                "relationships": {
-                    "user": {
-                        "links": {
-                            "self": "/v1/speakers/1/relationships/user",
-                            "related": "/v1/speakers/1/user"
-                        }
-                    },
-                    "event": {
-                        "links": {
-                            "self": "/v1/speakers/1/relationships/event",
-                            "related": "/v1/speakers/1/event"
-                        }
-                    },
-                    "sessions": {
-                        "links": {
-                            "self": "/v1/speakers/1/relationships/session",
-                            "related": "/v1/speakers/1/sessions"
-                        }
-                    }
-                },
-                "attributes": {
-                    "website": "https://firstSpeaker-Patched.com",
-                    "city": "Delhi",
-                    "short-biography": "",
-                    "name": "firstSpeaker-Patched",
-                    "speaking-experience": "",
-                    "country": "India",
-                    "twitter": null,
-                    "is-featured": false,
-                    "linkedin": null,
-                    "email": "firstSpeaker_Patched@gmail.com",
-                    "long-biography": "",
-                    "mobile": null,
-                    "github": null,
-                    "facebook": null,
-                    "gender": "Male",
-                    "position": null,
-                    "organisation": null,
-                    "sponsorship-required": "",
-                    "heard-from": null
-                },
-                "type": "speaker",
-                "id": "1",
-                "links": {
-                    "self": "/v1/speakers/1"
-                }
-            },
-            "jsonapi": {
-                "version": "1.0"
-            },
-            "links": {
-                "self": "/v1/speakers/1"
-            }
-        }
-
-### Delete Speaker [DELETE]
-
-+ Request
-
-    + Headers
-
-            Accept: application/vnd.api+json
-
-            Authorization: JWT <Auth Key>
-
-+ Response 200 (application/vnd.api+json)
-
-        {
-            "meta": {
-                "message": "Object successfully deleted"
-            },
-            "jsonapi": {
-                "version": "1.0"
-            }
-        }
-
-# Group Image Size
-
-**ADMIN**
 
 | Parameter | Description | Type | Required |
 |:----------|-------------|------|----------|


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Added basic speakers API 

#### Changes proposed in this pull request:

- Speakers list `/speakers` , event's speaker `/events/<int:event_id>/speakers`
- Speaker details `/speakers/<int:id>`
- SpeakerRelationship `/speakers/<int:id>/relationships/event'`

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3727 

However I am unable to fetch users' relationship `speakers/1/user` cause the permission is `is_user_itself` and the speakers' details fetching user may not be the same user.

So this won't work :
```
        if view_kwargs.get('speaker_id'):
            try:
                speaker = self.session.query(Speaker).filter_by(id=view_kwargs['speaker_id']).one()
            except NoResultFound:
                raise ObjectNotFound({'parameter': 'speaker_id'},
                                     "Speaker: {} not found".format(view_kwargs['speaker_id']))
            else:
                if speaker.user_id is not None:
                    view_kwargs['id'] = speaker.user_id
                else:
                    view_kwargs['id'] = None
```
