### PR TITLE
Fix accessible_events decorator, injecting user_id on all POST requests

### DIFF
--- a/app/api/helpers/permissions.py
+++ b/app/api/helpers/permissions.py
@@ -2,6 +2,7 @@ from functools import wraps
 from flask import current_app as app
 from flask_jwt import _jwt_required, current_identity
 from app.api.helpers.errors import ForbiddenError
+from flask import request
 
 
 def second_order_decorator(inner_dec):
@@ -210,8 +211,11 @@ def accessible_events(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
         user = current_identity
-        if not user.is_staff:
+        if 'POST' in request.method:
             kwargs['user_id'] = user.id
+        else:
+            if not user.is_staff:
+                kwargs['user_id'] = user.id
 
         return f(*args, **kwargs)
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
There was one issue. It was not providing ```user_id``` on POST request if user is staff ( but required to add event role ) 

Please review this fix, this is a priority one.

Related Issue #3773 ( not the fix of it )