### PR TITLE
Enables same endpoints for speakers-call list and detail

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -137,8 +137,8 @@ api.route(TrackRelationship, 'track_sessions', '/tracks/<int:id>/relationships/s
 api.route(TrackRelationship, 'track_event', '/tracks/<int:id>/relationships/event')
 
 # speakers_calls
-api.route(SpeakersCallList, 'speakers_call_list', '/events/<int:event_id>/speakers-calls',
-          '/events/<event_identifier>/speakers-calls')
+api.route(SpeakersCallList, 'speakers_call_list', '/events/<int:event_id>/speakers-call',
+          '/events/<event_identifier>/speakers-call')
 api.route(SpeakersCallDetail, 'speakers_call_detail', '/speakers-calls/<int:id>',
           '/events/<int:event_id>/speakers-call', '/events/<event_identifier>/speakers-call')
 api.route(SpeakersCallRelationship, 'speakers_call_event',

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -3096,7 +3096,8 @@ Announcement for call for speaker to accept session proposals from speakers.
 | `hash` | Hash for speakers call | string | - |
 | `privacy` | Privacy of speakers call | string | - |
 
-## Create Speakers Call for an Event [/v1/events/{event_identifier}/speakers-calls{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]
+
+## Speakers Call Collection [/v1/events/{event_identifier}/speakers-calls{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]
 + Parameters
     + event_identifier: b8324ae2 (string) - identifier of the event. (Can also be the event ID)
     + page%5bsize%5d (optional, integer, `10`) - Maximum number of resources in a single paginated response.
@@ -3104,17 +3105,53 @@ Announcement for call for speaker to accept session proposals from speakers.
     + sort (optional, string, `starts-at`) - Sort the resources according to the given attribute in ascending order. Append '-' to sort in descending order.
     + filter (optional, string, `[{"announcement":"string"}]`) - Filter according to the flask-rest-jsonapi filtering system. Please refer: http://flask-rest-jsonapi.readthedocs.io/en/latest/filtering.html for more.
 
+### Get Speakers Call [GET]
+Get Speakers Call for an event.
+
++ Request
+
+    + Headers
+
+
+            Accept: application/vnd.api+json
+
+            Authorization: JWT <Auth Key>
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "data": {
+                "relationships": {
+                    "event": {
+                        "links": {
+                            "self": "/v1/speakers-calls/1/relationships/event",
+                            "related": "/v1/speakers-calls/1/event"
+                        }
+                    }
+                },
+                "attributes": {
+                    "announcement": "Speaker Call Announcement",
+                    "ends-at": "2017-06-20T01:24:47.500127+00:00",
+                    "hash": "sfasd",
+                    "starts-at": "2017-06-01T01:24:47.500127+00:00",
+                    "privacy": "public"
+                },
+                "type": "speakers-call",
+                "id": "10",
+                "links": {
+                    "self": "/v1/speakers-calls/1"
+                }
+            },
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/speakers-calls/1"
+            }
+        }
 
 ### Create Speakers Call [POST]
 Create a new speakers call using an event_id.
-
-| Parameter | Description | Type | Required |
-|:----------|-------------|------|----------|
-| `announcement`  | Announcement for speakers call | string | **yes** |
-| `starts-at` | Start date of the speakers call | ISO 8601 (tz-aware) | **yes** |
-| `ends-at` | End date of the speakers call | ISO 8601 (tz-aware) | **yes** |
-| `hash` | Hash for speakers call | string | - |
-| `privacy` | Privacy of speakers call | string | - |
 
 + Request (application/vnd.api+json)
 
@@ -3170,59 +3207,6 @@ Create a new speakers call using an event_id.
             "self": "/v1/speaker-calls/1"
           }
         }
-
-## Get Speakers Call for an Event [/v1/events/{event_id}/speakers-call{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]
-+ Parameters
-    + event_id: 1 (integer) - ID of the specific event in integer
-    + page%5bsize%5d (optional, integer, `10`) - Maximum number of resources in a single paginated response.
-    + page%5bnumber%5d (optional, integer, `2`) - Page number to fetched for the paginated response.
-    + sort (optional, string, `level`) - Sort the resources according to the given attribute in ascending order. Append '-' to sort in descending order.
-    + filter (optional, string, `[{"description":"string"}]`) - Filter according to the flask-rest-jsonapi filtering system. Please refer: http://flask-rest-jsonapi.readthedocs.io/en/latest/filtering.html for more.
-### Get Speakers Call [GET]
-
-+ Request
-
-    + Headers
-
-
-            Accept: application/vnd.api+json
-
-            Authorization: JWT <Auth Key>
-
-+ Response 200 (application/vnd.api+json)
-
-        {
-            "data": {
-                "relationships": {
-                    "event": {
-                        "links": {
-                            "self": "/v1/speakers-calls/1/relationships/event",
-                            "related": "/v1/speakers-calls/1/event"
-                        }
-                    }
-                },
-                "attributes": {
-                    "announcement": "Speaker Call Announcement",
-                    "ends-at": "2017-06-20T01:24:47.500127+00:00",
-                    "hash": "sfasd",
-                    "starts-at": "2017-06-01T01:24:47.500127+00:00",
-                    "privacy": "public"
-                },
-                "type": "speakers-call",
-                "id": "10",
-                "links": {
-                    "self": "/v1/speakers-calls/1"
-                }
-            },
-            "jsonapi": {
-                "version": "1.0"
-            },
-            "links": {
-                "self": "/v1/speakers-calls/1"
-            }
-        }
-
-
 
 ## Speakers Call Details [/v1/speakers-calls/{speakers_call_id}]
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `nextgen` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- Speakers Call had two different endpoints `speakers-calls` for List POST and `speaker-call` for Detail GET. This fix makes both classes use same endpoint
- Changed `id` and `identifier` to `event_id` and `event_identifier`.
- Updated `speakers-call` documentation: replaces two different endpoints for Speakers Call collection by one.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #3808.
Fixes #3712 . 
