### PR TITLE
Set max line length to 120 in hound

### DIFF
--- a/.flake8.ini
+++ b/.flake8.ini
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
79 is way too strict.