### PR TITLE
initialize sentry for nextgen

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,7 @@ from flask_login import current_user
 from flask_jwt import JWT
 from datetime import timedelta
 from flask_cors import CORS
+from raven.contrib.flask import Sentry
 
 import sqlalchemy as sa
 
@@ -134,6 +135,11 @@ def create_app():
         app.add_url_rule('/static/<path:filename>',
                          endpoint='static',
                          view_func=app.send_static_file)
+
+    # sentry
+    if app.config['SENTRY_DSN']:
+        sentry = Sentry(dsn=app.config['SENTRY_DSN'])
+        sentry.init_app(app)
 
     return app, _manager, db, _jwt
 

--- a/config.py
+++ b/config.py
@@ -58,6 +58,7 @@ class Config(object):
     PROPOGATE_ERROR = env.bool('PROPOGATE_ERROR', default=False)
     DASHERIZE_API = True
     ETAG = True
+    SENTRY_DSN = env('SENTRY_DSN', default=None)
 
     if not SQLALCHEMY_DATABASE_URI:
         print('`DATABASE_URL` either not exported or empty')

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -48,3 +48,4 @@ wtforms
 flask-admin
 google-compute-engine
 factory_boy
+raven[flask]


### PR DESCRIPTION
No issue required.
As suggested by @niranjan94 , The dsn is fetched from the env itself, So even errors during migration or setup get logged and is not dependant on the database being available