### PR TITLE
Fix bug: sentry cannot catch internal server errors

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,7 +17,7 @@ import os.path
 from os import environ
 from envparse import env
 import sys
-from flask import Flask
+from flask import Flask, json, make_response
 from app.settings import get_settings, get_setts
 from flask_migrate import Migrate, MigrateCommand
 from flask_script import Manager
@@ -26,6 +26,8 @@ from flask_jwt import JWT
 from datetime import timedelta
 from flask_cors import CORS
 from raven.contrib.flask import Sentry
+from flask_rest_jsonapi.errors import jsonapi_errors
+from flask_rest_jsonapi.exceptions import JsonApiException
 
 import sqlalchemy as sa
 
@@ -201,6 +203,17 @@ scheduler.add_job(send_after_event_mail, 'cron', hour=5, minute=30)
 scheduler.add_job(send_event_fee_notification, 'cron', day=1)
 scheduler.add_job(send_event_fee_notification_followup, 'cron', day=15)
 scheduler.start()
+
+
+@app.errorhandler(500)
+def internal_server_error(error):
+    if current_app.config['PROPOGATE_ERROR'] is True:
+        exc = JsonApiException({'pointer': ''}, str(error))
+    else:
+        exc = JsonApiException({'pointer': ''}, 'Unknown error')
+    return make_response(json.dumps(jsonapi_errors([exc.to_dict()])), exc.status,
+                         {'Content-Type': 'application/vnd.api+json'})
+
 
 if __name__ == '__main__':
     current_app.run()

--- a/config.py
+++ b/config.py
@@ -54,11 +54,14 @@ class Config(object):
     SQLALCHEMY_DATABASE_URI = env('DATABASE_URL', default=None)
     SERVE_STATIC = env.bool('SERVE_STATIC', default=False)
     DATABASE_QUERY_TIMEOUT = 0.1
+    SENTRY_DSN = env('SENTRY_DSN', default=None)
+
+    # API configs
     SOFT_DELETE = True
     PROPOGATE_ERROR = env.bool('PROPOGATE_ERROR', default=False)
     DASHERIZE_API = True
+    API_PROPOGATE_UNCAUGHT_EXCEPTIONS = env.bool('API_PROPOGATE_UNCAUGHT_EXCEPTIONS', default=True)
     ETAG = True
-    SENTRY_DSN = env('SENTRY_DSN', default=None)
 
     if not SQLALCHEMY_DATABASE_URI:
         print('`DATABASE_URL` either not exported or empty')


### PR DESCRIPTION
fixes #4039 

related commit on framework: https://github.com/shubham-padia/flask-rest-jsonapi/commit/33c728e330ec4936671f0a2a15d488cf8edd1530

Changes:
add optional config `API_PROPOGATE_UNCAUGHT_EXCEPTIONS`  to raise exceptions and made `PROPOGATE_ERROR` in framework