### PR TITLE
Dasherize session-type endpoint

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -164,7 +164,7 @@ api.route(MicrolocationRelationship, 'microlocation_event',
 # sessions
 api.route(SessionList, 'session_list', '/sessions', '/events/<int:event_id>/sessions',
           '/events/<event_identifier>/sessions',
-          '/tracks/<int:track_id>/sessions', '/session_types/<int:session_type_id>/sessions',
+          '/tracks/<int:track_id>/sessions', '/session-types/<int:session_type_id>/sessions',
           '/microlocations/<int:microlocation_id>/sessions', '/speakers/<int:speaker_id>/sessions')
 api.route(SessionDetail, 'session_detail', '/sessions/<int:id>')
 api.route(SessionRelationship, 'session_microlocation',


### PR DESCRIPTION
Minor fix to dasherize session-type in `/session-types/<int:session_type_id>/sessions` endpoint.