### PR TITLE
Sponsors: Add seperate resourcelist class, docs, permissions for dire…

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -14,7 +14,7 @@ from app.api.sessions import SessionList, SessionListPost, SessionDetail, Sessio
     SessionRelationshipOptional
 from app.api.speakers import SpeakerList, SpeakerDetail, SpeakerRelationshipRequired, SpeakerRelationshipOptional
 from app.api.social_links import SocialLinkList, SocialLinkDetail, SocialLinkRelationship
-from app.api.sponsors import SponsorList, SponsorDetail, SponsorRelationship
+from app.api.sponsors import SponsorList, SponsorListPost, SponsorDetail, SponsorRelationship
 from app.api.tracks import TrackList, TrackListPost, TrackDetail, TrackRelationshipOptional, TrackRelationshipRequired
 from app.api.speakers_calls import SpeakersCallList, SpeakersCallDetail, SpeakersCallRelationship
 from app.api.event_invoices import EventInvoiceList, EventInvoiceListPost, EventInvoiceDetail, \
@@ -46,8 +46,8 @@ from app.api.activities import ActivityList, ActivityDetail
 api.route(UserList, 'user_list', '/users')
 api.route(VerifyUser, 'verify_user', '/users/<int:user_id>/verify')
 api.route(UserDetail, 'user_detail', '/users/<int:id>', '/notifications/<int:notification_id>/user',
-          '/event-invoices/<int:event_invoice_id>/user', '/speakers/<int:speaker_id>/user', 
-          '/access-codes/<int:access_code_id>/marketer', '/email-notifications/<int:email_notification_id>/user', 
+          '/event-invoices/<int:event_invoice_id>/user', '/speakers/<int:speaker_id>/user',
+          '/access-codes/<int:access_code_id>/marketer', '/email-notifications/<int:email_notification_id>/user',
           '/discount-codes/<int:discount_code_id>/marketer')
 api.route(UserRelationship, 'user_notification', '/users/<int:id>/relationships/notifications')
 api.route(UserRelationship, 'user_event_invoices', '/users/<int:id>/relationships/event-invoices')
@@ -211,7 +211,8 @@ api.route(SocialLinkRelationship, 'social_link_event',
           '/social-links/<int:id>/relationships/event')
 
 # sponsors
-api.route(SponsorList, 'sponsor_list', '/sponsors', '/events/<int:event_id>/sponsors',
+api.route(SponsorListPost, 'sponsor_list_post', '/sponsors')
+api.route(SponsorList, 'sponsor_list', '/events/<int:event_id>/sponsors',
           '/events/<event_identifier>/sponsors')
 api.route(SponsorDetail, 'sponsor_detail', '/sponsors/<int:id>')
 api.route(SponsorRelationship, 'sponsor_event', '/sponsors/<int:id>/relationships/event')

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -4698,7 +4698,77 @@ Data related to the various sponsors with their level, url and images associated
 | `level` | Level of the sponsor | string | - |
 | `type` | The type of the sponsor | string | - |
 
-## Sponsors Collection [/v1/events/{event_identifier}/sponsors{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]
+## Sponsors Post Collection [/v1/sponsors]
+
+### Create Sponsor [POST]
+Create a new sponsor using an event_id.
+
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Authorization: JWT <Auth Key>
+
+    + Body
+
+            {
+              "data": {
+                "relationships":{
+                  "event":{
+                    "data":{
+                      "type":"event",
+                      "id":"1"
+                    }
+                  }
+                },
+                "attributes": {
+                  "name": "Fossasia",
+                  "description": "Fossasia",
+                  "logo-url": "http://example.com/example.png",
+                  "url": "http://example.com",
+                  "level": "1",
+                  "type": "Gold"
+                },
+                "type": "sponsor"
+              }
+            }
+
+
++ Response 201 (application/vnd.api+json)
+
+        {
+          "data": {
+            "relationships": {
+              "event": {
+                "links": {
+                  "self": "/v1/sponsors/1/relationships/event",
+                  "related": "/v1/sponsors/1/event"
+                }
+              }
+            },
+            "attributes": {
+              "description": "Fossasia",
+              "level": "1",
+              "url": "http://example.com",
+              "logo-url": "http://example.com/example.png",
+              "type": "Gold",
+              "name": "Fossasia"
+            },
+            "type": "sponsor",
+            "id": "1",
+            "links": {
+              "self": "/v1/sponsors/1"
+            }
+          },
+          "jsonapi": {
+            "version": "1.0"
+          },
+          "links": {
+            "self": "/v1/sponsors/1"
+          }
+        }
+
+## Sponsors Get Collection [/v1/events/{event_identifier}/sponsors{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]
 + Parameters
     + event_identifier: 1 (string) - identifier or event id of the event. (b8324ae2 is an example of identifier)
     + page%5bsize%5d (optional, integer, `10`) - Maximum number of resources in a single paginated response.
@@ -4752,68 +4822,7 @@ Get a list of Sponsors.
             "version": "1.0"
           },
           "links": {
-            "self": "/v1/sponsors"
-          }
-        }
-
-
-### Create Sponsor [POST]
-Create a new sponsor using an event_id.
-
-+ Request (application/vnd.api+json)
-
-    + Headers
-
-            Authorization: JWT <Auth Key>
-
-    + Body
-
-            {
-              "data": {
-                "attributes": {
-                  "name": "Fossasia",
-                  "description": "Fossasia",
-                  "logo-url": "http://example.com/example.png",
-                  "url": "http://example.com",
-                  "level": "1",
-                  "type": "Gold"
-                },
-                "type": "sponsor"
-              }
-            }
-
-
-+ Response 201 (application/vnd.api+json)
-
-        {
-          "data": {
-            "relationships": {
-              "event": {
-                "links": {
-                  "self": "/v1/sponsors/1/relationships/event",
-                  "related": "/v1/sponsors/1/event"
-                }
-              }
-            },
-            "attributes": {
-              "description": "Fossasia",
-              "level": "1",
-              "url": "http://example.com",
-              "logo-url": "http://example.com/example.png",
-              "type": "Gold",
-              "name": "Fossasia"
-            },
-            "type": "sponsor",
-            "id": "1",
-            "links": {
-              "self": "/v1/sponsors/1"
-            }
-          },
-          "jsonapi": {
-            "version": "1.0"
-          },
-          "links": {
-            "self": "/v1/sponsors/1"
+            "self": "/v1/events/1/sponsors"
           }
         }
 

--- a/tests/hook_main.py
+++ b/tests/hook_main.py
@@ -782,7 +782,7 @@ def speakers_call_delete(transaction):
 
 
 # ------------------------- Sponsors -------------------------
-@hooks.before("Sponsors > Sponsors Collection > List All Sponsors")
+@hooks.before("Sponsors > Sponsors Get Collection > List All Sponsors")
 def sponsor_get_list(transaction):
     """
     GET /events/1/sponsors
@@ -795,16 +795,13 @@ def sponsor_get_list(transaction):
         db.session.commit()
 
 
-@hooks.before("Sponsors > Sponsors Collection > Create Sponsor")
+@hooks.before("Sponsors > Sponsors Post Collection > Create Sponsor")
 def sponsor_post(transaction):
     """
-    POST /events/1/sponsors
+    POST /sponsors
     :param transaction:
     :return:
     """
-    # Skip until docs for direct endpoints added
-    transaction['skip'] = True
-
     with stash['app'].app_context():
         event = EventFactoryBasic()
         db.session.add(event)


### PR DESCRIPTION
…ct endpoints

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4117 

from the dev-handbook:

---

#### Sponsors - Eg. `/v1/sponsors`

An event would usually be sponsored by companies in-turn for advertisement oppurtunities.  An event can have multiple sponsors. But a sponsor would be linked to only one event.

|   | List | View | Create | Update | Delete |
|---|------|------|--------|--------|--------|
| **Superadmin/admin** | ✓ | ✓ | ✓ | ✓ |  ✓ |
| **Event organizer** | ✓ <sup>[1]</sup> | ✓ <sup>[1]</sup> | ✓ <sup>[1]</sup> | ✓ <sup>[1]</sup> | ✓ <sup>[1]</sup> |
| **Everyone else** | ✓ <sup>[2]</sup> | ✓ <sup>[2]</sup>  |  | |  |

1. Only self-owned events
2. Only of events with state `published`

---

