### PR TITLE
Fix: Relationships Permissions for users and attendees

### DIFF
--- a/app/api/attendees.py
+++ b/app/api/attendees.py
@@ -2,6 +2,7 @@ from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationshi
 from marshmallow_jsonapi.flask import Schema, Relationship
 from marshmallow_jsonapi import fields
 
+from app.api.bootstrap import api
 from app.models import db
 from app.models.order import Order
 from app.models.ticket_holder import TicketHolder
@@ -133,7 +134,7 @@ class AttendeeRelationshipOptional(ResourceRelationship):
     """
     Attendee Relationship(Optional)
     """
-    decorators = (jwt_required,)
+    decorators = (api.has_permission('is_user_itself', fetch="user_id", fetch_as="id", model=TicketHolder),)
     schema = AttendeeSchema
     data_layer = {'session': db.session,
                   'model': TicketHolder}

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -229,7 +229,7 @@ class UserDetail(ResourceDetail):
 
 class UserRelationship(ResourceRelationship):
 
-    decorators = (jwt_required, )
+    decorators = (is_user_itself, )
     schema = UserSchema
     data_layer = {'session': db.session,
                   'model': User}


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4114 
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `nextgen` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Add relationship permissions to Users and Attendees API which uses **is_user_itself.**

