### PR TITLE
Health-check: Check if migrations are up to date only once

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,8 +5,6 @@ from flask.exthook import ExtDeprecationWarning
 warnings.simplefilter('ignore', ExtDeprecationWarning)
 # Keep it before flask extensions are imported
 
-from pytz import utc
-
 from celery import Celery
 from celery.signals import after_task_publish
 import logging
@@ -22,7 +20,6 @@ from flask_login import current_user
 from flask_jwt import JWT
 from datetime import timedelta
 from flask_cors import CORS
-from raven.contrib.flask import Sentry
 from flask_rest_jsonapi.errors import jsonapi_errors
 from flask_rest_jsonapi.exceptions import JsonApiException
 from healthcheck import HealthCheck, EnvironmentDump
@@ -40,6 +37,7 @@ from app.api.helpers.auth import AuthManager
 from app.models.event import Event, EventsUsers
 from app.models.role_invite import RoleInvite
 from app.views.healthcheck import health_check_celery, health_check_db, health_check_migrations, check_migrations
+from app.views.sentry import sentry
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -123,9 +121,8 @@ def create_app():
                          view_func=app.send_static_file)
 
     # sentry
-    if app.config['SENTRY_DSN']:
-        sentry = Sentry(dsn=app.config['SENTRY_DSN'])
-        sentry.init_app(app)
+    if 'SENTRY_DSN' in app.config:
+        sentry.init_app(app, dsn=app.config['SENTRY_DSN'])
 
     return app, _manager, db, _jwt
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -39,7 +39,7 @@ from app.views import BlueprintsManager
 from app.api.helpers.auth import AuthManager
 from app.models.event import Event, EventsUsers
 from app.models.role_invite import RoleInvite
-from app.views.healthcheck import health_check_celery, health_check_db, health_check_migrations
+from app.views.healthcheck import health_check_celery, health_check_db, health_check_migrations, check_migrations
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -166,6 +166,8 @@ health = HealthCheck(current_app, "/health-check")
 envdump = EnvironmentDump(current_app, "/environment", include_config=False)
 health.add_check(health_check_celery)
 health.add_check(health_check_db)
+with current_app.app_context():
+    current_app.config['MIGRATION_STATUS'] = check_migrations()
 health.add_check(health_check_migrations)
 
 

--- a/app/views/healthcheck.py
+++ b/app/views/healthcheck.py
@@ -52,7 +52,6 @@ def check_migrations():
     Checks whether database is up to date with migrations by performing a select query on each model
     :return:
     """
-    print("Checking if migrations are up to date.....")
     # Get all the models in the db, all models should have a explicit __tablename__
     classes, models, table_names = [], [], []
     # noinspection PyProtectedMember
@@ -71,9 +70,7 @@ def check_migrations():
             db.session.query(model).first()
         except:
             sentry.captureException()
-            print("failure: {} model out of date with migrations.....".format(model))
             return 'failure,{} model out of date with migrations'.format(model)
-    print("success: database up to date with migrations.....")
     return 'success,database up to date with migrations'
 
 

--- a/app/views/sentry.py
+++ b/app/views/sentry.py
@@ -1,0 +1,3 @@
+from raven.contrib.flask import Sentry
+
+sentry = Sentry()

--- a/tests/unittests/test_migrations.py
+++ b/tests/unittests/test_migrations.py
@@ -1,0 +1,14 @@
+from app import current_app as app
+from tests.unittests.utils import OpenEventTestCase
+from tests.unittests.setup_database import Setup
+from app.views.healthcheck import check_migrations
+
+
+class TestMigrations(OpenEventTestCase):
+    def setUp(self):
+        self.app = Setup.create_app()
+
+    def test_migrations(self):
+        with app.test_request_context():
+            result = check_migrations().split(',')
+            self.assertEqual(result[0], 'success')


### PR DESCRIPTION
fixes #4165 
Changes:
- Health-check: Check if migrations are up to date only once
- add proper sentry exception catching in health-check
- add unittest to check if migrations are missing




