### PR TITLE
speakers-call, remove events/id/speakers-call from list

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -233,8 +233,7 @@ api.route(TrackRelationshipOptional, 'track_sessions', '/tracks/<int:id>/relatio
 api.route(TrackRelationshipRequired, 'track_event', '/tracks/<int:id>/relationships/event')
 
 # speakers_calls
-api.route(SpeakersCallList, 'speakers_call_list', '/speakers-calls', '/events/<int:event_id>/speakers-call',
-          '/events/<event_identifier>/speakers-call')
+api.route(SpeakersCallList, 'speakers_call_list', '/speakers-calls')
 api.route(SpeakersCallDetail, 'speakers_call_detail', '/speakers-calls/<int:id>',
           '/events/<int:event_id>/speakers-call', '/events/<event_identifier>/speakers-call')
 api.route(SpeakersCallRelationship, 'speakers_call_event',

--- a/app/api/sponsors.py
+++ b/app/api/sponsors.py
@@ -5,7 +5,6 @@ from flask_rest_jsonapi.exceptions import ObjectNotFound
 from flask import request
 
 from app.api.helpers.utilities import dasherize
-from app.api.helpers.permissions import jwt_required
 from app.models import db
 from app.models.sponsor import Sponsor
 from app.models.event import Event

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -2302,7 +2302,7 @@ Create a new Event Copyright.
                 "relationships":{
                   "event":{
                     "data": {
-                      "type": "event", 
+                      "type": "event",
                       "id": "1"
                     }
                   }
@@ -4956,9 +4956,8 @@ Announcement for call for speaker to accept session proposals from speakers.
 | `privacy` | Privacy of speakers call | string | - |
 
 
-## Speakers Call Collection [/v1/events/{event_identifier}/speakers-call{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]
+## Speakers Call Collection [/v1/speakers-calls{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]
 + Parameters
-    + event_identifier: 1 (string) - identifier or event id of the event. (b8324ae2 is an example of identifier)
     + page%5bsize%5d (optional, integer, `10`) - Maximum number of resources in a single paginated response.
     + page%5bnumber%5d (optional, integer, `2`) - Page number to fetched for the paginated response.
     + sort (optional, string, `starts-at`) - Sort the resources according to the given attribute in ascending order. Append '-' to sort in descending order.
@@ -4977,6 +4976,14 @@ Create a new speakers call using an event_id.
 
             {
               "data": {
+                "relationships":{
+                  "event":{
+                    "data":{
+                      "type":"event",
+                      "id":"1"
+                    }
+                  }
+                },
                 "attributes": {
                   "announcement": "Speaker Call Announcement",
                   "starts-at": "2017-06-01T01:24:47.500127+00:00",

--- a/tests/hook_main.py
+++ b/tests/hook_main.py
@@ -762,9 +762,6 @@ def speakers_call_post(transaction):
     :param transaction:
     :return:
     """
-    # Skip until docs for direct endpoints added
-    transaction['skip'] = True
-
     with stash['app'].app_context():
         event = EventFactoryBasic()
         db.session.add(event)


### PR DESCRIPTION
fixes #4188 

---

#### Speaker Calls - Eg. `/v1/speaker-calls`

Speaker Calls (usually known as Call for speakers) is an invitation sent out people asking them to submit their talk for an event (usually a conference). An event can have only one speaker call record. 

|   | List | View | Create | Update | Delete |
|---|------|------|--------|--------|--------|
| **Superadmin/admin** | | ✓ | ✓ | ✓ |  ✓ |
| **Event organizer** | | ✓ <sup>[1]</sup> | ✓ <sup>[1]</sup> | ✓ <sup>[1]</sup> | ✓ <sup>[1]</sup> |
| **Everyone else** | | ✓ <sup>[2]</sup>  |  | |  |

1. Only self-owned events
2. Only of events with state `published`

---

List is not required according to the handbook, removed it.

