### PR TITLE
Removed one click heroku deployment button

### DIFF
--- a/docs/installation/heroku.md
+++ b/docs/installation/heroku.md
@@ -2,10 +2,6 @@
 title: Heroku
 ---
 
-One-click Heroku deployment is available:
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-
 ### Steps for Manual Deployment
 
 * We need to install heroku on our machine. Type the following in your linux terminal:


### PR DESCRIPTION
Clicking deployment button was giving error because app.json file is missing but in case of deployment button in README.md its working fine. So it's better to remove this from here. 

As shown in image:

![screenshot from 2017-07-30 20-32-29](https://user-images.githubusercontent.com/9320644/28754659-26ff159a-7567-11e7-81bf-430fcc6d54b2.png)

