### PR TITLE
Add general event statistics

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -48,6 +48,7 @@ from app.api.modules import ModuleDetail
 from app.api.custom_placeholders import CustomPlaceholderList, CustomPlaceholderDetail, CustomPlaceholderRelationship
 from app.api.activities import ActivityList, ActivityDetail
 from app.api.orders import OrdersList, OrderDetail, OrderRelationship, ChargeList, OrdersListPost
+from app.api.event_statistics import EventStatisticsGeneralDetail
 
 # users
 api.route(UserList, 'user_list', '/users')
@@ -385,11 +386,13 @@ api.route(StripeAuthorizationDetail, 'stripe_authorization_detail',  '/stripe-au
 api.route(StripeAuthorizationRelationship, 'stripe_authorization_event',
           '/stripe-authorization/<int:id>/relationships/event')
 
+
 # Orders API
 api.route(OrdersListPost, 'order_list_post', '/orders')
 api.route(OrdersList, 'orders_list', '/orders', '/events/<int:event_id>/orders',
           '/events/<event_identifier>/orders')
 api.route(OrderDetail, 'order_detail', '/orders/<identifier>')
+
 # Charges API
 api.route(ChargeList, 'charge_list', '/orders/<identifier>/charge', '/orders/<identifier>/charge')
 api.route(OrderRelationship, 'order_attendee', '/orders/<identifier>/relationships/attendee')
@@ -398,3 +401,7 @@ api.route(OrderRelationship, 'order_user', '/orders/<identifier>/relationships/u
 api.route(OrderRelationship, 'order_event', '/orders/<identifier>/relationships/event')
 api.route(OrderRelationship, 'order_marketer', '/orders/<identifier>/relationships/marketer')
 api.route(OrderRelationship, 'order_discount', '/orders/<identifier>/relationships/discount-code')
+
+# Event Statistics API
+api.route(EventStatisticsGeneralDetail, 'event_statistics_general_detail', '/events/<int:id>/general-statistics',
+          '/events/<identifier>/general-statistics')

--- a/app/api/event_statistics.py
+++ b/app/api/event_statistics.py
@@ -1,0 +1,84 @@
+from flask_rest_jsonapi import ResourceDetail
+from marshmallow_jsonapi.flask import Schema
+from marshmallow_jsonapi import fields
+
+from app.api.helpers.utilities import dasherize
+from app.api.helpers.db import safe_query
+from app.api.bootstrap import api
+from app.models import db
+from app.models.event import Event
+from app.models.session import Session
+from app.models.speaker import Speaker
+from app.models.sponsor import Sponsor
+
+
+class EventStatisticsGeneralSchema(Schema):
+    """
+    Api schema for general statistics of event
+    """
+    class Meta:
+        """
+        Meta class
+        """
+        type_ = 'event-statistics-general'
+        self_view = 'v1.event_statistics_general_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str()
+    identifier = fields.Str()
+    sessions_draft = fields.Method("sessions_draft_count")
+    sessions_submitted = fields.Method("sessions_submitted_count")
+    sessions_accepted = fields.Method("sessions_accepted_count")
+    sessions_confirmed = fields.Method("sessions_confirmed_count")
+    sessions_pending = fields.Method("sessions_pending_count")
+    sessions_rejected = fields.Method("sessions_rejected_count")
+    speakers = fields.Method("speakers_count")
+    sessions = fields.Method("sessions_count")
+    sponsors = fields.Method("sponsors_count")
+
+    def sessions_draft_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='draft').count()
+
+    def sessions_submitted_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='submitted').count()
+
+    def sessions_accepted_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='accepted').count()
+
+    def sessions_confirmed_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='confirmed').count()
+
+    def sessions_pending_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='pending').count()
+
+    def sessions_rejected_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='rejected').count()
+
+    def speakers_count(self, obj):
+        return Speaker.query.filter_by(event_id=obj.id).count()
+
+    def sessions_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id).count()
+
+    def sponsors_count(self, obj):
+        return Sponsor.query.filter_by(event_id=obj.id).count()
+
+
+class EventStatisticsGeneralDetail(ResourceDetail):
+    """
+    Event statistics detail by id
+    """
+    def before_get_object(self, view_kwargs):
+        if view_kwargs.get('identifier'):
+            event = safe_query(self, Event, 'identifier', view_kwargs['identifier'], 'identifier')
+            view_kwargs['id'] = event.id
+
+    methods = ['GET']
+    decorators = (api.has_permission('is_coorganizer', fetch="id", fetch_as="event_id", model=Event),)
+    schema = EventStatisticsGeneralSchema
+    data_layer = {'session': db.session,
+                  'model': Event,
+                  'methods': {
+                      'before_get_object': before_get_object
+                  }}

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -15502,3 +15502,67 @@ Requires Event Co-Organizer Access
             "version": "1.0"
           }
         }
+
+
+# Group Event Statistics
+
+**General:**
+
+| Parameter | Description | Type |
+|:----------|-------------|------|
+| `id`  | Event Id | Integer |
+| `identifier`  | Event identifier | String |
+| `speakers`  | No. of speakers | Integer |
+| `sponsors`  | No. of sponsors | Integer |
+| `sessions`  | No. of sessions | Integer |
+| `sessions_draft`  | No. of draft sessions | Integer |
+| `sessions_submitted`  | No. of submitted sessions | Integer |
+| `sessions_accepted`  | No. of accepted sessions | Integer |
+| `sessions_confirmed`  | No. of confirmed sessions | Integer |
+| `sessions_pending`  | No. of pending sessions | Integer |
+| `sessions_rejected`  | No. of rejected sessions | Integer |
+
+
+## Event Statistics Details [/v1/events/{event_identifier}/general-statistics]
++ Parameters
+    + event_identifier: 1 (string) - identifier or event id of the event. (b8324ae2 is an example of identifier)
+
+### Show Event Statistics General [GET]
+
++ Request
+
+    + Headers
+
+            Accept: application/vnd.api+json
+
+            Authorization: JWT <Auth Key>
+
++ Response 200 (application/vnd.api+json)
+
+        {
+            "data": {
+                "attributes": {
+                    "speakers": 60,
+                    "sessions": 60,
+                    "sessions-pending": 10,
+                    "sponsors": 441,
+                    "sessions-submitted": 10,
+                    "sessions-rejected": 10,
+                    "sessions-confirmed": 10,
+                    "identifier": "e03a8a32",
+                    "sessions-accepted": 10,
+                    "sessions-draft": 10
+                },
+                "type": "event-statistics-general",
+                "id": "1",
+                "links": {
+                    "self": "/v1/events/1/statistics/general"
+                }
+            },
+            "jsonapi": {
+                "version": "1.0"
+            },
+            "links": {
+                "self": "/v1/events/1/statistics/general"
+            }
+        }

--- a/tests/hook_main.py
+++ b/tests/hook_main.py
@@ -2770,3 +2770,18 @@ def stripe_authorization_delete(transaction):
         stripe = StripeAuthorizationFactory()
         db.session.add(stripe)
         db.session.commit()
+
+
+# ------------------------- Event Statistics -------------------------
+
+@hooks.before("Event Statistics > Event Statistics Details > Show Event Statistics General")
+def event_statistics_general_get(transaction):
+    """
+    GET /events/1/general-statistics
+    :param transaction:
+    :return:
+    """
+    with stash['app'].app_context():
+        event = EventFactoryBasic()
+        db.session.add(event)
+        db.session.commit()


### PR DESCRIPTION
fixes #4007 
Add general event analytics at `analytics/events/{event_identifier}/general`.
There will be another endpoint called `analytics/events/{event_identifier}/sales` in future, that's why the extra general in the current endpoint. The sales data is irrelevant for the event dashboards and they generally have a separate section.

The fields were decided on the basis of the following views,
![selection_223](https://user-images.githubusercontent.com/13910561/28979180-72d753f8-7966-11e7-84af-8fde679d7e9e.png)
![selection_222](https://user-images.githubusercontent.com/13910561/28979181-72d7a7ae-7966-11e7-8c95-203407aec1e2.png)

Co-organizer level access is required, no matter if the event is published, public access to analytics should not be there.