### PR TITLE
Fix tracks font-color attribute, add dump_only=True

### DIFF
--- a/app/api/tracks.py
+++ b/app/api/tracks.py
@@ -32,12 +32,6 @@ class TrackSchema(Schema):
         self_view_kwargs = {'id': '<id>'}
         inflect = dasherize
 
-    @pre_load
-    def remove_font_color(self, data):
-        if data.get('font_color'):
-            del data['font_color']
-        return data
-
     @validates_schema
     def valid_color(self, data):
         if not re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', data['color']):
@@ -47,7 +41,7 @@ class TrackSchema(Schema):
     name = fields.Str(required=True)
     description = fields.Str(allow_none=True)
     color = fields.Str(required=True)
-    font_color = fields.Str(allow_none=True)
+    font_color = fields.Str(allow_none=True, dump_only=True)
     event = Relationship(attribute='event',
                          self_view='v1.track_event',
                          self_view_kwargs={'id': '<id>'},


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4241 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `nextgen` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Add dump_only to font-color attribute.