### PR TITLE
`include` refactor: move schema to separate folder and refactor Events API

### DIFF
--- a/app/api/access_codes.py
+++ b/app/api/access_codes.py
@@ -1,97 +1,15 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-from marshmallow import validates_schema
 
-from app.api.helpers.utilities import dasherize
+from app.api.helpers.db import safe_query
 from app.api.helpers.permissions import jwt_required, current_identity
+from app.api.helpers.query import event_query
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.access_codes import AccessCodeSchema
 from app.models import db
-from app.api.helpers.exceptions import UnprocessableEntity
 from app.models.access_code import AccessCode
-from app.models.user import User
 from app.models.event import Event
 from app.models.ticket import Ticket
-from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.query import event_query
-
-
-class AccessCodeSchema(Schema):
-    """
-    Api schema for Access Code Model
-    """
-
-    class Meta:
-        """
-        Meta class for Access Code Api Schema
-        """
-        type_ = 'access-code'
-        self_view = 'v1.access_code_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    @validates_schema(pass_original=True)
-    def validate_date(self, data, original_data):
-        if 'id' in original_data['data']:
-            access_code = AccessCode.query.filter_by(id=original_data['data']['id']).one()
-
-            if 'valid_from' not in data:
-                data['valid_from'] = access_code.valid_from
-
-            if 'valid_till' not in data:
-                data['valid_till'] = access_code.valid_till
-
-        if data['valid_from'] >= data['valid_till']:
-            raise UnprocessableEntity({'pointer': '/data/attributes/valid-till'},
-                                      "valid_till should be after valid_from")
-
-    @validates_schema
-    def validate_order_quantity(self, data):
-        if 'max_order' in data and 'min_order' in data:
-            if data['max_order'] < data['min_order']:
-                raise UnprocessableEntity({'pointer': '/data/attributes/max-order'},
-                                          "max-order should be greater than min-order")
-
-        if 'quantity' in data and 'min_order' in data:
-            if data['quantity'] < data['min_order']:
-                raise UnprocessableEntity({'pointer': '/data/attributes/quantity'},
-                                          "quantity should be greater than min-order")
-
-    id = fields.Integer(dump_only=True)
-    code = fields.Str(allow_none=True)
-    access_url = fields.Url(allow_none=True)
-    is_active = fields.Boolean(default=False)
-
-    # For event level access this holds the max. uses
-    tickets_number = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-
-    min_quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    max_quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    valid_from = fields.DateTime(required=True)
-    valid_till = fields.DateTime(required=True)
-    used_for = fields.Str(allow_none=True)
-    event = Relationship(attribute='event',
-                         self_view='v1.access_code_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'access_code_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
-    marketer = Relationship(attribute='user',
-                            self_view='v1.access_code_user',
-                            self_view_kwargs={'id': '<id>'},
-                            related_view='v1.user_detail',
-                            related_view_kwargs={'access_code_id': '<id>'},
-                            schema='UserSchema',
-                            type_='user')
-    tickets = Relationship(attribute='tickets',
-                           self_view='v1.access_code_tickets',
-                           self_view_kwargs={'id': '<id>'},
-                           related_view='v1.ticket_list',
-                           related_view_kwargs={'access_code_id': '<id>'},
-                           schema='TicketSchema',
-                           many=True,
-                           type_='ticket')
+from app.models.user import User
 
 
 class AccessCodeList(ResourceList):

--- a/app/api/activities.py
+++ b/app/api/activities.py
@@ -1,30 +1,9 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList
-from marshmallow_jsonapi.flask import Schema
-from marshmallow_jsonapi import fields
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
+from app.api.schema.activities import ActivitySchema
 from app.models import db
 from app.models.activity import Activity
-
-
-class ActivitySchema(Schema):
-    """
-    Api schema for Activity Model
-    """
-    class Meta:
-        """
-        Meta class for Activity Api Schema
-        """
-        type_ = 'activity'
-        self_view = 'v1.activity_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    actor = fields.Str(allow_none=True)
-    time = fields.DateTime(allow_none=True)
-    action = fields.Str(allow_none=True)
 
 
 class ActivityList(ResourceList):

--- a/app/api/attendees.py
+++ b/app/api/attendees.py
@@ -1,61 +1,18 @@
 from flask_jwt import current_identity
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
 
 from app.api.bootstrap import api
+from app.api.helpers.db import safe_query
 from app.api.helpers.exceptions import ForbiddenException
 from app.api.helpers.permission_manager import has_access
+from app.api.helpers.permissions import jwt_required
+from app.api.helpers.query import event_query
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.attendees import AttendeeSchema
 from app.models import db
 from app.models.order import Order
-from app.models.ticket_holder import TicketHolder
 from app.models.ticket import Ticket
-from app.api.helpers.permissions import jwt_required
-from app.api.helpers.utilities import dasherize
-from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.query import event_query
-
-
-class AttendeeSchema(Schema):
-    """
-    Api schema for Ticket Holder Model
-    """
-
-    class Meta:
-        """
-        Meta class for Attendee API Schema
-        """
-        type_ = 'attendee'
-        self_view = 'v1.attendee_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    firstname = fields.Str(required=True)
-    lastname = fields.Str(allow_none=True)
-    email = fields.Str(allow_none=True)
-    address = fields.Str(allow_none=True)
-    city = fields.Str(allow_none=True)
-    state = fields.Str(allow_none=True)
-    country = fields.Str(allow_none=True)
-    ticket_id = fields.Str(allow_none=True)
-    is_checked_in = fields.Boolean()
-    pdf_url = fields.Url(required=True)
-    ticket = Relationship(attribute='ticket',
-                          self_view='v1.attendee_ticket',
-                          self_view_kwargs={'id': '<id>'},
-                          related_view='v1.ticket_detail',
-                          related_view_kwargs={'attendee_id': '<id>'},
-                          schema='TicketSchema',
-                          type_='ticket')
-    event = Relationship(attribute='event',
-                         self_view='v1.attendee_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'attendee_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
+from app.models.ticket_holder import TicketHolder
 
 
 class AttendeeListPost(ResourceList):

--- a/app/api/custom_forms.py
+++ b/app/api/custom_forms.py
@@ -1,49 +1,16 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-import marshmallow.validate as validate
-from app.api.helpers.permissions import jwt_required
 from flask_rest_jsonapi.exceptions import ObjectNotFound
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
+from app.api.helpers.db import safe_query
+from app.api.helpers.permission_manager import has_access
+from app.api.helpers.permissions import jwt_required
+from app.api.helpers.query import event_query
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.custom_forms import CustomFormSchema
 from app.models import db
 from app.models.custom_form import CustomForms
 from app.models.event import Event
-from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.permission_manager import has_access
-from app.api.helpers.query import event_query
-
-
-class CustomFormSchema(Schema):
-    """
-    API Schema for Custom Forms database model
-    """
-    class Meta:
-        """
-        Meta class for CustomForm Schema
-        """
-        type_ = 'custom-form'
-        self_view = 'v1.custom_form_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Integer(dump_only=True)
-    field_identifier = fields.Str(required=True)
-    form = fields.Str(required=True)
-    type = fields.Str(default="text", validate=validate.OneOf(
-        choices=["text", "checkbox", "select", "file", "image", "email"]))
-    is_required = fields.Boolean(default=False)
-    is_included = fields.Boolean(default=False)
-    is_fixed = fields.Boolean(default=False)
-    event = Relationship(attribute='event',
-                         self_view='v1.custom_form_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'custom_form_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
 
 
 class CustomFormListPost(ResourceList):

--- a/app/api/custom_placeholders.py
+++ b/app/api/custom_placeholders.py
@@ -1,39 +1,12 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
 
 from app.api.bootstrap import api
 from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import dasherize
+from app.api.helpers.files import create_save_image_sizes
+from app.api.schema.custom_placeholders import CustomPlaceholderSchema
 from app.models import db
 from app.models.custom_placeholder import CustomPlaceholder
 from app.models.event_sub_topic import EventSubTopic
-from app.api.helpers.files import create_save_image_sizes
-
-
-class CustomPlaceholderSchema(Schema):
-    class Meta:
-        type_ = 'custom-placeholder'
-        self_view = 'v1.custom_placeholder_detail'
-        self_view_kwargs = {'id': '<id>'}
-        self_view_many = 'v1.custom_placeholder_list'
-        inflect = dasherize
-
-    id = fields.Integer(dump_only=True)
-    name = fields.String(required=True)
-    original_image_url = fields.Url(required=True)
-    thumbnail_image_url = fields.Url(dump_only=True)
-    large_image_url = fields.Url(dump_only=True)
-    icon_image_url = fields.Url(dump_only=True)
-    copyright = fields.String(allow_none=True)
-    origin = fields.String(allow_none=True)
-    event_sub_topic = Relationship(attribute='event_sub_topic',
-                                   self_view='v1.custom_placeholder_event_sub_topic',
-                                   self_view_kwargs={'id': '<id>'},
-                                   related_view='v1.event_sub_topic_detail',
-                                   related_view_kwargs={'custom_placeholder_id': '<id>'},
-                                   schema='EventSubTopicSchema',
-                                   type_='event-sub-topic')
 
 
 class CustomPlaceholderList(ResourceList):

--- a/app/api/email_notifications.py
+++ b/app/api/email_notifications.py
@@ -1,53 +1,12 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-from app.api.bootstrap import api
 
-from app.api.helpers.utilities import dasherize
+from app.api.bootstrap import api
+from app.api.helpers.db import safe_query
+from app.api.helpers.permissions import jwt_required
+from app.api.schema.email_notifications import EmailNotificationSchema
 from app.models import db
 from app.models.email_notification import EmailNotification
 from app.models.user import User
-from app.api.helpers.permissions import jwt_required
-from app.api.helpers.db import safe_query
-
-
-class EmailNotificationSchema(Schema):
-    """
-    API Schema for email notification Model
-    """
-
-    class Meta:
-        """
-        Meta class for email notification API schema
-        """
-        type_ = 'email-notification'
-        self_view = 'v1.email_notification_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    next_event = fields.Boolean(default=False, allow_none=True)
-    new_paper = fields.Boolean(default=False, allow_none=True)
-    session_accept_reject = fields.Boolean(default=False, allow_none=True)
-    session_schedule = fields.Boolean(default=False, allow_none=True)
-    after_ticket_purchase = fields.Boolean(default=True, allow_none=True)
-    event_id = fields.Integer(allow_none=True)
-    event = Relationship(attribute='event',
-                         self_view='v1.email_notification_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'email_notification_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event'
-                         )
-    user = Relationship(attribute='user',
-                        self_view='v1.email_notification_user',
-                        self_view_kwargs={'id': '<id>'},
-                        related_view='v1.user_detail',
-                        related_view_kwargs={'email_notification_id': '<id>'},
-                        schema='UserSchema',
-                        type_='user'
-                        )
 
 
 class EmailNotificationListAdmin(ResourceList):

--- a/app/api/event_copyright.py
+++ b/app/api/event_copyright.py
@@ -1,43 +1,16 @@
-from datetime import datetime
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.api.bootstrap import api
 from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.models.event_copyright import EventCopyright
-from app.models.event import Event
-from app.api.helpers.exceptions import UnprocessableEntity
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.permission_manager import has_access
 from app.api.helpers.exceptions import ForbiddenException
-
-
-class EventCopyrightSchema(Schema):
-
-    class Meta:
-        type_ = 'event-copyright'
-        self_view = 'v1.event_copyright_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    holder = fields.Str(allow_none=True)
-    holder_url = fields.Url(allow_none=True)
-    licence = fields.Str(required=True)
-    licence_url = fields.Url(allow_none=True)
-    year = fields.Int(validate=lambda n: 1900 <= n <= datetime.now().year, allow_none=True)
-    logo_url = fields.Url(attribute='logo', allow_none=True)
-    event = Relationship(attribute='event',
-                         self_view='v1.copyright_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'copyright_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
+from app.api.helpers.exceptions import UnprocessableEntity
+from app.api.helpers.permission_manager import has_access
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.event_copyright import EventCopyrightSchema
+from app.models import db
+from app.models.event import Event
+from app.models.event_copyright import EventCopyright
 
 
 class EventCopyrightListPost(ResourceList):

--- a/app/api/event_invoices.py
+++ b/app/api/event_invoices.py
@@ -1,78 +1,15 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-import marshmallow.validate as validate
 
-from app.api.helpers.utilities import dasherize
-from app.api.helpers.permissions import is_admin
-from app.models import db
-from app.models.user import User
-from app.models.event_invoice import EventInvoice
-from app.models.discount_code import DiscountCode
-from app.api.helpers.static import PAYMENT_COUNTRIES
-from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.exceptions import ForbiddenException
-from app.api.helpers.permission_manager import has_access
 from app.api.bootstrap import api
+from app.api.helpers.db import safe_query
+from app.api.helpers.permissions import is_admin
 from app.api.helpers.query import event_query
-
-
-class EventInvoiceSchema(Schema):
-    """
-    Event Invoice API Schema based on event invoice model
-    """
-    class Meta:
-        type_ = 'event-invoice'
-        self_view = 'v1.event_invoice_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    identifier = fields.Str(allow_none=True)
-    amount = fields.Float(validate=lambda n: n >= 0, allow_none=True)
-    address = fields.Str(allow_none=True)
-    city = fields.Str(allow_none=True)
-    state = fields.Str(allow_none=True)
-    country = fields.Str(validate=validate.OneOf(choices=PAYMENT_COUNTRIES), allow_none=True)
-    zipcode = fields.Str(allow_none=True)
-    created_at = fields.DateTime(allow_none=True)
-    completed_at = fields.DateTime(default=None)
-    transaction_id = fields.Str(allow_none=True)
-    paid_via = fields.Str(validate=validate.OneOf(
-        choices=["free", "stripe", "paypal", "transfer", "onsite", "cheque"]), allow_none=True)
-    payment_mode = fields.Str(allow_none=True)
-    brand = fields.Str(allow_none=True)
-    exp_month = fields.Integer(validate=lambda n: 0 <= n <= 12, allow_none=True)
-    exp_year = fields.Integer(validate=lambda n: n >= 2015, allow_none=True)
-    last4 = fields.Str(allow_none=True)
-    stripe_token = fields.Str(allow_none=True)
-    paypal_token = fields.Str(allow_none=True)
-    status = fields.Str(validate=validate.OneOf(
-        choices=["expired", "deleted", "initialized" "completed", "placed", "pending", "cancelled"]), allow_none=True)
-    invoice_pdf_url = fields.Url(allow_none=True)
-    user = Relationship(attribute='user',
-                        self_view='v1.event_invoice_user',
-                        self_view_kwargs={'id': '<id>'},
-                        related_view='v1.user_detail',
-                        related_view_kwargs={'event_invoice_id': '<id>'},
-                        schema='UserSchema',
-                        type_='user')
-    event = Relationship(attribute='event',
-                         self_view='v1.event_invoice_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'event_invoice_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
-    discount_codes = Relationship(attribute='discount_code',
-                                  many=True,
-                                  self_view='v1.event_invoice_discount_code',
-                                  self_view_kwargs={'id': '<id>'},
-                                  related_view='v1.discount_code_detail',
-                                  related_view_kwargs={'event_invoice_id': '<id>'},
-                                  schema='DiscountCodeSchema',
-                                  type_='discount-code')
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.event_invoices import EventInvoiceSchema
+from app.models import db
+from app.models.discount_code import DiscountCode
+from app.models.event_invoice import EventInvoice
+from app.models.user import User
 
 
 class EventInvoiceList(ResourceList):

--- a/app/api/event_statistics.py
+++ b/app/api/event_statistics.py
@@ -1,68 +1,10 @@
 from flask_rest_jsonapi import ResourceDetail
-from marshmallow_jsonapi.flask import Schema
-from marshmallow_jsonapi import fields
 
-from app.api.helpers.utilities import dasherize
-from app.api.helpers.db import safe_query
 from app.api.bootstrap import api
+from app.api.helpers.db import safe_query
+from app.api.schema.event_statistics import EventStatisticsGeneralSchema
 from app.models import db
 from app.models.event import Event
-from app.models.session import Session
-from app.models.speaker import Speaker
-from app.models.sponsor import Sponsor
-
-
-class EventStatisticsGeneralSchema(Schema):
-    """
-    Api schema for general statistics of event
-    """
-    class Meta:
-        """
-        Meta class
-        """
-        type_ = 'event-statistics-general'
-        self_view = 'v1.event_statistics_general_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str()
-    identifier = fields.Str()
-    sessions_draft = fields.Method("sessions_draft_count")
-    sessions_submitted = fields.Method("sessions_submitted_count")
-    sessions_accepted = fields.Method("sessions_accepted_count")
-    sessions_confirmed = fields.Method("sessions_confirmed_count")
-    sessions_pending = fields.Method("sessions_pending_count")
-    sessions_rejected = fields.Method("sessions_rejected_count")
-    speakers = fields.Method("speakers_count")
-    sessions = fields.Method("sessions_count")
-    sponsors = fields.Method("sponsors_count")
-
-    def sessions_draft_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='draft').count()
-
-    def sessions_submitted_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='submitted').count()
-
-    def sessions_accepted_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='accepted').count()
-
-    def sessions_confirmed_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='confirmed').count()
-
-    def sessions_pending_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='pending').count()
-
-    def sessions_rejected_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id, state='rejected').count()
-
-    def speakers_count(self, obj):
-        return Speaker.query.filter_by(event_id=obj.id).count()
-
-    def sessions_count(self, obj):
-        return Session.query.filter_by(event_id=obj.id).count()
-
-    def sponsors_count(self, obj):
-        return Sponsor.query.filter_by(event_id=obj.id).count()
 
 
 class EventStatisticsGeneralDetail(ResourceDetail):

--- a/app/api/event_sub_topics.py
+++ b/app/api/event_sub_topics.py
@@ -1,59 +1,16 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
 
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.models.event_sub_topic import EventSubTopic
-from app.models.event import Event
-from app.models.event_topic import EventTopic
 from app.api.bootstrap import api
-from app.api.helpers.db import safe_query
 from app.api.custom_placeholders import CustomPlaceholder
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.permission_manager import has_access
+from app.api.helpers.db import safe_query
 from app.api.helpers.exceptions import ForbiddenException
-
-
-class EventSubTopicSchema(Schema):
-    """
-    Api Schema for event sub topic model
-    """
-
-    class Meta:
-        """
-        Meta class for event sub topic Api Schema
-        """
-        type_ = 'event-sub-topic'
-        self_view = 'v1.event_sub_topic_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    slug = fields.Str(dump_only=True)
-    events = Relationship(attribute='event',
-                          many=True,
-                          self_view='v1.event_topic_event',
-                          self_view_kwargs={'id': '<id>'},
-                          related_view='v1.event_list',
-                          related_view_kwargs={'event_sub_topic_id': '<id>'},
-                          schema='EventSchema',
-                          type_='event')
-    event_topic = Relationship(attribute='event_topic',
-                               self_view='v1.event_sub_topic_event_topic',
-                               self_view_kwargs={'id': '<id>'},
-                               related_view='v1.event_topic_detail',
-                               related_view_kwargs={'event_sub_topic_id': '<id>'},
-                               schema='EventTopicSchema',
-                               type_='event-topic')
-    custom_placeholder = Relationship(attribute='custom_placeholder',
-                                      self_view='v1.event_sub_topic_custom_placeholder',
-                                      self_view_kwargs={'id': '<id>'},
-                                      related_view='v1.custom_placeholder_detail',
-                                      related_view_kwargs={'event_sub_topic_id': '<id>'},
-                                      schema='CustomPlaceholderSchema',
-                                      type_='custom-placeholder')
+from app.api.helpers.permission_manager import has_access
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.event_sub_topics import EventSubTopicSchema
+from app.models import db
+from app.models.event import Event
+from app.models.event_sub_topic import EventSubTopic
+from app.models.event_topic import EventTopic
 
 
 class EventSubTopicListPost(ResourceList):

--- a/app/api/event_topics.py
+++ b/app/api/event_topics.py
@@ -1,49 +1,12 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
 
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.models.event_topic import EventTopic
-from app.models.event_sub_topic import EventSubTopic
-from app.models.event import Event
 from app.api.bootstrap import api
 from app.api.helpers.db import safe_query
-
-
-class EventTopicSchema(Schema):
-    """
-    Api Schema for event topic model
-    """
-
-    class Meta:
-        """
-        Meta class for event topic Api Schema
-        """
-        type_ = 'event-topic'
-        self_view = 'v1.event_topic_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    slug = fields.Str(dump_only=True)
-    events = Relationship(attribute='event',
-                          many=True,
-                          self_view='v1.event_topic_event',
-                          self_view_kwargs={'id': '<id>'},
-                          related_view='v1.event_list',
-                          related_view_kwargs={'event_topic_id': '<id>'},
-                          schema='EventSchema',
-                          type_='event')
-    event_sub_topics = Relationship(attribute='event_sub_topics',
-                                    self_view='v1.event_topic_event_sub_topic',
-                                    self_view_kwargs={'id': '<id>'},
-                                    related_view='v1.event_sub_topic_list',
-                                    related_view_kwargs={'event_topic_id': '<id>'},
-                                    many=True,
-                                    schema='EventSubTopicSchema',
-                                    type_='event-sub-topic')
+from app.api.schema.event_topics import EventTopicSchema
+from app.models import db
+from app.models.event import Event
+from app.models.event_sub_topic import EventSubTopic
+from app.models.event_topic import EventTopic
 
 
 class EventTopicList(ResourceList):

--- a/app/api/event_types.py
+++ b/app/api/event_types.py
@@ -1,40 +1,11 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
 
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.models.event_type import EventType
-from app.models.event import Event
 from app.api.bootstrap import api
 from app.api.helpers.db import safe_query
-
-
-class EventTypeSchema(Schema):
-    """
-    Api Schema for event type model
-    """
-
-    class Meta:
-        """
-        Meta class for event type Api Schema
-        """
-        type_ = 'event-type'
-        self_view = 'v1.event_type_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    slug = fields.Str(dump_only=True)
-    events = Relationship(attribute='event',
-                          self_view='v1.event_type_event',
-                          self_view_kwargs={'id': '<id>'},
-                          related_view='v1.event_list',
-                          related_view_kwargs={'event_type_id': '<id>'},
-                          many=True,
-                          schema='EventSchema',
-                          type_='event')
+from app.api.schema.event_types import EventTypeSchema
+from app.models import db
+from app.models.event import Event
+from app.models.event_type import EventType
 
 
 class EventTypeList(ResourceList):

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -6,7 +6,9 @@ from sqlalchemy import or_
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.api.bootstrap import api
-from app.api.schema.events import EventSchema
+from app.api.schema.events import EventSchemaPublic, EventSchema
+from app.api.helpers.permission_manager import has_access
+# models
 from app.models import db
 from app.models.access_code import AccessCode
 from app.models.custom_form import CustomForms
@@ -37,6 +39,12 @@ from app.models.order import Order
 
 
 class EventList(ResourceList):
+    def before_get(self, args, kwargs):
+        if 'Authorization' in request.headers and has_access('is_admin'):
+            self.schema = EventSchema
+        else:
+            self.schema = EventSchemaPublic
+
     def query(self, view_kwargs):
         query_ = self.session.query(Event).filter_by(state='published')
         if 'Authorization' in request.headers:
@@ -47,7 +55,7 @@ class EventList(ResourceList):
             query_ = query_.union(query2)
 
         if view_kwargs.get('user_id') and 'GET' in request.method:
-            user = safe_query(self, User, 'id', view_kwargs['user_id'], 'user_id')
+            user = safe_query(db, User, 'id', view_kwargs['user_id'], 'user_id')
             query_ = query_.join(Event.roles).filter_by(user_id=user.id).join(UsersEventsRoles.role). \
                 filter(Role.name != ATTENDEE)
 
@@ -89,179 +97,192 @@ class EventList(ResourceList):
                               }}
 
 
-class EventDetail(ResourceDetail):
-    def before_get_object(self, view_kwargs):
-        if view_kwargs.get('identifier'):
-            event = safe_query(self, Event, 'identifier', view_kwargs['identifier'], 'identifier')
-            view_kwargs['id'] = event.id
+def get_id(view_kwargs):
+    if view_kwargs.get('identifier'):
+        event = safe_query(db, Event, 'identifier', view_kwargs['identifier'], 'identifier')
+        view_kwargs['id'] = event.id
 
-        if view_kwargs.get('sponsor_id') is not None:
-            sponsor = safe_query(self, Sponsor, 'id', view_kwargs['sponsor_id'], 'sponsor_id')
-            if sponsor.event_id is not None:
-                view_kwargs['id'] = sponsor.event_id
-            else:
-                view_kwargs['id'] = None
+    if view_kwargs.get('sponsor_id') is not None:
+        sponsor = safe_query(db, Sponsor, 'id', view_kwargs['sponsor_id'], 'sponsor_id')
+        if sponsor.event_id is not None:
+            view_kwargs['id'] = sponsor.event_id
+        else:
+            view_kwargs['id'] = None
 
-        if view_kwargs.get('copyright_id') is not None:
-            copyright = safe_query(self, EventCopyright, 'id', view_kwargs['copyright_id'], 'copyright_id')
-            if copyright.event_id is not None:
-                view_kwargs['id'] = copyright.event_id
-            else:
-                view_kwargs['id'] = None
+    if view_kwargs.get('copyright_id') is not None:
+        copyright = safe_query(db, EventCopyright, 'id', view_kwargs['copyright_id'], 'copyright_id')
+        if copyright.event_id is not None:
+            view_kwargs['id'] = copyright.event_id
+        else:
+            view_kwargs['id'] = None
 
-        if view_kwargs.get('track_id') is not None:
-            track = safe_query(self, Track, 'id', view_kwargs['track_id'], 'track_id')
-            if track.event_id is not None:
-                view_kwargs['id'] = track.event_id
-            else:
-                view_kwargs['id'] = None
+    if view_kwargs.get('track_id') is not None:
+        track = safe_query(db, Track, 'id', view_kwargs['track_id'], 'track_id')
+        if track.event_id is not None:
+            view_kwargs['id'] = track.event_id
+        else:
+            view_kwargs['id'] = None
 
-        if view_kwargs.get('session_type_id') is not None:
-            session_type = safe_query(self, SessionType, 'id', view_kwargs['session_type_id'], 'session_type_id')
-            if session_type.event_id is not None:
-                view_kwargs['id'] = session_type.event_id
-            else:
-                view_kwargs['id'] = None
+    if view_kwargs.get('session_type_id') is not None:
+        session_type = safe_query(db, SessionType, 'id', view_kwargs['session_type_id'], 'session_type_id')
+        if session_type.event_id is not None:
+            view_kwargs['id'] = session_type.event_id
+        else:
+            view_kwargs['id'] = None
 
-        if view_kwargs.get('event_invoice_id') is not None:
-            event_invoice = safe_query(self, EventInvoice, 'id', view_kwargs['event_invoice_id'], 'event_invoice_id')
-            if event_invoice.event_id is not None:
-                view_kwargs['id'] = event_invoice.event_id
-            else:
-                view_kwargs['id'] = None
+    if view_kwargs.get('event_invoice_id') is not None:
+        event_invoice = safe_query(db, EventInvoice, 'id', view_kwargs['event_invoice_id'], 'event_invoice_id')
+        if event_invoice.event_id is not None:
+            view_kwargs['id'] = event_invoice.event_id
+        else:
+            view_kwargs['id'] = None
 
-        if view_kwargs.get('discount_code_id') is not None:
-            discount_code = safe_query(self, DiscountCode, 'id', view_kwargs['discount_code_id'], 'discount_code_id')
+    if view_kwargs.get('discount_code_id') is not None:
+        discount_code = safe_query(db, DiscountCode, 'id', view_kwargs['discount_code_id'], 'discount_code_id')
+        if discount_code.event_id is not None:
+            view_kwargs['id'] = discount_code.event_id
+        else:
+            view_kwargs['id'] = None
+
+    if view_kwargs.get('session_id') is not None:
+        sessions = safe_query(db, Session, 'id', view_kwargs['session_id'], 'session_id')
+        if sessions.event_id is not None:
+            view_kwargs['id'] = sessions.event_id
+        else:
+            view_kwargs['id'] = None
+
+    if view_kwargs.get('social_link_id') is not None:
+        social_link = safe_query(db, SocialLink, 'id', view_kwargs['social_link_id'], 'social_link_id')
+        if social_link.event_id is not None:
+            view_kwargs['id'] = social_link.event_id
+        else:
+            view_kwargs['id'] = None
+
+    if view_kwargs.get('tax_id') is not None:
+        tax = safe_query(db, Tax, 'id', view_kwargs['tax_id'], 'tax_id')
+        if tax.event_id is not None:
+            view_kwargs['id'] = tax.event_id
+        else:
+            view_kwargs['id'] = None
+
+    if view_kwargs.get('user_id') is not None:
+        try:
+            discount_code = db.session.query(DiscountCode).filter_by(
+                id=view_kwargs['discount_code_id']).one()
+        except NoResultFound:
+            raise ObjectNotFound({'parameter': 'discount_code_id'},
+                                 "DiscountCode: {} not found".format(view_kwargs['discount_code_id']))
+        else:
             if discount_code.event_id is not None:
                 view_kwargs['id'] = discount_code.event_id
             else:
                 view_kwargs['id'] = None
 
-        if view_kwargs.get('session_id') is not None:
-            sessions = safe_query(self, Session, 'id', view_kwargs['session_id'], 'session_id')
-            if sessions.event_id is not None:
-                view_kwargs['id'] = sessions.event_id
+    if view_kwargs.get('speakers_call_id') is not None:
+        speakers_call = safe_query(db, SpeakersCall, 'id', view_kwargs['speakers_call_id'], 'speakers_call_id')
+        if speakers_call.event_id is not None:
+            view_kwargs['id'] = speakers_call.event_id
+        else:
+            view_kwargs['id'] = None
+
+    if view_kwargs.get('ticket_id') is not None:
+        ticket = safe_query(db, Ticket, 'id', view_kwargs['ticket_id'], 'ticket_id')
+        if ticket.event_id is not None:
+            view_kwargs['id'] = ticket.event_id
+        else:
+            view_kwargs['id'] = None
+
+    if view_kwargs.get('ticket_tag_id') is not None:
+        ticket_tag = safe_query(db, TicketTag, 'id', view_kwargs['ticket_tag_id'], 'ticket_tag_id')
+        if ticket_tag.event_id is not None:
+            view_kwargs['id'] = ticket_tag.event_id
+        else:
+            view_kwargs['id'] = None
+
+    if view_kwargs.get('role_invite_id') is not None:
+        role_invite = safe_query(db, RoleInvite, 'id', view_kwargs['role_invite_id'], 'role_invite_id')
+        if role_invite.event_id is not None:
+            view_kwargs['id'] = role_invite.event_id
+        else:
+            view_kwargs['id'] = None
+
+    if view_kwargs.get('users_events_role_id') is not None:
+        users_events_role = safe_query(db, UsersEventsRoles, 'id', view_kwargs['users_events_role_id'],
+                                       'users_events_role_id')
+        if users_events_role.event_id is not None:
+            view_kwargs['id'] = users_events_role.event_id
+
+    if view_kwargs.get('access_code_id') is not None:
+        access_code = safe_query(db, AccessCode, 'id', view_kwargs['access_code_id'], 'access_code_id')
+        if access_code.event_id is not None:
+            view_kwargs['id'] = access_code.event_id
+        else:
+            view_kwargs['id'] = None
+
+    if view_kwargs.get('speaker_id'):
+        try:
+            speaker = db.session.query(Speaker).filter_by(id=view_kwargs['speaker_id']).one()
+        except NoResultFound:
+            raise ObjectNotFound({'parameter': 'speaker_id'},
+                                 "Speaker: {} not found".format(view_kwargs['speaker_id']))
+        else:
+            if speaker.event_id:
+                view_kwargs['id'] = speaker.event_id
             else:
                 view_kwargs['id'] = None
 
-        if view_kwargs.get('social_link_id') is not None:
-            social_link = safe_query(self, SocialLink, 'id', view_kwargs['social_link_id'], 'social_link_id')
-            if social_link.event_id is not None:
-                view_kwargs['id'] = social_link.event_id
+    if view_kwargs.get('email_notification_id'):
+        try:
+            email_notification = db.session.query(EmailNotification).filter_by(
+                id=view_kwargs['email_notification_id']).one()
+        except NoResultFound:
+            raise ObjectNotFound({'parameter': 'email_notification_id'},
+                                 "Email Notification: {} not found".format(view_kwargs['email_notification_id']))
+        else:
+            if email_notification.event_id:
+                view_kwargs['id'] = email_notification.event_id
             else:
                 view_kwargs['id'] = None
 
-        if view_kwargs.get('tax_id') is not None:
-            tax = safe_query(self, Tax, 'id', view_kwargs['tax_id'], 'tax_id')
-            if tax.event_id is not None:
-                view_kwargs['id'] = tax.event_id
+    if view_kwargs.get('microlocation_id'):
+        try:
+            microlocation = db.session.query(Microlocation).filter_by(id=view_kwargs['microlocation_id']).one()
+        except NoResultFound:
+            raise ObjectNotFound({'parameter': 'microlocation_id'},
+                                 "Microlocation: {} not found".format(view_kwargs['microlocation_id']))
+        else:
+            if microlocation.event_id:
+                view_kwargs['id'] = microlocation.event_id
             else:
                 view_kwargs['id'] = None
 
-        if view_kwargs.get('user_id') is not None:
-            try:
-                discount_code = self.session.query(DiscountCode).filter_by(
-                    id=view_kwargs['discount_code_id']).one()
-            except NoResultFound:
-                raise ObjectNotFound({'parameter': 'discount_code_id'},
-                                     "DiscountCode: {} not found".format(view_kwargs['discount_code_id']))
-            else:
-                if discount_code.event_id is not None:
-                    view_kwargs['id'] = discount_code.event_id
-                else:
-                    view_kwargs['id'] = None
+    if view_kwargs.get('attendee_id'):
+        attendee = safe_query(db, TicketHolder, 'id', view_kwargs['attendee_id'], 'attendee_id')
+        if attendee.event_id is not None:
+            view_kwargs['id'] = attendee.event_id
+        else:
+            view_kwargs['id'] = None
 
-        if view_kwargs.get('speakers_call_id') is not None:
-            speakers_call = safe_query(self, SpeakersCall, 'id', view_kwargs['speakers_call_id'], 'speakers_call_id')
-            if speakers_call.event_id is not None:
-                view_kwargs['id'] = speakers_call.event_id
-            else:
-                view_kwargs['id'] = None
+    if view_kwargs.get('custom_form_id') is not None:
+        custom_form = safe_query(db, CustomForms, 'id', view_kwargs['custom_form_id'], 'custom_form_id')
+        if custom_form.event_id is not None:
+            view_kwargs['id'] = custom_form.event_id
+        else:
+            view_kwargs['id'] = None
 
-        if view_kwargs.get('ticket_id') is not None:
-            ticket = safe_query(self, Ticket, 'id', view_kwargs['ticket_id'], 'ticket_id')
-            if ticket.event_id is not None:
-                view_kwargs['id'] = ticket.event_id
-            else:
-                view_kwargs['id'] = None
+    return view_kwargs
 
-        if view_kwargs.get('ticket_tag_id') is not None:
-            ticket_tag = safe_query(self, TicketTag, 'id', view_kwargs['ticket_tag_id'], 'ticket_tag_id')
-            if ticket_tag.event_id is not None:
-                view_kwargs['id'] = ticket_tag.event_id
-            else:
-                view_kwargs['id'] = None
 
-        if view_kwargs.get('role_invite_id') is not None:
-            role_invite = safe_query(self, RoleInvite, 'id', view_kwargs['role_invite_id'], 'role_invite_id')
-            if role_invite.event_id is not None:
-                view_kwargs['id'] = role_invite.event_id
-            else:
-                view_kwargs['id'] = None
+class EventDetail(ResourceDetail):
+    def before_get(self, args, kwargs):
+        kwargs = get_id(kwargs)
+        if 'Authorization' in request.headers and has_access('is_coorganizer', event_id=kwargs['id']):
+            self.schema = EventSchema
+        else:
+            self.schema = EventSchemaPublic
 
-        if view_kwargs.get('users_events_role_id') is not None:
-            users_events_role = safe_query(self, UsersEventsRoles, 'id', view_kwargs['users_events_role_id'],
-                                           'users_events_role_id')
-            if users_events_role.event_id is not None:
-                view_kwargs['id'] = users_events_role.event_id
-
-        if view_kwargs.get('access_code_id') is not None:
-            access_code = safe_query(self, AccessCode, 'id', view_kwargs['access_code_id'], 'access_code_id')
-            if access_code.event_id is not None:
-                view_kwargs['id'] = access_code.event_id
-            else:
-                view_kwargs['id'] = None
-
-        if view_kwargs.get('speaker_id'):
-            try:
-                speaker = self.session.query(Speaker).filter_by(id=view_kwargs['speaker_id']).one()
-            except NoResultFound:
-                raise ObjectNotFound({'parameter': 'speaker_id'},
-                                     "Speaker: {} not found".format(view_kwargs['speaker_id']))
-            else:
-                if speaker.event_id:
-                    view_kwargs['id'] = speaker.event_id
-                else:
-                    view_kwargs['id'] = None
-
-        if view_kwargs.get('email_notification_id'):
-            try:
-                email_notification = self.session.query(EmailNotification).filter_by(
-                                     id=view_kwargs['email_notification_id']).one()
-            except NoResultFound:
-                raise ObjectNotFound({'parameter': 'email_notification_id'},
-                                     "Email Notification: {} not found".format(view_kwargs['email_notification_id']))
-            else:
-                if email_notification.event_id:
-                    view_kwargs['id'] = email_notification.event_id
-                else:
-                    view_kwargs['id'] = None
-
-        if view_kwargs.get('microlocation_id'):
-            try:
-                microlocation = self.session.query(Microlocation).filter_by(id=view_kwargs['microlocation_id']).one()
-            except NoResultFound:
-                raise ObjectNotFound({'parameter': 'microlocation_id'},
-                                     "Microlocation: {} not found".format(view_kwargs['microlocation_id']))
-            else:
-                if microlocation.event_id:
-                    view_kwargs['id'] = microlocation.event_id
-                else:
-                    view_kwargs['id'] = None
-
-        if view_kwargs.get('attendee_id'):
-            attendee = safe_query(self, TicketHolder, 'id', view_kwargs['attendee_id'], 'attendee_id')
-            if attendee.event_id is not None:
-                view_kwargs['id'] = attendee.event_id
-            else:
-                view_kwargs['id'] = None
-
-        if view_kwargs.get('custom_form_id') is not None:
-            custom_form = safe_query(self, CustomForms, 'id', view_kwargs['custom_form_id'], 'custom_form_id')
-            if custom_form.event_id is not None:
-                view_kwargs['id'] = custom_form.event_id
-            else:
-                view_kwargs['id'] = None
+    def before_get_object(self, view_kwargs):
+        get_id(view_kwargs)
 
         if view_kwargs.get('order_identifier') is not None:
             order = safe_query(self, Order, 'identifier', view_kwargs['order_identifier'], 'order_identifier')
@@ -271,7 +292,6 @@ class EventDetail(ResourceDetail):
                 view_kwargs['id'] = None
 
     def before_update_object(self, event, data, view_kwargs):
-
         if data.get('original_image_url') and data['original_image_url'] != event.original_image_url:
             uploaded_images = create_save_image_sizes(data['original_image_url'], 'event', event.id)
             data['original_image_url'] = uploaded_images['original_image_url']
@@ -294,7 +314,7 @@ class EventRelationship(ResourceRelationship):
 
     def before_get_object(self, view_kwargs):
         if view_kwargs.get('identifier'):
-            event = safe_query(self, Event, 'identifier', view_kwargs['identifier'], 'identifier')
+            event = safe_query(db, Event, 'identifier', view_kwargs['identifier'], 'identifier')
             view_kwargs['id'] = event.id
 
     decorators = (api.has_permission('is_coorganizer', fetch="id", fetch_as="event_id",

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -1,40 +1,32 @@
-import pytz
-
-from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-from pytz import timezone
-from sqlalchemy.orm.exc import NoResultFound
-from flask_rest_jsonapi.exceptions import ObjectNotFound
-from marshmallow import validates_schema
 from flask import request, current_app
-import marshmallow.validate as validate
 from flask_jwt import current_identity, _jwt_required
+from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
+from flask_rest_jsonapi.exceptions import ObjectNotFound
 from sqlalchemy import or_
+from sqlalchemy.orm.exc import NoResultFound
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
+from app.api.schema.events import EventSchema
 from app.models import db
-from app.models.event import Event
-from app.models.sponsor import Sponsor
-from app.models.track import Track
-from app.models.session import Session
-from app.models.speaker import Speaker
-from app.models.ticket import Ticket
-from app.models.session_type import SessionType
-from app.models.discount_code import DiscountCode
-from app.models.event_invoice import EventInvoice
-from app.models.speakers_call import SpeakersCall
-from app.models.role_invite import RoleInvite
-from app.models.custom_form import CustomForms
-from app.models.ticket import TicketTag
 from app.models.access_code import AccessCode
+from app.models.custom_form import CustomForms
+from app.models.discount_code import DiscountCode
+from app.models.event import Event
+from app.models.event_invoice import EventInvoice
+from app.models.role_invite import RoleInvite
+from app.models.session import Session
+from app.models.session_type import SessionType
+from app.models.speaker import Speaker
+from app.models.speakers_call import SpeakersCall
+from app.models.sponsor import Sponsor
+from app.models.ticket import Ticket
+from app.models.ticket import TicketTag
+from app.models.track import Track
 from app.models.user import User, ATTENDEE, ORGANIZER, COORGANIZER
 from app.models.users_events_role import UsersEventsRoles
 from app.models.role import Role
 from app.models.ticket_holder import TicketHolder
 from app.api.helpers.db import save_to_db, safe_query
-from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.files import create_save_image_sizes
 from app.models.microlocation import Microlocation
 from app.models.email_notification import EmailNotification
@@ -42,297 +34,6 @@ from app.models.social_link import SocialLink
 from app.models.tax import Tax
 from app.models.event_copyright import EventCopyright
 from app.models.order import Order
-
-
-class EventSchema(Schema):
-
-    class Meta:
-        type_ = 'event'
-        self_view = 'v1.event_detail'
-        self_view_kwargs = {'id': '<id>'}
-        self_view_many = 'v1.event_list'
-        inflect = dasherize
-
-    @validates_schema(pass_original=True)
-    def validate_date(self, data, original_data):
-        if 'id' in original_data['data']:
-            event = Event.query.filter_by(id=original_data['data']['id']).one()
-
-            if 'starts_at' not in data:
-                data['starts_at'] = event.starts_at
-
-            if 'ends_at' not in data:
-                data['ends_at'] = event.ends_at
-
-        if 'starts_at' not in data or 'ends_at' not in data:
-            raise UnprocessableEntity({'pointer': '/data/attributes/date'},
-                                      "enter required fields starts-at/ends-at")
-
-        if data['starts_at'] >= data['ends_at']:
-            raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'},
-                                      "ends-at should be after starts-at")
-
-    @validates_schema(pass_original=True)
-    def validate_timezone(self, data, original_data):
-        if 'id' in original_data['data']:
-            event = Event.query.filter_by(id=original_data['data']['id']).one()
-
-            if 'timezone' not in data:
-                data['timezone'] = event.timezone
-        try:
-            timezone(data['timezone'])
-        except pytz.exceptions.UnknownTimeZoneError:
-            raise UnprocessableEntity({'pointer': '/data/attributes/timezone'},
-                                      "Unknown timezone: '{}'".
-                                      format(data['timezone']))
-
-    id = fields.Str(dump_only=True)
-    identifier = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    external_event_url = fields.Url(allow_none=True)
-    starts_at = fields.DateTime(required=True, timezone=True)
-    ends_at = fields.DateTime(required=True, timezone=True)
-    timezone = fields.Str(required=True)
-    latitude = fields.Float(validate=lambda n: -90 <= n <= 90, allow_none=True)
-    longitude = fields.Float(validate=lambda n: -180 <= n <= 180, allow_none=True)
-    logo_url = fields.Url(allow_none=True)
-    location_name = fields.Str(allow_none=True)
-    searchable_location_name = fields.Str(allow_none=True)
-    description = fields.Str(allow_none=True)
-    original_image_url = fields.Url(allow_none=True)
-    thumbnail_image_url = fields.Url(dump_only=True)
-    large_image_url = fields.Url(dump_only=True)
-    icon_image_url = fields.Url(dump_only=True)
-    organizer_name = fields.Str(allow_none=True)
-    is_map_shown = fields.Bool(default=False)
-    has_organizer_info = fields.Bool(default=False)
-    organizer_description = fields.Str(allow_none=True)
-    is_sessions_speakers_enabled = fields.Bool(default=False)
-    privacy = fields.Str(default="public")
-    state = fields.Str(validate=validate.OneOf(choices=["published", "draft"]), allow_none=True, default='draft')
-    ticket_url = fields.Url(allow_none=True)
-    code_of_conduct = fields.Str(allow_none=True)
-    schedule_published_on = fields.DateTime(allow_none=True)
-    is_ticketing_enabled = fields.Bool(default=True)
-    deleted_at = fields.DateTime(allow_none=True)
-    payment_country = fields.Str(allow_none=True)
-    payment_currency = fields.Str(allow_none=True)
-    paypal_email = fields.Str(allow_none=True)
-    is_tax_enabled = fields.Bool(default=False)
-    can_pay_by_paypal = fields.Bool(default=False)
-    can_pay_by_stripe = fields.Bool(default=False)
-    can_pay_by_cheque = fields.Bool(default=False)
-    can_pay_by_bank = fields.Bool(default=False)
-    can_pay_onsite = fields.Bool(default=False)
-    cheque_details = fields.Str(allow_none=True)
-    bank_details = fields.Str(allow_none=True)
-    onsite_details = fields.Str(allow_none=True)
-    is_sponsors_enabled = fields.Bool(default=False)
-    created_at = fields.DateTime(dump_only=True, timezone=True)
-    pentabarf_url = fields.Url(dump_only=True)
-    ical_url = fields.Url(dump_only=True)
-    xcal_url = fields.Url(dump_only=True)
-    tickets = Relationship(attribute='tickets',
-                           self_view='v1.event_ticket',
-                           self_view_kwargs={'id': '<id>'},
-                           related_view='v1.ticket_list',
-                           related_view_kwargs={'event_id': '<id>'},
-                           schema='TicketSchema',
-                           many=True,
-                           type_='ticket')
-    ticket_tags = Relationship(attribute='ticket_tags',
-                               self_view='v1.event_ticket_tag',
-                               self_view_kwargs={'id': '<id>'},
-                               related_view='v1.ticket_tag_list',
-                               related_view_kwargs={'event_id': '<id>'},
-                               schema='TicketTagSchema',
-                               many=True,
-                               type_='ticket-tag')
-    microlocations = Relationship(attribute='microlocation',
-                                  self_view='v1.event_microlocation',
-                                  self_view_kwargs={'id': '<id>'},
-                                  related_view='v1.microlocation_list',
-                                  related_view_kwargs={'event_id': '<id>'},
-                                  schema='MicrolocationSchema',
-                                  many=True,
-                                  type_='microlocation')
-    social_links = Relationship(attribute='social_link',
-                                self_view='v1.event_social_link',
-                                self_view_kwargs={'id': '<id>'},
-                                related_view='v1.social_link_list',
-                                related_view_kwargs={'event_id': '<id>'},
-                                schema='SocialLinkSchema',
-                                many=True,
-                                type_='social-link')
-    tracks = Relationship(attribute='track',
-                          self_view='v1.event_tracks',
-                          self_view_kwargs={'id': '<id>'},
-                          related_view='v1.track_list',
-                          related_view_kwargs={'event_id': '<id>'},
-                          schema='TrackSchema',
-                          many=True,
-                          type_='track')
-    sponsors = Relationship(attribute='sponsor',
-                            self_view='v1.event_sponsor',
-                            self_view_kwargs={'id': '<id>'},
-                            related_view='v1.sponsor_list',
-                            related_view_kwargs={'event_id': '<id>'},
-                            schema='SponsorSchema',
-                            many=True,
-                            type_='sponsor')
-    speakers_call = Relationship(attribute='speakers_call',
-                                 self_view='v1.event_speakers_call',
-                                 self_view_kwargs={'id': '<id>'},
-                                 related_view='v1.speakers_call_detail',
-                                 related_view_kwargs={'event_id': '<id>'},
-                                 schema='SpeakersCallSchema',
-                                 type_='speakers-call')
-    session_types = Relationship(attribute='session_type',
-                                 self_view='v1.event_session_types',
-                                 self_view_kwargs={'id': '<id>'},
-                                 related_view='v1.session_type_list',
-                                 related_view_kwargs={'event_id': '<id>'},
-                                 schema='SessionTypeSchema',
-                                 many=True,
-                                 type_='session-type')
-    event_copyright = Relationship(attribute='copyright',
-                                   self_view='v1.event_copyright',
-                                   self_view_kwargs={'id': '<id>'},
-                                   related_view='v1.event_copyright_detail',
-                                   related_view_kwargs={'event_id': '<id>'},
-                                   schema='EventCopyrightSchema',
-                                   type_='event-copyright')
-    tax = Relationship(self_view='v1.event_tax',
-                       self_view_kwargs={'id': '<id>'},
-                       related_view='v1.tax_detail',
-                       related_view_kwargs={'event_id': '<id>'},
-                       schema='TaxSchema',
-                       type_='tax')
-    event_invoices = Relationship(attribute='invoices',
-                                  self_view='v1.event_event_invoice',
-                                  self_view_kwargs={'id': '<id>'},
-                                  related_view='v1.event_invoice_list',
-                                  related_view_kwargs={'event_id': '<id>'},
-                                  schema='EventInvoiceSchema',
-                                  many=True,
-                                  type_='event-invoice')
-    discount_codes = Relationship(attribute='discount_code',
-                                  self_view='v1.event_discount_code',
-                                  self_view_kwargs={'id': '<id>'},
-                                  related_view='v1.discount_code_list',
-                                  related_view_kwargs={'event_id': '<id>'},
-                                  schema='DiscountCodeSchema',
-                                  type_='discount-code')
-    sessions = Relationship(attribute='session',
-                            self_view='v1.event_session',
-                            self_view_kwargs={'id': '<id>'},
-                            related_view='v1.session_list',
-                            related_view_kwargs={'event_id': '<id>'},
-                            schema='SessionSchema',
-                            many=True,
-                            type_='session')
-    speakers = Relationship(attribute='speaker',
-                            self_view='v1.event_speaker',
-                            self_view_kwargs={'id': '<id>'},
-                            related_view='v1.speaker_list',
-                            related_view_kwargs={'event_id': '<id>'},
-                            schema='SpeakerSchema',
-                            many=True,
-                            type_='speaker')
-    event_type = Relationship(attribute='event_type',
-                              self_view='v1.event_event_type',
-                              self_view_kwargs={'id': '<id>'},
-                              related_view='v1.event_type_detail',
-                              related_view_kwargs={'event_id': '<id>'},
-                              schema='EventTypeSchema',
-                              type_='event-type')
-    event_topic = Relationship(attribute='event_topic',
-                               self_view='v1.event_event_topic',
-                               self_view_kwargs={'id': '<id>'},
-                               related_view='v1.event_topic_detail',
-                               related_view_kwargs={'event_id': '<id>'},
-                               schema='EventTopicSchema',
-                               type_='event-topic')
-    event_sub_topic = Relationship(attribute='event_sub_topic',
-                                   self_view='v1.event_event_sub_topic',
-                                   self_view_kwargs={'id': '<id>'},
-                                   related_view='v1.event_sub_topic_detail',
-                                   related_view_kwargs={'event_id': '<id>'},
-                                   schema='EventSubTopicSchema',
-                                   type_='event-sub-topic')
-    role_invites = Relationship(attribute='role_invites',
-                                self_view='v1.event_role_invite',
-                                self_view_kwargs={'id': '<id>'},
-                                related_view='v1.role_invite_list',
-                                related_view_kwargs={'event_id': '<id>'},
-                                schema='RoleInviteSchema',
-                                type_='role-invite')
-    access_codes = Relationship(attribute='access_codes',
-                                self_view='v1.event_access_codes',
-                                self_view_kwargs={'id': '<id>'},
-                                related_view='v1.access_code_list',
-                                related_view_kwargs={'event_id': '<id>'},
-                                schema='AccessCodeSchema',
-                                many=True,
-                                type_='access-code')
-    attendees = Relationship(attribute='attendees',
-                             self_view='v1.event_attendees',
-                             self_view_kwargs={'id': '<id>'},
-                             related_view='v1.attendee_list',
-                             related_view_kwargs={'event_id': '<id>'},
-                             schema='AttendeeSchema',
-                             many=True,
-                             type_='attendee')
-    custom_forms = Relationship(attribute='custom_form',
-                                self_view='v1.event_custom_forms',
-                                self_view_kwargs={'id': '<id>'},
-                                related_view='v1.custom_form_list',
-                                related_view_kwargs={'event_id': '<id>'},
-                                schema='CustomFormSchema',
-                                many=True,
-                                type_='custom-form')
-    organizers = Relationship(attribute='organizers',
-                              self_view='v1.event_organizers',
-                              self_view_kwargs={'id': '<id>'},
-                              related_view='v1.user_list',
-                              schema='UserSchema',
-                              type_='user',
-                              many=True)
-    coorganizers = Relationship(attribute='coorganizers',
-                                self_view='v1.event_coorganizers',
-                                self_view_kwargs={'id': '<id>'},
-                                related_view='v1.user_list',
-                                schema='UserSchema',
-                                type_='user',
-                                many=True)
-    track_organizers = Relationship(attribute='track_organizers',
-                                    self_view='v1.event_track_organizers',
-                                    self_view_kwargs={'id': '<id>'},
-                                    related_view='v1.user_list',
-                                    schema='UserSchema',
-                                    type_='user',
-                                    many=True)
-    moderators = Relationship(attribute='moderators',
-                              self_view='v1.event_moderators',
-                              self_view_kwargs={'id': '<id>'},
-                              related_view='v1.user_list',
-                              schema='UserSchema',
-                              type_='user',
-                              many=True)
-    registrars = Relationship(attribute='registrars',
-                              self_view='v1.event_registrars',
-                              self_view_kwargs={'id': '<id>'},
-                              related_view='v1.user_list',
-                              schema='UserSchema',
-                              type_='user',
-                              many=True)
-    orders = Relationship(attribute='orders',
-                          self_view='v1.event_orders',
-                          self_view_kwargs={'id': '<id>'},
-                          related_view='v1.orders_list',
-                          schema='OrderSchema',
-                          type_='order',
-                          many=True)
 
 
 class EventList(ResourceList):

--- a/app/api/image_sizes.py
+++ b/app/api/image_sizes.py
@@ -1,42 +1,9 @@
-from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
+from flask_rest_jsonapi import ResourceDetail, ResourceList
 
-from app.api.helpers.utilities import dasherize
-from app.models import db
 from app.api.bootstrap import api
+from app.api.schema.image_sizes import ImageSizeSchema
+from app.models import db
 from app.models.image_size import ImageSizes
-
-
-class ImageSizeSchema(Schema):
-    """
-    Api schema for image_size Model
-    """
-    class Meta:
-        """
-        Meta class for image_size Api Schema
-        """
-        type_ = 'image-size'
-        self_view = 'v1.image_size_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    type = fields.Str(allow_none=True)
-    full_width = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    full_height = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    full_aspect = fields.Boolean(default=False)
-    full_quality = fields.Integer(validate=lambda n: 0 <= n <= 100, allow_none=True)
-    icon_width = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    icon_height = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    icon_aspect = fields.Boolean(default=False)
-    icon_quality = fields.Integer(validate=lambda n: 0 <= n <= 100, allow_none=True)
-    thumbnail_width = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    thumbnail_height = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    thumbnail_aspect = fields.Boolean(default=False)
-    thumbnail_quality = fields.Integer(validate=lambda n: 0 <= n <= 100, allow_none=True)
-    logo_width = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    logo_height = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
 
 
 class ImageSizeList(ResourceList):

--- a/app/api/imports.py
+++ b/app/api/imports.py
@@ -1,6 +1,5 @@
 from flask import jsonify, url_for, current_app, Blueprint, abort
 from flask_jwt import jwt_required, current_identity
-from sqlalchemy.ext.serializer import dumps
 
 from app.api.helpers.import_helpers import get_file_from_request, import_event_json, create_import_job
 from app.api.helpers.utilities import TASK_RESULTS

--- a/app/api/mails.py
+++ b/app/api/mails.py
@@ -1,33 +1,9 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList
-from marshmallow_jsonapi.flask import Schema
-from marshmallow_jsonapi import fields
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
+from app.api.schema.mails import MailSchema
 from app.models import db
 from app.models.mail import Mail
-
-
-class MailSchema(Schema):
-    """
-    Api schema for mail Model
-    """
-    class Meta:
-        """
-        Meta class for mail Api Schema
-        """
-        type_ = 'mail'
-        self_view = 'v1.mail_detail'
-        self_view_kwargs = {'id': '<id>'}
-        self_view_many = 'v1.mail_list'
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    recipient = fields.Email(dump_only=True)
-    time = fields.DateTime(dump_only=True)
-    action = fields.Str(dump_only=True)
-    subject = fields.Str(dump_only=True)
-    message = fields.Str(dump_only=True)
 
 
 class MailList(ResourceList):

--- a/app/api/microlocations.py
+++ b/app/api/microlocations.py
@@ -1,55 +1,15 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
+from app.api.helpers.db import safe_query
+from app.api.helpers.exceptions import ForbiddenException
+from app.api.helpers.permission_manager import has_access
+from app.api.helpers.query import event_query
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.microlocations import MicrolocationSchema
 from app.models import db
 from app.models.microlocation import Microlocation
 from app.models.session import Session
-from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.permission_manager import has_access
-from app.api.helpers.exceptions import ForbiddenException
-from app.api.helpers.query import event_query
-
-
-class MicrolocationSchema(Schema):
-    """
-    Api schema for Microlocation Model
-    """
-
-    class Meta:
-        """
-        Meta class for Microlocation Api Schema
-        """
-        type_ = 'microlocation'
-        self_view = 'v1.microlocation_detail'
-        self_view_kwargs = {'id': '<id>'}
-        self_view_many = 'v1.microlocation_list_post'
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    latitude = fields.Float(validate=lambda n: -90 <= n <= 90, allow_none=True)
-    longitude = fields.Float(validate=lambda n: -180 <= n <= 180, allow_none=True)
-    floor = fields.Integer(allow_none=True)
-    room = fields.Str(allow_none=True)
-    sessions = Relationship(attribute='session',
-                            many=True,
-                            self_view='v1.microlocation_session',
-                            self_view_kwargs={'id': '<id>'},
-                            related_view='v1.session_list',
-                            related_view_kwargs={'microlocation_id': '<id>'},
-                            schema='SessionSchema',
-                            type_='session')
-    event = Relationship(attribute='event',
-                         self_view='v1.microlocation_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'microlocation_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
 
 
 class MicrolocationListPost(ResourceList):

--- a/app/api/modules.py
+++ b/app/api/modules.py
@@ -1,30 +1,9 @@
 from flask_rest_jsonapi import ResourceDetail
-from marshmallow_jsonapi.flask import Schema
-from marshmallow_jsonapi import fields
 
-from app.api.helpers.utilities import dasherize
+from app.api.bootstrap import api
+from app.api.schema.modules import ModuleSchema
 from app.models import db
 from app.models.module import Module
-from app.api.bootstrap import api
-
-
-class ModuleSchema(Schema):
-    """
-    Admin Api schema for modules Model
-    """
-    class Meta:
-        """
-        Meta class for module Api Schema
-        """
-        type_ = 'module'
-        self_view = 'v1.module_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    ticket_include = fields.Boolean(default=False)
-    payment_include = fields.Boolean(default=False)
-    donation_include = fields.Boolean(default=False)
 
 
 class ModuleDetail(ResourceDetail):

--- a/app/api/notifications.py
+++ b/app/api/notifications.py
@@ -1,44 +1,11 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-from app.api.bootstrap import api
 
-from app.api.helpers.utilities import dasherize
+from app.api.bootstrap import api
+from app.api.helpers.db import safe_query
+from app.api.schema.notifications import NotificationSchema
 from app.models import db
 from app.models.notification import Notification
 from app.models.user import User
-from app.api.helpers.db import safe_query
-
-
-class NotificationSchema(Schema):
-    """
-    API Schema for Notification Model
-    """
-
-    class Meta:
-        """
-        Meta class for Notification API schema
-        """
-        type_ = 'notification'
-        self_view = 'v1.notification_detail'
-        self_view_kwargs = {'id': '<id>'}
-        self_view_many = 'v1.microlocation_list_post'
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    title = fields.Str(allow_none=True, dump_only=True)
-    message = fields.Str(allow_none=True, dump_only=True)
-    received_at = fields.DateTime(dump_only=True)
-    accept = fields.Str(allow_none=True, dump_only=True)
-    is_read = fields.Boolean()
-    user = Relationship(attribute='user',
-                        self_view='v1.notification_user',
-                        self_view_kwargs={'id': '<id>'},
-                        related_view='v1.user_detail',
-                        related_view_kwargs={'notification_id': '<id>'},
-                        schema='UserSchema',
-                        type_='user'
-                        )
 
 
 class NotificationListAdmin(ResourceList):

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from flask import request, render_template
-from flask import request
 from flask_jwt import current_identity as current_user
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
 from marshmallow_jsonapi import fields

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -1,11 +1,10 @@
 from datetime import datetime
-
 from flask import request, render_template
-from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-from marshmallow import post_dump, validates_schema, validate
+from flask import request
 from flask_jwt import current_identity as current_user
+from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
 
 from app.api.bootstrap import api
 from app.api.data_layers.ChargesLayer import ChargesLayer
@@ -13,104 +12,14 @@ from app.api.helpers.db import save_to_db, safe_query
 from app.api.helpers.exceptions import ForbiddenException, UnprocessableEntity
 from app.api.helpers.files import create_save_pdf
 from app.api.helpers.mail import send_email_to_attendees
-from app.api.helpers.payment import PayPalPaymentsManager
-from app.api.helpers.ticketing import TicketingManager
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.permissions import jwt_required
+from app.api.helpers.ticketing import TicketingManager
 from app.api.helpers.utilities import dasherize, require_relationship
+from app.api.schema.orders import OrderSchema
 from app.models import db
 from app.models.discount_code import DiscountCode, TICKET
 from app.models.order import Order, OrderTicket
-
-
-class OrderSchema(Schema):
-    class Meta:
-        type_ = 'order'
-        self_view = 'v1.order_detail'
-        self_view_kwargs = {'order_identifier': '<identifier>'}
-        inflect = dasherize
-
-    @post_dump
-    def generate_payment_url(self, data):
-        if 'POST' in request.method or ('GET' in request.method and 'regenerate' in request.args) and 'completed' != \
-           data["status"]:
-            if data['payment_mode'] == 'stripe':
-                data['payment_url'] = 'stripe://payment'
-            elif data['payment_mode'] == 'paypal':
-                order = Order.query.filter_by(id=data['id']).first()
-                data['payment_url'] = PayPalPaymentsManager.get_checkout_url(order)
-        return data
-
-    @validates_schema
-    def initial_values(self, data):
-        if data.get('payment_mode') is None and 'POST' in request.method:
-            data['payment_mode'] = 'free'
-        return data
-
-    id = fields.Str(dump_only=True)
-    identifier = fields.Str(dump_only=True)
-    amount = fields.Float(validate=lambda n: n > 0)
-    address = fields.Str()
-    city = fields.Str()
-    state = fields.Str(db.String)
-    country = fields.Str(required=True)
-    zipcode = fields.Str()
-    completed_at = fields.DateTime(dump_only=True)
-    transaction_id = fields.Str(dump_only=True)
-    payment_mode = fields.Str(default="free", required=True)
-    paid_via = fields.Str(dump_only=True)
-    brand = fields.Str(dump_only=True)
-    exp_month = fields.Str(dump_only=True)
-    exp_year = fields.Str(dump_only=True)
-    last4 = fields.Str(dump_only=True)
-    status = fields.Str(validate=validate.OneOf(choices=["pending", "cancelled", "confirmed", "deleted"]))
-    discount_code_id = fields.Str()
-    payment_url = fields.Str(dump_only=True)
-
-    attendees = Relationship(attribute='ticket_holders',
-                             self_view='v1.order_attendee',
-                             self_view_kwargs={'order_identifier': '<identifier>'},
-                             related_view='v1.attendee_list',
-                             related_view_kwargs={'order_id': '<id>'},
-                             schema='AttendeeSchema',
-                             many=True,
-                             type_='attendee')
-
-    tickets = Relationship(self_view='v1.order_ticket',
-                           self_view_kwargs={'order_identifier': '<identifier>'},
-                           related_view='v1.ticket_list',
-                           related_view_kwargs={'order_id': '<id>'},
-                           schema='TicketSchema',
-                           many=True,
-                           type_="ticket")
-
-    user = Relationship(self_view='v1.order_user',
-                        self_view_kwargs={'order_identifier': '<identifier>'},
-                        related_view='v1.user_detail',
-                        related_view_kwargs={'id': '<user_id>'},
-                        schema='UserSchema',
-                        type_="user")
-
-    event = Relationship(self_view='v1.order_event',
-                         self_view_kwargs={'order_identifier': '<identifier>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'id': '<event_id>'},
-                         schema='EventSchema',
-                         type_="event")
-
-    marketer = Relationship(self_view='v1.order_marketer',
-                            self_view_kwargs={'order_identifier': '<identifier>'},
-                            related_view='v1.user_detail',
-                            related_view_kwargs={'id': '<marketer_id>'},
-                            schema='UserSchema',
-                            type_="user")
-
-    discount_code = Relationship(self_view='v1.order_discount',
-                                 self_view_kwargs={'order_identifier': '<identifier>'},
-                                 related_view='v1.discount_code_detail',
-                                 related_view_kwargs={'id': '<discount_code_id>'},
-                                 schema='DiscountCodeSchema',
-                                 type_="discount-code")
 
 
 class OrdersListPost(ResourceList):

--- a/app/api/pages.py
+++ b/app/api/pages.py
@@ -1,35 +1,9 @@
-from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-import marshmallow.validate as validate
+from flask_rest_jsonapi import ResourceDetail, ResourceList
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
+from app.api.schema.pages import PageSchema
 from app.models import db
 from app.models.page import Page
-
-
-class PageSchema(Schema):
-    """
-    Api schema for page Model
-    """
-    class Meta:
-        """
-        Meta class for page Api Schema
-        """
-        type_ = 'page'
-        self_view = 'v1.page_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    title = fields.Str(allow_none=True)
-    url = fields.String(required=True)
-    description = fields.Str(allow_none=True)
-    place = fields.Str(validate=validate.OneOf(choices=["footer", "event"]), allow_none=True)
-    language = fields.Str(allow_none=True)
-    index = fields.Integer(default=0)
 
 
 class PageList(ResourceList):

--- a/app/api/role_invites.py
+++ b/app/api/role_invites.py
@@ -1,80 +1,21 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-import marshmallow.validate as validate
-from marshmallow import validates_schema
 
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.settings import get_settings
-from app.models.event import Event
-from app.models.role_invite import RoleInvite
-from app.models.users_events_role import UsersEventsRoles
-from app.models.role import Role
-from app.models.user import User
 from app.api.bootstrap import api
 from app.api.helpers.db import save_to_db
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.permission_manager import has_access
-from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.exceptions import ForbiddenException
-from app.api.helpers.query import event_query
+from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.mail import send_email_role_invite
-
-
-class RoleInviteSchema(Schema):
-    """
-    Api Schema for role invite model
-    """
-
-    class Meta:
-        """
-        Meta class for role invite Api Schema
-        """
-        type_ = 'role-invite'
-        self_view = 'v1.role_invite_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    @validates_schema(pass_original=True)
-    def validate_satus(self, data, original_data):
-        if 'role' in data and 'role_name' in data:
-            role = Role.query.filter_by(id=data['role']).one()
-            if role.name != data['role_name']:
-                raise UnprocessableEntity({'pointer': '/data/attributes/role'},
-                                          "Role id do not match role name")
-        if 'id' in original_data['data']:
-            role_invite = RoleInvite.query.filter_by(id=original_data['data']['id']).one()
-            if 'role' not in data:
-                data['role'] = role_invite.role.id
-            if 'role_name' in data:
-                role = Role.query.filter_by(id=data['role']).one()
-                if role.name != data['role_name']:
-                    raise UnprocessableEntity({'pointer': '/data/attributes/role'},
-                                              "Role id do not match role name")
-
-    id = fields.Str(dump_only=True)
-    email = fields.Str(required=True)
-    hash = fields.Str(dump_only=True)
-    created_at = fields.DateTime(dump_only=True, timezone=True)
-    role_name = fields.Str(validate=validate.OneOf(choices=["organizer", "coorganizer", "track_organizer",
-                           "moderator", "attendee", "registrar"]))
-    status = fields.Str(validate=validate.OneOf(choices=["pending", "accepted", "declined"]),
-                        default="pending")
-    event = Relationship(attribute='event',
-                         self_view='v1.role_invite_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'role_invite_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
-    role = Relationship(attribute='role',
-                        self_view='v1.role_invite_role',
-                        self_view_kwargs={'id': '<id>'},
-                        related_view='v1.role_detail',
-                        related_view_kwargs={'role_invite_id': '<id>'},
-                        schema='RoleSchema',
-                        type_='role')
+from app.api.helpers.permission_manager import has_access
+from app.api.helpers.query import event_query
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.role_invites import RoleInviteSchema
+from app.models import db
+from app.models.event import Event
+from app.models.role import Role
+from app.models.role_invite import RoleInvite
+from app.models.user import User
+from app.models.users_events_role import UsersEventsRoles
+from app.settings import get_settings
 
 
 class RoleInviteListPost(ResourceList):

--- a/app/api/roles.py
+++ b/app/api/roles.py
@@ -1,32 +1,12 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList
-from marshmallow_jsonapi.flask import Schema
-from marshmallow_jsonapi import fields
 
-from app.api.helpers.utilities import dasherize
-from app.models import db
 from app.api.bootstrap import api
+from app.api.helpers.db import safe_query
+from app.api.schema.roles import RoleSchema
+from app.models import db
 from app.models.role import Role
 from app.models.role_invite import RoleInvite
 from app.models.users_events_role import UsersEventsRoles
-from app.api.helpers.db import safe_query
-
-
-class RoleSchema(Schema):
-    """
-    Api schema for role Model
-    """
-    class Meta:
-        """
-        Meta class for role Api Schema
-        """
-        type_ = 'role'
-        self_view = 'v1.role_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    title_name = fields.Str(allow_none=True)
 
 
 class RoleList(ResourceList):

--- a/app/api/schema/access_codes.py
+++ b/app/api/schema/access_codes.py
@@ -1,0 +1,85 @@
+from marshmallow import validates_schema
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.exceptions import UnprocessableEntity
+from app.api.helpers.utilities import dasherize
+from app.models.access_code import AccessCode
+
+
+class AccessCodeSchema(Schema):
+    """
+    Api schema for Access Code Model
+    """
+
+    class Meta:
+        """
+        Meta class for Access Code Api Schema
+        """
+        type_ = 'access-code'
+        self_view = 'v1.access_code_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    @validates_schema(pass_original=True)
+    def validate_date(self, data, original_data):
+        if 'id' in original_data['data']:
+            access_code = AccessCode.query.filter_by(id=original_data['data']['id']).one()
+
+            if 'valid_from' not in data:
+                data['valid_from'] = access_code.valid_from
+
+            if 'valid_till' not in data:
+                data['valid_till'] = access_code.valid_till
+
+        if data['valid_from'] >= data['valid_till']:
+            raise UnprocessableEntity({'pointer': '/data/attributes/valid-till'},
+                                      "valid_till should be after valid_from")
+
+    @validates_schema
+    def validate_order_quantity(self, data):
+        if 'max_order' in data and 'min_order' in data:
+            if data['max_order'] < data['min_order']:
+                raise UnprocessableEntity({'pointer': '/data/attributes/max-order'},
+                                          "max-order should be greater than min-order")
+
+        if 'quantity' in data and 'min_order' in data:
+            if data['quantity'] < data['min_order']:
+                raise UnprocessableEntity({'pointer': '/data/attributes/quantity'},
+                                          "quantity should be greater than min-order")
+
+    id = fields.Integer(dump_only=True)
+    code = fields.Str(allow_none=True)
+    access_url = fields.Url(allow_none=True)
+    is_active = fields.Boolean(default=False)
+
+    # For event level access this holds the max. uses
+    tickets_number = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+
+    min_quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    max_quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    valid_from = fields.DateTime(required=True)
+    valid_till = fields.DateTime(required=True)
+    used_for = fields.Str(allow_none=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.access_code_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'access_code_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    marketer = Relationship(attribute='user',
+                            self_view='v1.access_code_user',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.user_detail',
+                            related_view_kwargs={'access_code_id': '<id>'},
+                            schema='UserSchema',
+                            type_='user')
+    tickets = Relationship(attribute='tickets',
+                           self_view='v1.access_code_tickets',
+                           self_view_kwargs={'id': '<id>'},
+                           related_view='v1.ticket_list',
+                           related_view_kwargs={'access_code_id': '<id>'},
+                           schema='TicketSchema',
+                           many=True,
+                           type_='ticket')

--- a/app/api/schema/activities.py
+++ b/app/api/schema/activities.py
@@ -1,0 +1,23 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app.api.helpers.utilities import dasherize
+
+
+class ActivitySchema(Schema):
+    """
+    Api schema for Activity Model
+    """
+    class Meta:
+        """
+        Meta class for Activity Api Schema
+        """
+        type_ = 'activity'
+        self_view = 'v1.activity_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    actor = fields.Str(allow_none=True)
+    time = fields.DateTime(allow_none=True)
+    action = fields.Str(allow_none=True)

--- a/app/api/schema/attendees.py
+++ b/app/api/schema/attendees.py
@@ -1,0 +1,45 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class AttendeeSchema(Schema):
+    """
+    Api schema for Ticket Holder Model
+    """
+
+    class Meta:
+        """
+        Meta class for Attendee API Schema
+        """
+        type_ = 'attendee'
+        self_view = 'v1.attendee_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    firstname = fields.Str(required=True)
+    lastname = fields.Str(allow_none=True)
+    email = fields.Str(allow_none=True)
+    address = fields.Str(allow_none=True)
+    city = fields.Str(allow_none=True)
+    state = fields.Str(allow_none=True)
+    country = fields.Str(allow_none=True)
+    ticket_id = fields.Str(allow_none=True)
+    is_checked_in = fields.Boolean()
+    pdf_url = fields.Url(required=True)
+    ticket = Relationship(attribute='ticket',
+                          self_view='v1.attendee_ticket',
+                          self_view_kwargs={'id': '<id>'},
+                          related_view='v1.ticket_detail',
+                          related_view_kwargs={'attendee_id': '<id>'},
+                          schema='TicketSchema',
+                          type_='ticket')
+    event = Relationship(attribute='event',
+                         self_view='v1.attendee_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'attendee_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')

--- a/app/api/schema/custom_forms.py
+++ b/app/api/schema/custom_forms.py
@@ -1,0 +1,35 @@
+from marshmallow import validate as validate
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class CustomFormSchema(Schema):
+    """
+    API Schema for Custom Forms database model
+    """
+    class Meta:
+        """
+        Meta class for CustomForm Schema
+        """
+        type_ = 'custom-form'
+        self_view = 'v1.custom_form_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Integer(dump_only=True)
+    field_identifier = fields.Str(required=True)
+    form = fields.Str(required=True)
+    type = fields.Str(default="text", validate=validate.OneOf(
+        choices=["text", "checkbox", "select", "file", "image", "email"]))
+    is_required = fields.Boolean(default=False)
+    is_included = fields.Boolean(default=False)
+    is_fixed = fields.Boolean(default=False)
+    event = Relationship(attribute='event',
+                         self_view='v1.custom_form_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'custom_form_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')

--- a/app/api/schema/custom_placeholders.py
+++ b/app/api/schema/custom_placeholders.py
@@ -1,0 +1,29 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class CustomPlaceholderSchema(Schema):
+    class Meta:
+        type_ = 'custom-placeholder'
+        self_view = 'v1.custom_placeholder_detail'
+        self_view_kwargs = {'id': '<id>'}
+        self_view_many = 'v1.custom_placeholder_list'
+        inflect = dasherize
+
+    id = fields.Integer(dump_only=True)
+    name = fields.String(required=True)
+    original_image_url = fields.Url(required=True)
+    thumbnail_image_url = fields.Url(dump_only=True)
+    large_image_url = fields.Url(dump_only=True)
+    icon_image_url = fields.Url(dump_only=True)
+    copyright = fields.String(allow_none=True)
+    origin = fields.String(allow_none=True)
+    event_sub_topic = Relationship(attribute='event_sub_topic',
+                                   self_view='v1.custom_placeholder_event_sub_topic',
+                                   self_view_kwargs={'id': '<id>'},
+                                   related_view='v1.event_sub_topic_detail',
+                                   related_view_kwargs={'custom_placeholder_id': '<id>'},
+                                   schema='EventSubTopicSchema',
+                                   type_='event-sub-topic')

--- a/app/api/schema/discount_codes.py
+++ b/app/api/schema/discount_codes.py
@@ -1,0 +1,128 @@
+from marshmallow import validates_schema, validate, validate, validate, validate
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.exceptions import UnprocessableEntity
+from app.api.helpers.utilities import dasherize
+from app.models.discount_code import DiscountCode
+
+
+class DiscountCodeSchemaTicket(Schema):
+    """
+    API Schema for discount_code Model
+    """
+
+    class Meta:
+        type_ = 'discount-code'
+        self_view = 'v1.discount_code_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    @validates_schema(pass_original=True)
+    def validate_quantity(self, data, original_data):
+        if 'id' in original_data['data']:
+            discount_code = DiscountCode.query.filter_by(id=original_data['data']['id']).one()
+            if 'min_quantity' not in data:
+                data['min_quantity'] = discount_code.min_quantity
+
+            if 'max_quantity' not in data:
+                data['max_quantity'] = discount_code.max_quantity
+
+            if 'tickets_number' not in data:
+                data['tickets_number'] = discount_code.tickets_number
+
+        if 'min_quantity' in data and 'max_quantity' in data:
+            if data['min_quantity'] >= data['max_quantity']:
+                raise UnprocessableEntity({'pointer': '/data/attributes/min-quantity'},
+                                          "min-quantity should be less than max-quantity")
+
+        if 'tickets_number' in data and 'max_quantity' in data:
+            if data['tickets_number'] < data['max_quantity']:
+                raise UnprocessableEntity({'pointer': '/data/attributes/tickets-number'},
+                                          "tickets-number should be greater than max-quantity")
+
+    id = fields.Integer()
+    code = fields.Str(required=True)
+    discount_url = fields.Url(allow_none=True)
+    value = fields.Float(required=True)
+    type = fields.Str(validate=validate.OneOf(choices=["amount", "percent"]), required=True)
+    is_active = fields.Boolean()
+    tickets_number = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    min_quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    max_quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    valid_from = fields.DateTime(allow_none=True)
+    valid_till = fields.DateTime(allow_none=True)
+    tickets = fields.Str(validate=validate.OneOf(choices=["event", "ticket"]), allow_none=True)
+    created_at = fields.DateTime(allow_none=True)
+    used_for = fields.Str(required=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.discount_code_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'discount_code_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    marketer = Relationship(attribute='user',
+                            self_view='v1.discount_code_user',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.user_detail',
+                            related_view_kwargs={'discount_code_id': '<id>'},
+                            schema='UserSchema',
+                            type_='user')
+
+
+class DiscountCodeSchemaEvent(Schema):
+    """
+    API Schema for discount_code Model
+    """
+
+    class Meta:
+        type_ = 'discount-code'
+        self_view = 'v1.discount_code_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    @validates_schema(pass_original=True)
+    def validate_quantity(self, data, original_data):
+        if 'id' in original_data['data']:
+            discount_code = DiscountCode.query.filter_by(id=original_data['data']['id']).one()
+            if 'min_quantity' not in data:
+                data['min_quantity'] = discount_code.min_quantity
+
+            if 'max_quantity' not in data:
+                data['max_quantity'] = discount_code.max_quantity
+
+            if 'tickets_number' not in data:
+                data['tickets_number'] = discount_code.tickets_number
+
+        if 'min_quantity' in data and 'max_quantity' in data:
+            if data['min_quantity'] >= data['max_quantity']:
+                raise UnprocessableEntity({'pointer': '/data/attributes/min-quantity'},
+                                          "min-quantity should be less than max-quantity")
+
+        if 'tickets_number' in data and 'max_quantity' in data:
+            if data['tickets_number'] < data['max_quantity']:
+                raise UnprocessableEntity({'pointer': '/data/attributes/tickets-number'},
+                                          "tickets-number should be greater than max-quantity")
+
+    id = fields.Integer()
+    code = fields.Str(required=True)
+    discount_url = fields.Url(allow_none=True)
+    value = fields.Float(required=True)
+    type = fields.Str(validate=validate.OneOf(choices=["amount", "percent"]), required=True)
+    is_active = fields.Boolean()
+    tickets_number = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    min_quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    max_quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    valid_from = fields.DateTime(allow_none=True)
+    valid_till = fields.DateTime(allow_none=True)
+    tickets = fields.Str(validate=validate.OneOf(choices=["event", "ticket"]), allow_none=True)
+    created_at = fields.DateTime(allow_none=True)
+    used_for = fields.Str(required=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.discount_code_events',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_list',
+                         related_view_kwargs={'discount_code_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')

--- a/app/api/schema/discount_codes.py
+++ b/app/api/schema/discount_codes.py
@@ -1,4 +1,4 @@
-from marshmallow import validates_schema, validate, validate, validate, validate
+from marshmallow import validates_schema, validate
 from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema, Relationship
 

--- a/app/api/schema/email_notifications.py
+++ b/app/api/schema/email_notifications.py
@@ -1,0 +1,43 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class EmailNotificationSchema(Schema):
+    """
+    API Schema for email notification Model
+    """
+
+    class Meta:
+        """
+        Meta class for email notification API schema
+        """
+        type_ = 'email-notification'
+        self_view = 'v1.email_notification_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    next_event = fields.Boolean(default=False, allow_none=True)
+    new_paper = fields.Boolean(default=False, allow_none=True)
+    session_accept_reject = fields.Boolean(default=False, allow_none=True)
+    session_schedule = fields.Boolean(default=False, allow_none=True)
+    after_ticket_purchase = fields.Boolean(default=True, allow_none=True)
+    event_id = fields.Integer(allow_none=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.email_notification_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'email_notification_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event'
+                         )
+    user = Relationship(attribute='user',
+                        self_view='v1.email_notification_user',
+                        self_view_kwargs={'id': '<id>'},
+                        related_view='v1.user_detail',
+                        related_view_kwargs={'email_notification_id': '<id>'},
+                        schema='UserSchema',
+                        type_='user'
+                        )

--- a/app/api/schema/event_copyright.py
+++ b/app/api/schema/event_copyright.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class EventCopyrightSchema(Schema):
+
+    class Meta:
+        type_ = 'event-copyright'
+        self_view = 'v1.event_copyright_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    holder = fields.Str(allow_none=True)
+    holder_url = fields.Url(allow_none=True)
+    licence = fields.Str(required=True)
+    licence_url = fields.Url(allow_none=True)
+    year = fields.Int(validate=lambda n: 1900 <= n <= datetime.now().year, allow_none=True)
+    logo_url = fields.Url(attribute='logo', allow_none=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.copyright_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'copyright_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')

--- a/app/api/schema/event_invoices.py
+++ b/app/api/schema/event_invoices.py
@@ -1,0 +1,63 @@
+from marshmallow import validate as validate
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.static import PAYMENT_COUNTRIES
+from app.api.helpers.utilities import dasherize
+
+
+class EventInvoiceSchema(Schema):
+    """
+    Event Invoice API Schema based on event invoice model
+    """
+    class Meta:
+        type_ = 'event-invoice'
+        self_view = 'v1.event_invoice_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    identifier = fields.Str(allow_none=True)
+    amount = fields.Float(validate=lambda n: n >= 0, allow_none=True)
+    address = fields.Str(allow_none=True)
+    city = fields.Str(allow_none=True)
+    state = fields.Str(allow_none=True)
+    country = fields.Str(validate=validate.OneOf(choices=PAYMENT_COUNTRIES), allow_none=True)
+    zipcode = fields.Str(allow_none=True)
+    created_at = fields.DateTime(allow_none=True)
+    completed_at = fields.DateTime(default=None)
+    transaction_id = fields.Str(allow_none=True)
+    paid_via = fields.Str(validate=validate.OneOf(
+        choices=["free", "stripe", "paypal", "transfer", "onsite", "cheque"]), allow_none=True)
+    payment_mode = fields.Str(allow_none=True)
+    brand = fields.Str(allow_none=True)
+    exp_month = fields.Integer(validate=lambda n: 0 <= n <= 12, allow_none=True)
+    exp_year = fields.Integer(validate=lambda n: n >= 2015, allow_none=True)
+    last4 = fields.Str(allow_none=True)
+    stripe_token = fields.Str(allow_none=True)
+    paypal_token = fields.Str(allow_none=True)
+    status = fields.Str(validate=validate.OneOf(
+        choices=["expired", "deleted", "initialized" "completed", "placed", "pending", "cancelled"]), allow_none=True)
+    invoice_pdf_url = fields.Url(allow_none=True)
+    user = Relationship(attribute='user',
+                        self_view='v1.event_invoice_user',
+                        self_view_kwargs={'id': '<id>'},
+                        related_view='v1.user_detail',
+                        related_view_kwargs={'event_invoice_id': '<id>'},
+                        schema='UserSchema',
+                        type_='user')
+    event = Relationship(attribute='event',
+                         self_view='v1.event_invoice_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'event_invoice_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    discount_codes = Relationship(attribute='discount_code',
+                                  many=True,
+                                  self_view='v1.event_invoice_discount_code',
+                                  self_view_kwargs={'id': '<id>'},
+                                  related_view='v1.discount_code_detail',
+                                  related_view_kwargs={'event_invoice_id': '<id>'},
+                                  schema='DiscountCodeSchema',
+                                  type_='discount-code')

--- a/app/api/schema/event_statistics.py
+++ b/app/api/schema/event_statistics.py
@@ -1,0 +1,60 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app.api.helpers.utilities import dasherize
+from app.models.session import Session
+from app.models.speaker import Speaker
+from app.models.sponsor import Sponsor
+
+
+class EventStatisticsGeneralSchema(Schema):
+    """
+    Api schema for general statistics of event
+    """
+    class Meta:
+        """
+        Meta class
+        """
+        type_ = 'event-statistics-general'
+        self_view = 'v1.event_statistics_general_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str()
+    identifier = fields.Str()
+    sessions_draft = fields.Method("sessions_draft_count")
+    sessions_submitted = fields.Method("sessions_submitted_count")
+    sessions_accepted = fields.Method("sessions_accepted_count")
+    sessions_confirmed = fields.Method("sessions_confirmed_count")
+    sessions_pending = fields.Method("sessions_pending_count")
+    sessions_rejected = fields.Method("sessions_rejected_count")
+    speakers = fields.Method("speakers_count")
+    sessions = fields.Method("sessions_count")
+    sponsors = fields.Method("sponsors_count")
+
+    def sessions_draft_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='draft').count()
+
+    def sessions_submitted_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='submitted').count()
+
+    def sessions_accepted_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='accepted').count()
+
+    def sessions_confirmed_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='confirmed').count()
+
+    def sessions_pending_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='pending').count()
+
+    def sessions_rejected_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id, state='rejected').count()
+
+    def speakers_count(self, obj):
+        return Speaker.query.filter_by(event_id=obj.id).count()
+
+    def sessions_count(self, obj):
+        return Session.query.filter_by(event_id=obj.id).count()
+
+    def sponsors_count(self, obj):
+        return Sponsor.query.filter_by(event_id=obj.id).count()

--- a/app/api/schema/event_sub_topics.py
+++ b/app/api/schema/event_sub_topics.py
@@ -1,0 +1,45 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class EventSubTopicSchema(Schema):
+    """
+    Api Schema for event sub topic model
+    """
+
+    class Meta:
+        """
+        Meta class for event sub topic Api Schema
+        """
+        type_ = 'event-sub-topic'
+        self_view = 'v1.event_sub_topic_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    slug = fields.Str(dump_only=True)
+    events = Relationship(attribute='event',
+                          many=True,
+                          self_view='v1.event_topic_event',
+                          self_view_kwargs={'id': '<id>'},
+                          related_view='v1.event_list',
+                          related_view_kwargs={'event_sub_topic_id': '<id>'},
+                          schema='EventSchema',
+                          type_='event')
+    event_topic = Relationship(attribute='event_topic',
+                               self_view='v1.event_sub_topic_event_topic',
+                               self_view_kwargs={'id': '<id>'},
+                               related_view='v1.event_topic_detail',
+                               related_view_kwargs={'event_sub_topic_id': '<id>'},
+                               schema='EventTopicSchema',
+                               type_='event-topic')
+    custom_placeholder = Relationship(attribute='custom_placeholder',
+                                      self_view='v1.event_sub_topic_custom_placeholder',
+                                      self_view_kwargs={'id': '<id>'},
+                                      related_view='v1.custom_placeholder_detail',
+                                      related_view_kwargs={'event_sub_topic_id': '<id>'},
+                                      schema='CustomPlaceholderSchema',
+                                      type_='custom-placeholder')

--- a/app/api/schema/event_topics.py
+++ b/app/api/schema/event_topics.py
@@ -1,0 +1,39 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class EventTopicSchema(Schema):
+    """
+    Api Schema for event topic model
+    """
+
+    class Meta:
+        """
+        Meta class for event topic Api Schema
+        """
+        type_ = 'event-topic'
+        self_view = 'v1.event_topic_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    slug = fields.Str(dump_only=True)
+    events = Relationship(attribute='event',
+                          many=True,
+                          self_view='v1.event_topic_event',
+                          self_view_kwargs={'id': '<id>'},
+                          related_view='v1.event_list',
+                          related_view_kwargs={'event_topic_id': '<id>'},
+                          schema='EventSchema',
+                          type_='event')
+    event_sub_topics = Relationship(attribute='event_sub_topics',
+                                    self_view='v1.event_topic_event_sub_topic',
+                                    self_view_kwargs={'id': '<id>'},
+                                    related_view='v1.event_sub_topic_list',
+                                    related_view_kwargs={'event_topic_id': '<id>'},
+                                    many=True,
+                                    schema='EventSubTopicSchema',
+                                    type_='event-sub-topic')

--- a/app/api/schema/event_types.py
+++ b/app/api/schema/event_types.py
@@ -1,0 +1,31 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class EventTypeSchema(Schema):
+    """
+    Api Schema for event type model
+    """
+
+    class Meta:
+        """
+        Meta class for event type Api Schema
+        """
+        type_ = 'event-type'
+        self_view = 'v1.event_type_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    slug = fields.Str(dump_only=True)
+    events = Relationship(attribute='event',
+                          self_view='v1.event_type_event',
+                          self_view_kwargs={'id': '<id>'},
+                          related_view='v1.event_list',
+                          related_view_kwargs={'event_type_id': '<id>'},
+                          many=True,
+                          schema='EventSchema',
+                          type_='event')

--- a/app/api/schema/events.py
+++ b/app/api/schema/events.py
@@ -4,12 +4,12 @@ from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema, Relationship
 from pytz import timezone
 
-from app import Event
+from app.models.event import Event
 from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.utilities import dasherize
 
 
-class EventSchema(Schema):
+class EventSchemaPublic(Schema):
 
     class Meta:
         type_ = 'event'
@@ -173,21 +173,6 @@ class EventSchema(Schema):
                        related_view_kwargs={'event_id': '<id>'},
                        schema='TaxSchema',
                        type_='tax')
-    event_invoices = Relationship(attribute='invoices',
-                                  self_view='v1.event_event_invoice',
-                                  self_view_kwargs={'id': '<id>'},
-                                  related_view='v1.event_invoice_list',
-                                  related_view_kwargs={'event_id': '<id>'},
-                                  schema='EventInvoiceSchema',
-                                  many=True,
-                                  type_='event-invoice')
-    discount_codes = Relationship(attribute='discount_code',
-                                  self_view='v1.event_discount_code',
-                                  self_view_kwargs={'id': '<id>'},
-                                  related_view='v1.discount_code_list',
-                                  related_view_kwargs={'event_id': '<id>'},
-                                  schema='DiscountCodeSchema',
-                                  type_='discount-code')
     sessions = Relationship(attribute='session',
                             self_view='v1.event_session',
                             self_view_kwargs={'id': '<id>'},
@@ -225,29 +210,6 @@ class EventSchema(Schema):
                                    related_view_kwargs={'event_id': '<id>'},
                                    schema='EventSubTopicSchema',
                                    type_='event-sub-topic')
-    role_invites = Relationship(attribute='role_invites',
-                                self_view='v1.event_role_invite',
-                                self_view_kwargs={'id': '<id>'},
-                                related_view='v1.role_invite_list',
-                                related_view_kwargs={'event_id': '<id>'},
-                                schema='RoleInviteSchema',
-                                type_='role-invite')
-    access_codes = Relationship(attribute='access_codes',
-                                self_view='v1.event_access_codes',
-                                self_view_kwargs={'id': '<id>'},
-                                related_view='v1.access_code_list',
-                                related_view_kwargs={'event_id': '<id>'},
-                                schema='AccessCodeSchema',
-                                many=True,
-                                type_='access-code')
-    attendees = Relationship(attribute='attendees',
-                             self_view='v1.event_attendees',
-                             self_view_kwargs={'id': '<id>'},
-                             related_view='v1.attendee_list',
-                             related_view_kwargs={'event_id': '<id>'},
-                             schema='AttendeeSchema',
-                             many=True,
-                             type_='attendee')
     custom_forms = Relationship(attribute='custom_form',
                                 self_view='v1.event_custom_forms',
                                 self_view_kwargs={'id': '<id>'},
@@ -256,6 +218,31 @@ class EventSchema(Schema):
                                 schema='CustomFormSchema',
                                 many=True,
                                 type_='custom-form')
+
+
+class EventSchema(EventSchemaPublic):
+    class Meta:
+        type_ = 'event'
+        self_view = 'v1.event_detail'
+        self_view_kwargs = {'id': '<id>'}
+        self_view_many = 'v1.event_list'
+        inflect = dasherize
+
+    event_invoices = Relationship(attribute='invoices',
+                                  self_view='v1.event_event_invoice',
+                                  self_view_kwargs={'id': '<id>'},
+                                  related_view='v1.event_invoice_list',
+                                  related_view_kwargs={'event_id': '<id>'},
+                                  schema='EventInvoiceSchema',
+                                  many=True,
+                                  type_='event-invoice')
+    discount_codes = Relationship(attribute='discount_code',
+                                  self_view='v1.event_discount_code',
+                                  self_view_kwargs={'id': '<id>'},
+                                  related_view='v1.discount_code_list',
+                                  related_view_kwargs={'event_id': '<id>'},
+                                  schema='DiscountCodeSchema',
+                                  type_='discount-code')
     organizers = Relationship(attribute='organizers',
                               self_view='v1.event_organizers',
                               self_view_kwargs={'id': '<id>'},
@@ -298,3 +285,26 @@ class EventSchema(Schema):
                           schema='OrderSchema',
                           type_='order',
                           many=True)
+    role_invites = Relationship(attribute='role_invites',
+                                self_view='v1.event_role_invite',
+                                self_view_kwargs={'id': '<id>'},
+                                related_view='v1.role_invite_list',
+                                related_view_kwargs={'event_id': '<id>'},
+                                schema='RoleInviteSchema',
+                                type_='role-invite')
+    access_codes = Relationship(attribute='access_codes',
+                                self_view='v1.event_access_codes',
+                                self_view_kwargs={'id': '<id>'},
+                                related_view='v1.access_code_list',
+                                related_view_kwargs={'event_id': '<id>'},
+                                schema='AccessCodeSchema',
+                                many=True,
+                                type_='access-code')
+    attendees = Relationship(attribute='attendees',
+                             self_view='v1.event_attendees',
+                             self_view_kwargs={'id': '<id>'},
+                             related_view='v1.attendee_list',
+                             related_view_kwargs={'event_id': '<id>'},
+                             schema='AttendeeSchema',
+                             many=True,
+                             type_='attendee')

--- a/app/api/schema/events.py
+++ b/app/api/schema/events.py
@@ -1,0 +1,300 @@
+import pytz
+from marshmallow import validates_schema, validate
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+from pytz import timezone
+
+from app import Event
+from app.api.helpers.exceptions import UnprocessableEntity
+from app.api.helpers.utilities import dasherize
+
+
+class EventSchema(Schema):
+
+    class Meta:
+        type_ = 'event'
+        self_view = 'v1.event_detail'
+        self_view_kwargs = {'id': '<id>'}
+        self_view_many = 'v1.event_list'
+        inflect = dasherize
+
+    @validates_schema(pass_original=True)
+    def validate_date(self, data, original_data):
+        if 'id' in original_data['data']:
+            event = Event.query.filter_by(id=original_data['data']['id']).one()
+
+            if 'starts_at' not in data:
+                data['starts_at'] = event.starts_at
+
+            if 'ends_at' not in data:
+                data['ends_at'] = event.ends_at
+
+        if 'starts_at' not in data or 'ends_at' not in data:
+            raise UnprocessableEntity({'pointer': '/data/attributes/date'},
+                                      "enter required fields starts-at/ends-at")
+
+        if data['starts_at'] >= data['ends_at']:
+            raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'},
+                                      "ends-at should be after starts-at")
+
+    @validates_schema(pass_original=True)
+    def validate_timezone(self, data, original_data):
+        if 'id' in original_data['data']:
+            event = Event.query.filter_by(id=original_data['data']['id']).one()
+
+            if 'timezone' not in data:
+                data['timezone'] = event.timezone
+        try:
+            timezone(data['timezone'])
+        except pytz.exceptions.UnknownTimeZoneError:
+            raise UnprocessableEntity({'pointer': '/data/attributes/timezone'},
+                                      "Unknown timezone: '{}'".
+                                      format(data['timezone']))
+
+    id = fields.Str(dump_only=True)
+    identifier = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    external_event_url = fields.Url(allow_none=True)
+    starts_at = fields.DateTime(required=True, timezone=True)
+    ends_at = fields.DateTime(required=True, timezone=True)
+    timezone = fields.Str(required=True)
+    latitude = fields.Float(validate=lambda n: -90 <= n <= 90, allow_none=True)
+    longitude = fields.Float(validate=lambda n: -180 <= n <= 180, allow_none=True)
+    logo_url = fields.Url(allow_none=True)
+    location_name = fields.Str(allow_none=True)
+    searchable_location_name = fields.Str(allow_none=True)
+    description = fields.Str(allow_none=True)
+    original_image_url = fields.Url(allow_none=True)
+    thumbnail_image_url = fields.Url(dump_only=True)
+    large_image_url = fields.Url(dump_only=True)
+    icon_image_url = fields.Url(dump_only=True)
+    organizer_name = fields.Str(allow_none=True)
+    is_map_shown = fields.Bool(default=False)
+    has_organizer_info = fields.Bool(default=False)
+    organizer_description = fields.Str(allow_none=True)
+    is_sessions_speakers_enabled = fields.Bool(default=False)
+    privacy = fields.Str(default="public")
+    state = fields.Str(validate=validate.OneOf(choices=["published", "draft"]), allow_none=True, default='draft')
+    ticket_url = fields.Url(allow_none=True)
+    code_of_conduct = fields.Str(allow_none=True)
+    schedule_published_on = fields.DateTime(allow_none=True)
+    is_ticketing_enabled = fields.Bool(default=True)
+    deleted_at = fields.DateTime(allow_none=True)
+    payment_country = fields.Str(allow_none=True)
+    payment_currency = fields.Str(allow_none=True)
+    paypal_email = fields.Str(allow_none=True)
+    is_tax_enabled = fields.Bool(default=False)
+    can_pay_by_paypal = fields.Bool(default=False)
+    can_pay_by_stripe = fields.Bool(default=False)
+    can_pay_by_cheque = fields.Bool(default=False)
+    can_pay_by_bank = fields.Bool(default=False)
+    can_pay_onsite = fields.Bool(default=False)
+    cheque_details = fields.Str(allow_none=True)
+    bank_details = fields.Str(allow_none=True)
+    onsite_details = fields.Str(allow_none=True)
+    is_sponsors_enabled = fields.Bool(default=False)
+    created_at = fields.DateTime(dump_only=True, timezone=True)
+    pentabarf_url = fields.Url(dump_only=True)
+    ical_url = fields.Url(dump_only=True)
+    xcal_url = fields.Url(dump_only=True)
+    tickets = Relationship(attribute='tickets',
+                           self_view='v1.event_ticket',
+                           self_view_kwargs={'id': '<id>'},
+                           related_view='v1.ticket_list',
+                           related_view_kwargs={'event_id': '<id>'},
+                           schema='TicketSchema',
+                           many=True,
+                           type_='ticket')
+    ticket_tags = Relationship(attribute='ticket_tags',
+                               self_view='v1.event_ticket_tag',
+                               self_view_kwargs={'id': '<id>'},
+                               related_view='v1.ticket_tag_list',
+                               related_view_kwargs={'event_id': '<id>'},
+                               schema='TicketTagSchema',
+                               many=True,
+                               type_='ticket-tag')
+    microlocations = Relationship(attribute='microlocation',
+                                  self_view='v1.event_microlocation',
+                                  self_view_kwargs={'id': '<id>'},
+                                  related_view='v1.microlocation_list',
+                                  related_view_kwargs={'event_id': '<id>'},
+                                  schema='MicrolocationSchema',
+                                  many=True,
+                                  type_='microlocation')
+    social_links = Relationship(attribute='social_link',
+                                self_view='v1.event_social_link',
+                                self_view_kwargs={'id': '<id>'},
+                                related_view='v1.social_link_list',
+                                related_view_kwargs={'event_id': '<id>'},
+                                schema='SocialLinkSchema',
+                                many=True,
+                                type_='social-link')
+    tracks = Relationship(attribute='track',
+                          self_view='v1.event_tracks',
+                          self_view_kwargs={'id': '<id>'},
+                          related_view='v1.track_list',
+                          related_view_kwargs={'event_id': '<id>'},
+                          schema='TrackSchema',
+                          many=True,
+                          type_='track')
+    sponsors = Relationship(attribute='sponsor',
+                            self_view='v1.event_sponsor',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.sponsor_list',
+                            related_view_kwargs={'event_id': '<id>'},
+                            schema='SponsorSchema',
+                            many=True,
+                            type_='sponsor')
+    speakers_call = Relationship(attribute='speakers_call',
+                                 self_view='v1.event_speakers_call',
+                                 self_view_kwargs={'id': '<id>'},
+                                 related_view='v1.speakers_call_detail',
+                                 related_view_kwargs={'event_id': '<id>'},
+                                 schema='SpeakersCallSchema',
+                                 type_='speakers-call')
+    session_types = Relationship(attribute='session_type',
+                                 self_view='v1.event_session_types',
+                                 self_view_kwargs={'id': '<id>'},
+                                 related_view='v1.session_type_list',
+                                 related_view_kwargs={'event_id': '<id>'},
+                                 schema='SessionTypeSchema',
+                                 many=True,
+                                 type_='session-type')
+    event_copyright = Relationship(attribute='copyright',
+                                   self_view='v1.event_copyright',
+                                   self_view_kwargs={'id': '<id>'},
+                                   related_view='v1.event_copyright_detail',
+                                   related_view_kwargs={'event_id': '<id>'},
+                                   schema='EventCopyrightSchema',
+                                   type_='event-copyright')
+    tax = Relationship(self_view='v1.event_tax',
+                       self_view_kwargs={'id': '<id>'},
+                       related_view='v1.tax_detail',
+                       related_view_kwargs={'event_id': '<id>'},
+                       schema='TaxSchema',
+                       type_='tax')
+    event_invoices = Relationship(attribute='invoices',
+                                  self_view='v1.event_event_invoice',
+                                  self_view_kwargs={'id': '<id>'},
+                                  related_view='v1.event_invoice_list',
+                                  related_view_kwargs={'event_id': '<id>'},
+                                  schema='EventInvoiceSchema',
+                                  many=True,
+                                  type_='event-invoice')
+    discount_codes = Relationship(attribute='discount_code',
+                                  self_view='v1.event_discount_code',
+                                  self_view_kwargs={'id': '<id>'},
+                                  related_view='v1.discount_code_list',
+                                  related_view_kwargs={'event_id': '<id>'},
+                                  schema='DiscountCodeSchema',
+                                  type_='discount-code')
+    sessions = Relationship(attribute='session',
+                            self_view='v1.event_session',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.session_list',
+                            related_view_kwargs={'event_id': '<id>'},
+                            schema='SessionSchema',
+                            many=True,
+                            type_='session')
+    speakers = Relationship(attribute='speaker',
+                            self_view='v1.event_speaker',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.speaker_list',
+                            related_view_kwargs={'event_id': '<id>'},
+                            schema='SpeakerSchema',
+                            many=True,
+                            type_='speaker')
+    event_type = Relationship(attribute='event_type',
+                              self_view='v1.event_event_type',
+                              self_view_kwargs={'id': '<id>'},
+                              related_view='v1.event_type_detail',
+                              related_view_kwargs={'event_id': '<id>'},
+                              schema='EventTypeSchema',
+                              type_='event-type')
+    event_topic = Relationship(attribute='event_topic',
+                               self_view='v1.event_event_topic',
+                               self_view_kwargs={'id': '<id>'},
+                               related_view='v1.event_topic_detail',
+                               related_view_kwargs={'event_id': '<id>'},
+                               schema='EventTopicSchema',
+                               type_='event-topic')
+    event_sub_topic = Relationship(attribute='event_sub_topic',
+                                   self_view='v1.event_event_sub_topic',
+                                   self_view_kwargs={'id': '<id>'},
+                                   related_view='v1.event_sub_topic_detail',
+                                   related_view_kwargs={'event_id': '<id>'},
+                                   schema='EventSubTopicSchema',
+                                   type_='event-sub-topic')
+    role_invites = Relationship(attribute='role_invites',
+                                self_view='v1.event_role_invite',
+                                self_view_kwargs={'id': '<id>'},
+                                related_view='v1.role_invite_list',
+                                related_view_kwargs={'event_id': '<id>'},
+                                schema='RoleInviteSchema',
+                                type_='role-invite')
+    access_codes = Relationship(attribute='access_codes',
+                                self_view='v1.event_access_codes',
+                                self_view_kwargs={'id': '<id>'},
+                                related_view='v1.access_code_list',
+                                related_view_kwargs={'event_id': '<id>'},
+                                schema='AccessCodeSchema',
+                                many=True,
+                                type_='access-code')
+    attendees = Relationship(attribute='attendees',
+                             self_view='v1.event_attendees',
+                             self_view_kwargs={'id': '<id>'},
+                             related_view='v1.attendee_list',
+                             related_view_kwargs={'event_id': '<id>'},
+                             schema='AttendeeSchema',
+                             many=True,
+                             type_='attendee')
+    custom_forms = Relationship(attribute='custom_form',
+                                self_view='v1.event_custom_forms',
+                                self_view_kwargs={'id': '<id>'},
+                                related_view='v1.custom_form_list',
+                                related_view_kwargs={'event_id': '<id>'},
+                                schema='CustomFormSchema',
+                                many=True,
+                                type_='custom-form')
+    organizers = Relationship(attribute='organizers',
+                              self_view='v1.event_organizers',
+                              self_view_kwargs={'id': '<id>'},
+                              related_view='v1.user_list',
+                              schema='UserSchema',
+                              type_='user',
+                              many=True)
+    coorganizers = Relationship(attribute='coorganizers',
+                                self_view='v1.event_coorganizers',
+                                self_view_kwargs={'id': '<id>'},
+                                related_view='v1.user_list',
+                                schema='UserSchema',
+                                type_='user',
+                                many=True)
+    track_organizers = Relationship(attribute='track_organizers',
+                                    self_view='v1.event_track_organizers',
+                                    self_view_kwargs={'id': '<id>'},
+                                    related_view='v1.user_list',
+                                    schema='UserSchema',
+                                    type_='user',
+                                    many=True)
+    moderators = Relationship(attribute='moderators',
+                              self_view='v1.event_moderators',
+                              self_view_kwargs={'id': '<id>'},
+                              related_view='v1.user_list',
+                              schema='UserSchema',
+                              type_='user',
+                              many=True)
+    registrars = Relationship(attribute='registrars',
+                              self_view='v1.event_registrars',
+                              self_view_kwargs={'id': '<id>'},
+                              related_view='v1.user_list',
+                              schema='UserSchema',
+                              type_='user',
+                              many=True)
+    orders = Relationship(attribute='orders',
+                          self_view='v1.event_orders',
+                          self_view_kwargs={'id': '<id>'},
+                          related_view='v1.orders_list',
+                          schema='OrderSchema',
+                          type_='order',
+                          many=True)

--- a/app/api/schema/image_sizes.py
+++ b/app/api/schema/image_sizes.py
@@ -1,0 +1,35 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app.api.helpers.utilities import dasherize
+
+
+class ImageSizeSchema(Schema):
+    """
+    Api schema for image_size Model
+    """
+    class Meta:
+        """
+        Meta class for image_size Api Schema
+        """
+        type_ = 'image-size'
+        self_view = 'v1.image_size_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    type = fields.Str(allow_none=True)
+    full_width = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    full_height = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    full_aspect = fields.Boolean(default=False)
+    full_quality = fields.Integer(validate=lambda n: 0 <= n <= 100, allow_none=True)
+    icon_width = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    icon_height = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    icon_aspect = fields.Boolean(default=False)
+    icon_quality = fields.Integer(validate=lambda n: 0 <= n <= 100, allow_none=True)
+    thumbnail_width = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    thumbnail_height = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    thumbnail_aspect = fields.Boolean(default=False)
+    thumbnail_quality = fields.Integer(validate=lambda n: 0 <= n <= 100, allow_none=True)
+    logo_width = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    logo_height = fields.Integer(validate=lambda n: n >= 0, allow_none=True)

--- a/app/api/schema/mails.py
+++ b/app/api/schema/mails.py
@@ -1,0 +1,26 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app.api.helpers.utilities import dasherize
+
+
+class MailSchema(Schema):
+    """
+    Api schema for mail Model
+    """
+    class Meta:
+        """
+        Meta class for mail Api Schema
+        """
+        type_ = 'mail'
+        self_view = 'v1.mail_detail'
+        self_view_kwargs = {'id': '<id>'}
+        self_view_many = 'v1.mail_list'
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    recipient = fields.Email(dump_only=True)
+    time = fields.DateTime(dump_only=True)
+    action = fields.Str(dump_only=True)
+    subject = fields.Str(dump_only=True)
+    message = fields.Str(dump_only=True)

--- a/app/api/schema/microlocations.py
+++ b/app/api/schema/microlocations.py
@@ -1,0 +1,42 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class MicrolocationSchema(Schema):
+    """
+    Api schema for Microlocation Model
+    """
+
+    class Meta:
+        """
+        Meta class for Microlocation Api Schema
+        """
+        type_ = 'microlocation'
+        self_view = 'v1.microlocation_detail'
+        self_view_kwargs = {'id': '<id>'}
+        self_view_many = 'v1.microlocation_list_post'
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    latitude = fields.Float(validate=lambda n: -90 <= n <= 90, allow_none=True)
+    longitude = fields.Float(validate=lambda n: -180 <= n <= 180, allow_none=True)
+    floor = fields.Integer(allow_none=True)
+    room = fields.Str(allow_none=True)
+    sessions = Relationship(attribute='session',
+                            many=True,
+                            self_view='v1.microlocation_session',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.session_list',
+                            related_view_kwargs={'microlocation_id': '<id>'},
+                            schema='SessionSchema',
+                            type_='session')
+    event = Relationship(attribute='event',
+                         self_view='v1.microlocation_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'microlocation_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')

--- a/app/api/schema/modules.py
+++ b/app/api/schema/modules.py
@@ -1,0 +1,23 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app.api.helpers.utilities import dasherize
+
+
+class ModuleSchema(Schema):
+    """
+    Admin Api schema for modules Model
+    """
+    class Meta:
+        """
+        Meta class for module Api Schema
+        """
+        type_ = 'module'
+        self_view = 'v1.module_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    ticket_include = fields.Boolean(default=False)
+    payment_include = fields.Boolean(default=False)
+    donation_include = fields.Boolean(default=False)

--- a/app/api/schema/notifications.py
+++ b/app/api/schema/notifications.py
@@ -1,0 +1,35 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class NotificationSchema(Schema):
+    """
+    API Schema for Notification Model
+    """
+
+    class Meta:
+        """
+        Meta class for Notification API schema
+        """
+        type_ = 'notification'
+        self_view = 'v1.notification_detail'
+        self_view_kwargs = {'id': '<id>'}
+        self_view_many = 'v1.microlocation_list_post'
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    title = fields.Str(allow_none=True, dump_only=True)
+    message = fields.Str(allow_none=True, dump_only=True)
+    received_at = fields.DateTime(dump_only=True)
+    accept = fields.Str(allow_none=True, dump_only=True)
+    is_read = fields.Boolean()
+    user = Relationship(attribute='user',
+                        self_view='v1.notification_user',
+                        self_view_kwargs={'id': '<id>'},
+                        related_view='v1.user_detail',
+                        related_view_kwargs={'notification_id': '<id>'},
+                        schema='UserSchema',
+                        type_='user'
+                        )

--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -1,0 +1,99 @@
+from flask import request
+from marshmallow import post_dump, validates_schema, validate
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app import db
+from app.api.helpers.payment import PayPalPaymentsManager
+from app.api.helpers.utilities import dasherize
+from app.models.order import Order
+
+
+class OrderSchema(Schema):
+    class Meta:
+        type_ = 'order'
+        self_view = 'v1.order_detail'
+        self_view_kwargs = {'order_identifier': '<identifier>'}
+        inflect = dasherize
+
+    @post_dump
+    def generate_payment_url(self, data):
+        if 'POST' in request.method or ('GET' in request.method and 'regenerate' in request.args) and 'completed' != \
+           data["status"]:
+            if data['payment_mode'] == 'stripe':
+                data['payment_url'] = 'stripe://payment'
+            elif data['payment_mode'] == 'paypal':
+                order = Order.query.filter_by(id=data['id']).first()
+                data['payment_url'] = PayPalPaymentsManager.get_checkout_url(order)
+        return data
+
+    @validates_schema
+    def initial_values(self, data):
+        if data.get('payment_mode') is None and 'POST' in request.method:
+            data['payment_mode'] = 'free'
+        return data
+
+    id = fields.Str(dump_only=True)
+    identifier = fields.Str(dump_only=True)
+    amount = fields.Float(validate=lambda n: n > 0)
+    address = fields.Str()
+    city = fields.Str()
+    state = fields.Str(db.String)
+    country = fields.Str(required=True)
+    zipcode = fields.Str()
+    completed_at = fields.DateTime(dump_only=True)
+    transaction_id = fields.Str(dump_only=True)
+    payment_mode = fields.Str(default="free", required=True)
+    paid_via = fields.Str(dump_only=True)
+    brand = fields.Str(dump_only=True)
+    exp_month = fields.Str(dump_only=True)
+    exp_year = fields.Str(dump_only=True)
+    last4 = fields.Str(dump_only=True)
+    status = fields.Str(validate=validate.OneOf(choices=["pending", "cancelled", "confirmed", "deleted"]))
+    discount_code_id = fields.Str()
+    payment_url = fields.Str(dump_only=True)
+
+    attendees = Relationship(attribute='ticket_holders',
+                             self_view='v1.order_attendee',
+                             self_view_kwargs={'order_identifier': '<identifier>'},
+                             related_view='v1.attendee_list',
+                             related_view_kwargs={'order_id': '<id>'},
+                             schema='AttendeeSchema',
+                             many=True,
+                             type_='attendee')
+
+    tickets = Relationship(self_view='v1.order_ticket',
+                           self_view_kwargs={'order_identifier': '<identifier>'},
+                           related_view='v1.ticket_list',
+                           related_view_kwargs={'order_id': '<id>'},
+                           schema='TicketSchema',
+                           many=True,
+                           type_="ticket")
+
+    user = Relationship(self_view='v1.order_user',
+                        self_view_kwargs={'order_identifier': '<identifier>'},
+                        related_view='v1.user_detail',
+                        related_view_kwargs={'id': '<user_id>'},
+                        schema='UserSchema',
+                        type_="user")
+
+    event = Relationship(self_view='v1.order_event',
+                         self_view_kwargs={'order_identifier': '<identifier>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'id': '<event_id>'},
+                         schema='EventSchema',
+                         type_="event")
+
+    marketer = Relationship(self_view='v1.order_marketer',
+                            self_view_kwargs={'order_identifier': '<identifier>'},
+                            related_view='v1.user_detail',
+                            related_view_kwargs={'id': '<marketer_id>'},
+                            schema='UserSchema',
+                            type_="user")
+
+    discount_code = Relationship(self_view='v1.order_discount',
+                                 self_view_kwargs={'order_identifier': '<identifier>'},
+                                 related_view='v1.discount_code_detail',
+                                 related_view_kwargs={'id': '<discount_code_id>'},
+                                 schema='DiscountCodeSchema',
+                                 type_="discount-code")

--- a/app/api/schema/pages.py
+++ b/app/api/schema/pages.py
@@ -1,0 +1,28 @@
+from marshmallow import validate as validate
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app.api.helpers.utilities import dasherize
+
+
+class PageSchema(Schema):
+    """
+    Api schema for page Model
+    """
+    class Meta:
+        """
+        Meta class for page Api Schema
+        """
+        type_ = 'page'
+        self_view = 'v1.page_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    title = fields.Str(allow_none=True)
+    url = fields.String(required=True)
+    description = fields.Str(allow_none=True)
+    place = fields.Str(validate=validate.OneOf(choices=["footer", "event"]), allow_none=True)
+    language = fields.Str(allow_none=True)
+    index = fields.Integer(default=0)

--- a/app/api/schema/role_invites.py
+++ b/app/api/schema/role_invites.py
@@ -1,0 +1,63 @@
+from marshmallow import validates_schema, validate, validate
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app import RoleInvite
+from app.api.helpers.exceptions import UnprocessableEntity
+from app.api.helpers.utilities import dasherize
+from app.models.role import Role
+
+
+class RoleInviteSchema(Schema):
+    """
+    Api Schema for role invite model
+    """
+
+    class Meta:
+        """
+        Meta class for role invite Api Schema
+        """
+        type_ = 'role-invite'
+        self_view = 'v1.role_invite_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    @validates_schema(pass_original=True)
+    def validate_satus(self, data, original_data):
+        if 'role' in data and 'role_name' in data:
+            role = Role.query.filter_by(id=data['role']).one()
+            if role.name != data['role_name']:
+                raise UnprocessableEntity({'pointer': '/data/attributes/role'},
+                                          "Role id do not match role name")
+        if 'id' in original_data['data']:
+            role_invite = RoleInvite.query.filter_by(id=original_data['data']['id']).one()
+            if 'role' not in data:
+                data['role'] = role_invite.role.id
+            if 'role_name' in data:
+                role = Role.query.filter_by(id=data['role']).one()
+                if role.name != data['role_name']:
+                    raise UnprocessableEntity({'pointer': '/data/attributes/role'},
+                                              "Role id do not match role name")
+
+    id = fields.Str(dump_only=True)
+    email = fields.Str(required=True)
+    hash = fields.Str(dump_only=True)
+    created_at = fields.DateTime(dump_only=True, timezone=True)
+    role_name = fields.Str(validate=validate.OneOf(choices=["organizer", "coorganizer", "track_organizer",
+                           "moderator", "attendee", "registrar"]))
+    status = fields.Str(validate=validate.OneOf(choices=["pending", "accepted", "declined"]),
+                        default="pending")
+    event = Relationship(attribute='event',
+                         self_view='v1.role_invite_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'role_invite_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    role = Relationship(attribute='role',
+                        self_view='v1.role_invite_role',
+                        self_view_kwargs={'id': '<id>'},
+                        related_view='v1.role_detail',
+                        related_view_kwargs={'role_invite_id': '<id>'},
+                        schema='RoleSchema',
+                        type_='role')

--- a/app/api/schema/role_invites.py
+++ b/app/api/schema/role_invites.py
@@ -1,8 +1,8 @@
-from marshmallow import validates_schema, validate, validate
+from marshmallow import validates_schema, validate
 from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema, Relationship
 
-from app import RoleInvite
+from app.models.role_invite import RoleInvite
 from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.utilities import dasherize
 from app.models.role import Role

--- a/app/api/schema/roles.py
+++ b/app/api/schema/roles.py
@@ -1,0 +1,22 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app.api.helpers.utilities import dasherize
+
+
+class RoleSchema(Schema):
+    """
+    Api schema for role Model
+    """
+    class Meta:
+        """
+        Meta class for role Api Schema
+        """
+        type_ = 'role'
+        self_view = 'v1.role_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    title_name = fields.Str(allow_none=True)

--- a/app/api/schema/session_types.py
+++ b/app/api/schema/session_types.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+
+from marshmallow import validates_schema
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.exceptions import UnprocessableEntity
+from app.api.helpers.utilities import dasherize
+
+
+class SessionTypeSchema(Schema):
+    """
+    Api Schema for session type model
+    """
+    class Meta:
+        """
+        Meta class for SessionTypeSchema
+        """
+        type_ = 'session-type'
+        self_view = 'v1.session_type_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    @validates_schema
+    def validate_length(self, data):
+        try:
+            datetime.strptime(data['length'], '%H:%M')
+        except ValueError:
+            raise UnprocessableEntity({'pointer': '/data/attributes/length'}, "Length should be in the format %H:%M")
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    length = fields.Str(required=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.session_type_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'session_type_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    sessions = Relationship(attribute='sessions',
+                            self_view='v1.session_type_sessions',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.session_list',
+                            related_view_kwargs={'session_type_id': '<id>'},
+                            schema='SessionSchema',
+                            many=True,
+                            type_='session')

--- a/app/api/schema/sessions.py
+++ b/app/api/schema/sessions.py
@@ -1,0 +1,118 @@
+from marshmallow import validates_schema, validate
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.exceptions import UnprocessableEntity, ForbiddenException
+from app.api.helpers.permission_manager import has_access
+from app.api.helpers.utilities import dasherize
+from app.models.session import Session
+
+
+class SessionSchema(Schema):
+    """
+    Api schema for Session Model
+    """
+
+    class Meta:
+        """
+        Meta class for Session Api Schema
+        """
+        type_ = 'session'
+        self_view = 'v1.session_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    @validates_schema(pass_original=True)
+    def validate_date(self, data, original_data):
+        if 'id' in original_data['data']:
+            session = Session.query.filter_by(id=original_data['data']['id']).one()
+
+            if 'starts_at' not in data:
+                data['starts_at'] = session.starts_at
+
+            if 'ends_at' not in data:
+                data['ends_at'] = session.ends_at
+
+            if 'event' not in data:
+                data['event'] = session.event_id
+
+        if data['starts_at'] >= data['ends_at']:
+            raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'}, "ends-at should be after starts-at")
+
+        if 'state' in data:
+            if data['state'] is not 'draft' or not 'pending':
+                if not has_access('is_coorganizer', event_id=data['event']):
+                    return ForbiddenException({'source': ''}, 'Co-organizer access is required.')
+
+        if 'track' in data:
+            if not has_access('is_coorganizer', event_id=data['event']):
+                return ForbiddenException({'source': ''}, 'Co-organizer access is required.')
+
+        if 'microlocation' in data:
+            if not has_access('is_coorganizer', event_id=data['event']):
+                return ForbiddenException({'source': ''}, 'Co-organizer access is required.')
+
+    id = fields.Str(dump_only=True)
+    title = fields.Str(required=True)
+    subtitle = fields.Str(allow_none=True)
+    level = fields.Int(allow_none=True)
+    short_abstract = fields.Str(allow_none=True)
+    long_abstract = fields.Str(allow_none=True)
+    comments = fields.Str(allow_none=True)
+    starts_at = fields.DateTime(required=True)
+    ends_at = fields.DateTime(required=True)
+    language = fields.Str(allow_none=True)
+    slides_url = fields.Url(allow_none=True)
+    video_url = fields.Url(allow_none=True)
+    audio_url = fields.Url(allow_none=True)
+    signup_url = fields.Url(allow_none=True)
+    state = fields.Str(validate=validate.OneOf(choices=["pending", "accepted", "confirmed", "rejected", "draft"]),
+                       allow_none=True, default='draft')
+    created_at = fields.DateTime(dump_only=True)
+    deleted_at = fields.DateTime(dump_only=True)
+    submitted_at = fields.DateTime(allow_none=True)
+    is_mail_sent = fields.Boolean()
+    microlocation = Relationship(attribute='microlocation',
+                                 self_view='v1.session_microlocation',
+                                 self_view_kwargs={'id': '<id>'},
+                                 related_view='v1.microlocation_detail',
+                                 related_view_kwargs={'session_id': '<id>'},
+                                 schema='MicrolocationSchema',
+                                 type_='microlocation')
+    track = Relationship(attribute='track',
+                         self_view='v1.session_track',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.track_detail',
+                         related_view_kwargs={'session_id': '<id>'},
+                         schema='TrackSchema',
+                         type_='track')
+    session_type = Relationship(attribute='session_type',
+                                self_view='v1.session_session_type',
+                                self_view_kwargs={'id': '<id>'},
+                                related_view='v1.session_type_detail',
+                                related_view_kwargs={'session_id': '<id>'},
+                                schema='SessionTypeSchema',
+                                type_='session-type')
+    event = Relationship(attribute='event',
+                         self_view='v1.session_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'session_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    speakers = Relationship(
+        attribute='speakers',
+        many=True,
+        self_view='v1.session_speaker',
+        self_view_kwargs={'id': '<id>'},
+        related_view='v1.speaker_list',
+        related_view_kwargs={'session_id': '<id>'},
+        schema='SpeakerSchema',
+        type_='speaker')
+    creator = Relationship(attribute='user',
+                           self_view='v1.session_user',
+                           self_view_kwargs={'id': '<id>'},
+                           related_view='v1.user_detail',
+                           related_view_kwargs={'session_id': '<id>'},
+                           schema='UserSchema',
+                           type_='user')

--- a/app/api/schema/settings.py
+++ b/app/api/schema/settings.py
@@ -2,7 +2,7 @@ from marshmallow_jsonapi import fields
 from marshmallow_jsonapi.flask import Schema
 
 from app.api.helpers.utilities import dasherize
-from app.api.settings import Environment
+from app.settings import Environment
 
 
 class SettingSchemaAdmin(Schema):

--- a/app/api/schema/settings.py
+++ b/app/api/schema/settings.py
@@ -1,0 +1,166 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app.api.helpers.utilities import dasherize
+from app.api.settings import Environment
+
+
+class SettingSchemaAdmin(Schema):
+    """
+    Admin Api schema for settings Model
+    """
+    class Meta:
+        """
+        Meta class for setting Api Schema
+        """
+        type_ = 'setting'
+        self_view = 'v1.setting_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    #
+    # General
+    #
+
+    app_environment = fields.Str(default=Environment.PRODUCTION)
+    # Name of the application. (Eg. Event Yay!, Open Event)
+    app_name = fields.Str(allow_none=True)
+    # Tagline for the application. (Eg. Event Management and Ticketing, Home)
+    tagline = fields.Str(allow_none=True)
+    # App secret
+    secret = fields.Str(allow_none=True)
+    # Static domain
+    static_domain = fields.Str(allow_none=True)
+
+    #
+    #  STORAGE
+    #
+
+    # storage place, local, s3, .. can be more in future
+    storage_place = fields.Str(allow_none=True)
+    # S3
+    aws_key = fields.Str(allow_none=True)
+    aws_secret = fields.Str(allow_none=True)
+    aws_bucket_name = fields.Str(allow_none=True)
+    aws_region = fields.Str(allow_none=True)
+    # Google Storage
+    gs_key = fields.Str(allow_none=True)
+    gs_secret = fields.Str(allow_none=True)
+    gs_bucket_name = fields.Str(allow_none=True)
+
+    #
+    # Social Login
+    #
+
+    # Google Auth
+    google_client_id = fields.Str(allow_none=True)
+    google_client_secret = fields.Str(allow_none=True)
+    # FB
+    fb_client_id = fields.Str(allow_none=True)
+    fb_client_secret = fields.Str(allow_none=True)
+    # Twitter
+    tw_consumer_key = fields.Str(allow_none=True)
+    tw_consumer_secret = fields.Str(allow_none=True)
+    # Instagram
+    in_client_id = fields.Str(allow_none=True)
+    in_client_secret = fields.Str(allow_none=True)
+
+    #
+    # Payment Gateway
+    #
+
+    # Stripe Keys
+    stripe_client_id = fields.Str(allow_none=True)
+    stripe_secret_key = fields.Str(allow_none=True)
+    stripe_publishable_key = fields.Str(allow_none=True)
+    # PayPal Credentials
+    paypal_mode = fields.Str(allow_none=True)
+    paypal_sandbox_username = fields.Str(allow_none=True)
+    paypal_sandbox_password = fields.Str(allow_none=True)
+    paypal_sandbox_signature = fields.Str(allow_none=True)
+    paypal_live_username = fields.Str(allow_none=True)
+    paypal_live_password = fields.Str(allow_none=True)
+    paypal_live_signature = fields.Str(allow_none=True)
+
+    #
+    # EMAIL
+    #
+
+    # Email service. (sendgrid,smtp)
+    email_service = fields.Str(allow_none=True)
+    email_from = fields.Str(allow_none=True)
+    email_from_name = fields.Str(allow_none=True)
+    # Sendgrid
+    sendgrid_key = fields.Str(allow_none=True)
+    # SMTP
+    smtp_host = fields.Str(allow_none=True)
+    smtp_username = fields.Str(allow_none=True)
+    smtp_password = fields.Str(allow_none=True)
+    smtp_port = fields.Integer(allow_none=True)
+    smtp_encryption = fields.Str(allow_none=True)  # Can be tls, ssl, none
+    # Google Analytics
+    analytics_key = fields.Str(allow_none=True)
+
+    #
+    # Social links
+    #
+    google_url = fields.Str(allow_none=True)
+    github_url = fields.Str(allow_none=True)
+    twitter_url = fields.Str(allow_none=True)
+    support_url = fields.Str(allow_none=True)
+    facebook_url = fields.Str(allow_none=True)
+    youtube_url = fields.Str(allow_none=True)
+
+    #
+    # Generators
+    #
+    android_app_url = fields.Str(allow_none=True)
+    web_app_url = fields.Str(allow_none=True)
+
+    # Url of Frontend
+    frontend_url = fields.Url(allow_none=True)
+
+
+class SettingSchemaNonAdmin(Schema):
+    """
+    Non Admin Api schema for settings Model
+    """
+    class Meta:
+        """
+        Meta class for setting Api Schema
+        """
+        type_ = 'setting'
+        self_view = 'v1.setting_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+
+    # Name of the application. (Eg. Event Yay!, Open Event)
+    app_name = fields.Str(allow_none=True)
+    # Tagline for the application. (Eg. Event Management and Ticketing, Home)
+    tagline = fields.Str(allow_none=True)
+    # Google Analytics
+    analytics_key = fields.Str(allow_none=True)
+
+    stripe_publishable_key = fields.Str(allow_none=True)
+
+    #
+    # Social links
+    #
+    google_url = fields.Str(allow_none=True)
+    github_url = fields.Str(allow_none=True)
+    twitter_url = fields.Str(allow_none=True)
+    support_url = fields.Str(allow_none=True)
+    facebook_url = fields.Str(allow_none=True)
+    youtube_url = fields.Str(allow_none=True)
+
+    #
+    # Generators
+    #
+    android_app_url = fields.Str(allow_none=True)
+    web_app_url = fields.Str(allow_none=True)
+
+    # Url of Frontend
+    frontend_url = fields.Url(allow_none=True)

--- a/app/api/schema/social_links.py
+++ b/app/api/schema/social_links.py
@@ -1,0 +1,29 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class SocialLinkSchema(Schema):
+    """
+    Social Link API Schema based on Social link model
+    """
+    class Meta:
+        """
+        Meta class for social link schema
+        """
+        type_ = 'social-link'
+        self_view = 'v1.social_link_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    link = fields.Url(required=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.social_link_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'social_link_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')

--- a/app/api/schema/speakers.py
+++ b/app/api/schema/speakers.py
@@ -1,0 +1,66 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class SpeakerSchema(Schema):
+    """
+    Speaker Schema based on Speaker Model
+    """
+
+    class Meta:
+        """
+        Meta class for speaker schema
+        """
+        type_ = 'speaker'
+        self_view = 'v1.speaker_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    email = fields.Str(required=True)
+    photo_url = fields.Url(allow_none=True)
+    thumbnail_image_url = fields.Url(allow_none=True)
+    small_image_url = fields.Url(allow_none=True)
+    icon_image_url = fields.Url(allow_none=True)
+    short_biography = fields.Str(allow_none=True)
+    long_biography = fields.Str(allow_none=True)
+    speaking_experience = fields.Str(allow_none=True)
+    mobile = fields.Str(allow_none=True)
+    website = fields.Url(allow_none=True)
+    twitter = fields.Url(allow_none=True)
+    facebook = fields.Url(allow_none=True)
+    github = fields.Url(allow_none=True)
+    linkedin = fields.Url(allow_none=True)
+    organisation = fields.Str(allow_none=True)
+    is_featured = fields.Boolean(default=False)
+    position = fields.Str(allow_none=True)
+    country = fields.Str(allow_none=True)
+    city = fields.Str(allow_none=True)
+    gender = fields.Str(allow_none=True)
+    heard_from = fields.Str(allow_none=True)
+    sponsorship_required = fields.Str(allow_none=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.speaker_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'speaker_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    user = Relationship(attribute='user',
+                        self_view='v1.speaker_user',
+                        self_view_kwargs={'id': '<id>'},
+                        related_view='v1.user_detail',
+                        related_view_kwargs={'speaker_id': '<id>'},
+                        schema='UserSchema',
+                        type_='user')
+    sessions = Relationship(attribute='sessions',
+                            self_view='v1.speaker_session',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.session_list',
+                            related_view_kwargs={'speaker_id': '<id>'},
+                            schema='SessionSchema',
+                            many=True,
+                            type_='session')

--- a/app/api/schema/speakers_calls.py
+++ b/app/api/schema/speakers_calls.py
@@ -1,0 +1,49 @@
+from marshmallow import validates_schema, validate
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.exceptions import UnprocessableEntity
+from app.api.helpers.utilities import dasherize
+from app.models.speakers_call import SpeakersCall
+
+
+class SpeakersCallSchema(Schema):
+    """
+    Api Schema for Speakers Call model
+    """
+    class Meta:
+        """
+        Meta class for Speakers Call Api Schema
+        """
+        type_ = 'speakers-call'
+        self_view = 'v1.speakers_call_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    @validates_schema(pass_original=True)
+    def validate_date(self, data, original_data):
+        if 'id' in original_data['data']:
+            speakers_calls = SpeakersCall.query.filter_by(id=original_data['data']['id']).one()
+
+            if 'starts_at' not in data:
+                data['starts_at'] = speakers_calls.starts_at
+
+            if 'ends_at' not in data:
+                data['ends_at'] = speakers_calls.ends_at
+
+        if data['starts_at'] >= data['ends_at']:
+            raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'}, "ends-at should be after starts-at")
+
+    id = fields.Str(dump_only=True)
+    announcement = fields.Str(required=True)
+    starts_at = fields.DateTime(required=True)
+    ends_at = fields.DateTime(required=True)
+    hash = fields.Str(allow_none=True)
+    privacy = fields.String(validate=validate.OneOf(choices=["private", "public"]), allow_none=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.speakers_call_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'speakers_call_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')

--- a/app/api/schema/sponsors.py
+++ b/app/api/schema/sponsors.py
@@ -1,0 +1,34 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class SponsorSchema(Schema):
+    """
+    Sponsors API schema based on Sponsors model
+    """
+
+    class Meta:
+        """
+        Meta class for Sponsor schema
+        """
+        type_ = 'sponsor'
+        self_view = 'v1.sponsor_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    description = fields.Str(allow_none=True)
+    url = fields.Url(allow_none=True)
+    level = fields.Integer(allow_none=True)
+    logo_url = fields.Url(allow_none=True)
+    type = fields.Str(allow_none=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.sponsor_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'sponsor_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')

--- a/app/api/schema/stripe_authorization.py
+++ b/app/api/schema/stripe_authorization.py
@@ -1,0 +1,33 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class StripeAuthorizationSchema(Schema):
+    """
+        Stripe Authorization Schema
+    """
+
+    class Meta:
+        """
+        Meta class for StripeAuthorization Api Schema
+        """
+        type_ = 'stripe-authorization'
+        self_view = 'v1.stripe_authorization_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    stripe_secret_key = fields.Str(required=True)
+    stripe_refresh_token = fields.Str(required=True)
+    stripe_publishable_key = fields.Str(required=True)
+    stripe_user_id = fields.Str(required=True)
+    stripe_email = fields.Str(required=True)
+
+    event = Relationship(self_view='v1.stripe_authorization_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'id': '<id>'},
+                         schema="EventSchema",
+                         type_='event')

--- a/app/api/schema/tax.py
+++ b/app/api/schema/tax.py
@@ -1,0 +1,53 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class TaxSchemaPublic(Schema):
+    class Meta:
+        type_ = 'tax'
+        self_view = 'v1.tax_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    rate = fields.Float(validate=lambda n: 0 <= n <= 100, required=True)
+    is_tax_included_in_price = fields.Boolean(default=False)
+    event = Relationship(attribute='event',
+                         self_view='v1.tax_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'tax_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+
+
+class TaxSchema(Schema):
+    class Meta:
+        type_ = 'tax'
+        self_view = 'v1.tax_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    country = fields.Str(allow_none=True)
+    name = fields.Str(required=True)
+    rate = fields.Float(validate=lambda n: 0 <= n <= 100, required=True)
+    tax_id = fields.Str(required=True)
+    should_send_invoice = fields.Boolean(default=False)
+    registered_company = fields.Str(allow_none=True)
+    address = fields.Str(allow_none=True)
+    city = fields.Str(allow_none=True)
+    state = fields.Str(allow_none=True)
+    zip = fields.Integer(allow_none=True)
+    invoice_footer = fields.Str(allow_none=True)
+    is_tax_included_in_price = fields.Boolean(default=False)
+    event = Relationship(attribute='event',
+                         self_view='v1.tax_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'tax_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')

--- a/app/api/schema/ticket_fees.py
+++ b/app/api/schema/ticket_fees.py
@@ -1,0 +1,25 @@
+from marshmallow import validate
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app.api.helpers.static import PAYMENT_CURRENCY_CHOICES
+from app.api.helpers.utilities import dasherize
+
+
+class TicketFeesSchema(Schema):
+    """
+    Api schema for ticket_fee Model
+    """
+    class Meta:
+        """
+        Meta class for image_size Api Schema
+        """
+        type_ = 'ticket-fee'
+        self_view = 'v1.ticket_fee_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Integer(dump_only=True)
+    currency = fields.Str(validate=validate.OneOf(choices=PAYMENT_CURRENCY_CHOICES), allow_none=True)
+    service_fee = fields.Float(validate=lambda n: n >= 0, allow_none=True)
+    maximum_fee = fields.Float(validate=lambda n: n >= 0, allow_none=True)

--- a/app/api/schema/ticket_tags.py
+++ b/app/api/schema/ticket_tags.py
@@ -1,0 +1,37 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class TicketTagSchema(Schema):
+    """
+    Api schema for TicketTag Model
+    """
+
+    class Meta:
+        """
+        Meta class for TicketTag Api Schema
+        """
+        type_ = 'ticket-tag'
+        self_view = 'v1.ticket_tag_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(allow_none=True)
+    tickets = Relationship(attribute='tickets',
+                           self_view='v1.ticket_tag_ticket',
+                           self_view_kwargs={'id': '<id>'},
+                           related_view='v1.ticket_list',
+                           related_view_kwargs={'ticket_tag_id': '<id>'},
+                           schema='TicketSchema',
+                           many=True,
+                           type_='ticket')
+    event = Relationship(attribute='event',
+                         self_view='v1.ticket_tag_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'ticket_tag_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')

--- a/app/api/schema/tickets.py
+++ b/app/api/schema/tickets.py
@@ -1,0 +1,88 @@
+from marshmallow import validates_schema
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.exceptions import UnprocessableEntity
+from app.api.helpers.utilities import dasherize
+from app.models.ticket import Ticket
+
+
+class TicketSchema(Schema):
+    class Meta:
+        type_ = 'ticket'
+        self_view = 'v1.ticket_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    @validates_schema(pass_original=True)
+    def validate_date(self, data, original_data):
+        if 'id' in original_data['data']:
+            ticket = Ticket.query.filter_by(id=original_data['data']['id']).one()
+
+            if 'sales_starts_at' not in data:
+                data['sales_starts_at'] = ticket.sales_starts_at
+
+            if 'sales_ends_at' not in data:
+                data['sales_ends_at'] = ticket.sales_ends_at
+
+        if data['sales_starts_at'] >= data['sales_ends_at']:
+            raise UnprocessableEntity({'pointer': '/data/attributes/sales-ends-at'},
+                                      "sales-ends-at should be after sales-starts-at")
+
+    @validates_schema
+    def validate_quantity(self, data):
+        if 'max_order' in data and 'min_order' in data:
+            if data['max_order'] < data['min_order']:
+                raise UnprocessableEntity({'pointer': '/data/attributes/max-order'},
+                                          "max-order should be greater than min-order")
+
+        if 'quantity' in data and 'min_order' in data:
+            if data['quantity'] < data['min_order']:
+                raise UnprocessableEntity({'pointer': '/data/attributes/quantity'},
+                                          "quantity should be greater than min-order")
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    description = fields.Str(allow_none=True)
+    type = fields.Str(required=True)
+    price = fields.Float(validate=lambda n: n >= 0, allow_none=True)
+    quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    is_description_visible = fields.Boolean(default=False)
+    position = fields.Integer(allow_none=True)
+    is_fee_absorbed = fields.Boolean()
+    sales_starts_at = fields.DateTime(required=True)
+    sales_ends_at = fields.DateTime(required=True)
+    is_hidden = fields.Boolean(default=False)
+    min_order = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    max_order = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.ticket_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'ticket_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    ticket_tags = Relationship(attribute='tags',
+                               self_view='v1.ticket_ticket_tag',
+                               self_view_kwargs={'id': '<id>'},
+                               related_view='v1.ticket_tag_list',
+                               related_view_kwargs={'ticket_id': '<id>'},
+                               schema='TicketTagSchema',
+                               many=True,
+                               type_='ticket-tag')
+    access_codes = Relationship(attribute='access_codes',
+                                self_view='v1.ticket_access_code',
+                                self_view_kwargs={'id': '<id>'},
+                                related_view='v1.access_code_list',
+                                related_view_kwargs={'ticket_id': '<id>'},
+                                schema='AccessCodeSchema',
+                                many=True,
+                                type_='access-code')
+    attendees = Relationship(attribute='ticket_holders',
+                             self_view='v1.ticket_attendees',
+                             self_view_kwargs={'id': '<id>'},
+                             related_view='v1.attendee_list_post',
+                             related_view_kwargs={'ticket_id': '<id>'},
+                             schema='AttendeeSchema',
+                             many=True,
+                             type_='attendee')

--- a/app/api/schema/tracks.py
+++ b/app/api/schema/tracks.py
@@ -1,0 +1,49 @@
+import re
+
+from marshmallow import validates_schema
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.exceptions import UnprocessableEntity
+from app.api.helpers.utilities import dasherize
+
+
+class TrackSchema(Schema):
+    """
+    Api Schema for track model
+    """
+
+    class Meta:
+        """
+        Meta class for User Api Schema
+        """
+        type_ = 'track'
+        self_view = 'v1.track_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    @validates_schema
+    def valid_color(self, data):
+        if not re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', data['color']):
+            return UnprocessableEntity({'pointer': 'data/attributes/color'}, "Color should be proper HEX color code")
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    description = fields.Str(allow_none=True)
+    color = fields.Str(required=True)
+    font_color = fields.Str(allow_none=True, dump_only=True)
+    event = Relationship(attribute='event',
+                         self_view='v1.track_event',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.event_detail',
+                         related_view_kwargs={'track_id': '<id>'},
+                         schema='EventSchema',
+                         type_='event')
+    sessions = Relationship(attribute='sessions',
+                            self_view='v1.track_sessions',
+                            self_view_kwargs={'id': '<id>'},
+                            related_view='v1.session_list',
+                            related_view_kwargs={'track_id': '<id>'},
+                            schema='SessionSchema',
+                            many=True,
+                            type_='session')

--- a/app/api/schema/user_permission.py
+++ b/app/api/schema/user_permission.py
@@ -1,0 +1,25 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema
+
+from app.api.helpers.utilities import dasherize
+
+
+class UserPermissionSchema(Schema):
+    """
+    Api schema for user permission Model
+    """
+    class Meta:
+        """
+        Meta class for user permission Api Schema
+        """
+        type_ = 'user-permission'
+        self_view = 'v1.user_permission_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True)
+    description = fields.Str(allow_none=True)
+
+    unverified_user = fields.Boolean(allow_none=True)
+    anonymous_user = fields.Boolean(allow_none=True)

--- a/app/api/schema/users.py
+++ b/app/api/schema/users.py
@@ -1,0 +1,102 @@
+from marshmallow_jsonapi import fields
+from marshmallow_jsonapi.flask import Schema, Relationship
+
+from app.api.helpers.utilities import dasherize
+
+
+class UserSchema(Schema):
+    """
+    Api schema for User Model
+    """
+    class Meta:
+        """
+        Meta class for User Api Schema
+        """
+        type_ = 'user'
+        self_view = 'v1.user_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    id = fields.Str(dump_only=True)
+    email = fields.Email(required=True)
+    password = fields.Str(required=True, load_only=True)
+    avatar_url = fields.Url(allow_none=True)
+    is_super_admin = fields.Boolean(dump_only=True)
+    is_admin = fields.Boolean(dump_only=True)
+    is_verified = fields.Boolean(dump_only=True)
+    last_accessed_at = fields.DateTime(dump_only=True)
+    created_at = fields.DateTime(dump_only=True)
+    deleted_at = fields.DateTime(dump_only=True)
+    first_name = fields.Str(allow_none=True)
+    last_name = fields.Str(allow_none=True)
+    details = fields.Str(allow_none=True)
+    contact = fields.Str(allow_none=True)
+    facebook_url = fields.Url(allow_none=True)
+    twitter_url = fields.Url(allow_none=True)
+    instagram_url = fields.Url(allow_none=True)
+    google_plus_url = fields.Url(allow_none=True)
+    original_image_url = fields.Url(allow_none=True)
+    thumbnail_image_url = fields.Url(dump_only=True, allow_none=True)
+    small_image_url = fields.Url(dump_only=True, allow_none=True)
+    icon_image_url = fields.Url(dump_only=True, allow_none=True)
+    notifications = Relationship(
+        attribute='notifications',
+        self_view='v1.user_notification',
+        self_view_kwargs={'id': '<id>'},
+        related_view='v1.notification_list',
+        related_view_kwargs={'user_id': '<id>'},
+        schema='NotificationSchema',
+        many=True,
+        type_='notification')
+    event_invoice = Relationship(
+        attribute='event_invoice',
+        self_view='v1.user_event_invoice',
+        self_view_kwargs={'id': '<id>'},
+        related_view='v1.event_invoice_list',
+        related_view_kwargs={'user_id': '<id>'},
+        schema='EventInvoiceSchema',
+        many=True,
+        type_='event-invoice')
+    speakers = Relationship(
+        attribute='speaker',
+        self_view='v1.user_speaker',
+        self_view_kwargs={'id': '<id>'},
+        related_view='v1.speaker_list',
+        related_view_kwargs={'user_id': '<id>'},
+        schema='SpeakerSchema',
+        many=True,
+        type_='speaker')
+    access_codes = Relationship(
+        attribute='access_codes',
+        self_view='v1.user_access_codes',
+        self_view_kwargs={'id': '<id>'},
+        related_view='v1.access_code_list',
+        related_view_kwargs={'user_id': '<id>'},
+        schema='AccessCodeSchema',
+        type_='access-codes')
+    discount_codes = Relationship(
+        attribute='discount_codes',
+        self_view='v1.user_discount_codes',
+        self_view_kwargs={'id': '<id>'},
+        related_view='v1.discount_code_list',
+        related_view_kwargs={'user_id': '<id>'},
+        schema='DiscountCodeSchema',
+        type_='discount-codes')
+    email_notifications = Relationship(
+        attribute='email_notifications',
+        self_view='v1.user_email_notifications',
+        self_view_kwargs={'id': '<id>'},
+        related_view='v1.email_notification_list',
+        related_view_kwargs={'id': '<id>'},
+        schema='EmailNotificationSchema',
+        many=True,
+        type_='email-notification')
+    sessions = Relationship(
+        attribute='session',
+        self_view='v1.user_session',
+        self_view_kwargs={'id': '<id>'},
+        related_view='v1.session_list',
+        related_view_kwargs={'user_id': '<id>'},
+        schema='SessionSchema',
+        many=True,
+        type_='session')

--- a/app/api/session_types.py
+++ b/app/api/session_types.py
@@ -1,61 +1,16 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-from datetime import datetime
-from marshmallow import validates_schema
 
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.api.helpers.permissions import jwt_required
-from app.models.session_type import SessionType
-from app.models.session import Session
-from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.bootstrap import api
 from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.permission_manager import has_access
 from app.api.helpers.exceptions import ForbiddenException
+from app.api.helpers.permission_manager import has_access
+from app.api.helpers.permissions import jwt_required
 from app.api.helpers.query import event_query
-
-
-class SessionTypeSchema(Schema):
-    """
-    Api Schema for session type model
-    """
-    class Meta:
-        """
-        Meta class for SessionTypeSchema
-        """
-        type_ = 'session-type'
-        self_view = 'v1.session_type_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    @validates_schema
-    def validate_length(self, data):
-        try:
-            datetime.strptime(data['length'], '%H:%M')
-        except ValueError:
-            raise UnprocessableEntity({'pointer': '/data/attributes/length'}, "Length should be in the format %H:%M")
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    length = fields.Str(required=True)
-    event = Relationship(attribute='event',
-                         self_view='v1.session_type_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'session_type_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
-    sessions = Relationship(attribute='sessions',
-                            self_view='v1.session_type_sessions',
-                            self_view_kwargs={'id': '<id>'},
-                            related_view='v1.session_list',
-                            related_view_kwargs={'session_type_id': '<id>'},
-                            schema='SessionSchema',
-                            many=True,
-                            type_='session')
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.session_types import SessionTypeSchema
+from app.models import db
+from app.models.session import Session
+from app.models.session_type import SessionType
 
 
 class SessionTypeListPost(ResourceList):

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -1,138 +1,21 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-from marshmallow import validates_schema
-import marshmallow.validate as validate
 
 from app.api.bootstrap import api
 from app.api.events import Event
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.settings import get_settings
-from app.models.session import Session
-from app.models.track import Track
-from app.models.speaker import Speaker
-from app.models.session_type import SessionType
-from app.models.microlocation import Microlocation
-from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.permission_manager import has_access
-from app.api.helpers.exceptions import ForbiddenException
-from app.api.helpers.permissions import current_identity
 from app.api.helpers.mail import send_email_new_session, send_email_session_accept_reject
 from app.api.helpers.notification import send_notif_new_session_organizer, send_notif_session_accept_reject
+from app.api.helpers.permissions import current_identity
 from app.api.helpers.query import event_query
-
-
-class SessionSchema(Schema):
-    """
-    Api schema for Session Model
-    """
-
-    class Meta:
-        """
-        Meta class for Session Api Schema
-        """
-        type_ = 'session'
-        self_view = 'v1.session_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    @validates_schema(pass_original=True)
-    def validate_date(self, data, original_data):
-        if 'id' in original_data['data']:
-            session = Session.query.filter_by(id=original_data['data']['id']).one()
-
-            if 'starts_at' not in data:
-                data['starts_at'] = session.starts_at
-
-            if 'ends_at' not in data:
-                data['ends_at'] = session.ends_at
-
-            if 'event' not in data:
-                data['event'] = session.event_id
-
-        if data['starts_at'] >= data['ends_at']:
-            raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'}, "ends-at should be after starts-at")
-
-        if 'state' in data:
-            if data['state'] is not 'draft' or not 'pending':
-                if not has_access('is_coorganizer', event_id=data['event']):
-                    return ForbiddenException({'source': ''}, 'Co-organizer access is required.')
-
-        if 'track' in data:
-            if not has_access('is_coorganizer', event_id=data['event']):
-                return ForbiddenException({'source': ''}, 'Co-organizer access is required.')
-
-        if 'microlocation' in data:
-            if not has_access('is_coorganizer', event_id=data['event']):
-                return ForbiddenException({'source': ''}, 'Co-organizer access is required.')
-
-    id = fields.Str(dump_only=True)
-    title = fields.Str(required=True)
-    subtitle = fields.Str(allow_none=True)
-    level = fields.Int(allow_none=True)
-    short_abstract = fields.Str(allow_none=True)
-    long_abstract = fields.Str(allow_none=True)
-    comments = fields.Str(allow_none=True)
-    starts_at = fields.DateTime(required=True)
-    ends_at = fields.DateTime(required=True)
-    language = fields.Str(allow_none=True)
-    slides_url = fields.Url(allow_none=True)
-    video_url = fields.Url(allow_none=True)
-    audio_url = fields.Url(allow_none=True)
-    signup_url = fields.Url(allow_none=True)
-    state = fields.Str(validate=validate.OneOf(choices=["pending", "accepted", "confirmed", "rejected", "draft"]),
-                       allow_none=True, default='draft')
-    created_at = fields.DateTime(dump_only=True)
-    deleted_at = fields.DateTime(dump_only=True)
-    submitted_at = fields.DateTime(allow_none=True)
-    is_mail_sent = fields.Boolean()
-    microlocation = Relationship(attribute='microlocation',
-                                 self_view='v1.session_microlocation',
-                                 self_view_kwargs={'id': '<id>'},
-                                 related_view='v1.microlocation_detail',
-                                 related_view_kwargs={'session_id': '<id>'},
-                                 schema='MicrolocationSchema',
-                                 type_='microlocation')
-    track = Relationship(attribute='track',
-                         self_view='v1.session_track',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.track_detail',
-                         related_view_kwargs={'session_id': '<id>'},
-                         schema='TrackSchema',
-                         type_='track')
-    session_type = Relationship(attribute='session_type',
-                                self_view='v1.session_session_type',
-                                self_view_kwargs={'id': '<id>'},
-                                related_view='v1.session_type_detail',
-                                related_view_kwargs={'session_id': '<id>'},
-                                schema='SessionTypeSchema',
-                                type_='session-type')
-    event = Relationship(attribute='event',
-                         self_view='v1.session_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'session_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
-    speakers = Relationship(
-        attribute='speakers',
-        many=True,
-        self_view='v1.session_speaker',
-        self_view_kwargs={'id': '<id>'},
-        related_view='v1.speaker_list',
-        related_view_kwargs={'session_id': '<id>'},
-        schema='SpeakerSchema',
-        type_='speaker')
-    creator = Relationship(attribute='user',
-                           self_view='v1.session_user',
-                           self_view_kwargs={'id': '<id>'},
-                           related_view='v1.user_detail',
-                           related_view_kwargs={'session_id': '<id>'},
-                           schema='UserSchema',
-                           type_='user')
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.sessions import SessionSchema
+from app.models import db
+from app.models.microlocation import Microlocation
+from app.models.session import Session
+from app.models.session_type import SessionType
+from app.models.speaker import Speaker
+from app.models.track import Track
+from app.settings import get_settings
 
 
 class SessionListPost(ResourceList):

--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -1,14 +1,12 @@
-from flask_rest_jsonapi import ResourceDetail
-from marshmallow_jsonapi.flask import Schema
-from marshmallow_jsonapi import fields
-from flask_jwt import current_identity as current_user, _jwt_required
 from flask import current_app as app
 from flask import request
+from flask_jwt import current_identity as current_user, _jwt_required
+from flask_rest_jsonapi import ResourceDetail
 
 from app.api.bootstrap import api
+from app.api.schema.settings import SettingSchemaAdmin, SettingSchemaNonAdmin
 from app.models import db
 from app.models.setting import Setting
-from app.api.helpers.utilities import dasherize
 
 
 class Environment:
@@ -20,167 +18,6 @@ class Environment:
     STAGING = 'staging'
     PRODUCTION = 'production'
     TESTING = 'testing'
-
-
-class SettingSchemaAdmin(Schema):
-    """
-    Admin Api schema for settings Model
-    """
-    class Meta:
-        """
-        Meta class for setting Api Schema
-        """
-        type_ = 'setting'
-        self_view = 'v1.setting_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    #
-    # General
-    #
-
-    app_environment = fields.Str(default=Environment.PRODUCTION)
-    # Name of the application. (Eg. Event Yay!, Open Event)
-    app_name = fields.Str(allow_none=True)
-    # Tagline for the application. (Eg. Event Management and Ticketing, Home)
-    tagline = fields.Str(allow_none=True)
-    # App secret
-    secret = fields.Str(allow_none=True)
-    # Static domain
-    static_domain = fields.Str(allow_none=True)
-
-    #
-    #  STORAGE
-    #
-
-    # storage place, local, s3, .. can be more in future
-    storage_place = fields.Str(allow_none=True)
-    # S3
-    aws_key = fields.Str(allow_none=True)
-    aws_secret = fields.Str(allow_none=True)
-    aws_bucket_name = fields.Str(allow_none=True)
-    aws_region = fields.Str(allow_none=True)
-    # Google Storage
-    gs_key = fields.Str(allow_none=True)
-    gs_secret = fields.Str(allow_none=True)
-    gs_bucket_name = fields.Str(allow_none=True)
-
-    #
-    # Social Login
-    #
-
-    # Google Auth
-    google_client_id = fields.Str(allow_none=True)
-    google_client_secret = fields.Str(allow_none=True)
-    # FB
-    fb_client_id = fields.Str(allow_none=True)
-    fb_client_secret = fields.Str(allow_none=True)
-    # Twitter
-    tw_consumer_key = fields.Str(allow_none=True)
-    tw_consumer_secret = fields.Str(allow_none=True)
-    # Instagram
-    in_client_id = fields.Str(allow_none=True)
-    in_client_secret = fields.Str(allow_none=True)
-
-    #
-    # Payment Gateway
-    #
-
-    # Stripe Keys
-    stripe_client_id = fields.Str(allow_none=True)
-    stripe_secret_key = fields.Str(allow_none=True)
-    stripe_publishable_key = fields.Str(allow_none=True)
-    # PayPal Credentials
-    paypal_mode = fields.Str(allow_none=True)
-    paypal_sandbox_username = fields.Str(allow_none=True)
-    paypal_sandbox_password = fields.Str(allow_none=True)
-    paypal_sandbox_signature = fields.Str(allow_none=True)
-    paypal_live_username = fields.Str(allow_none=True)
-    paypal_live_password = fields.Str(allow_none=True)
-    paypal_live_signature = fields.Str(allow_none=True)
-
-    #
-    # EMAIL
-    #
-
-    # Email service. (sendgrid,smtp)
-    email_service = fields.Str(allow_none=True)
-    email_from = fields.Str(allow_none=True)
-    email_from_name = fields.Str(allow_none=True)
-    # Sendgrid
-    sendgrid_key = fields.Str(allow_none=True)
-    # SMTP
-    smtp_host = fields.Str(allow_none=True)
-    smtp_username = fields.Str(allow_none=True)
-    smtp_password = fields.Str(allow_none=True)
-    smtp_port = fields.Integer(allow_none=True)
-    smtp_encryption = fields.Str(allow_none=True)  # Can be tls, ssl, none
-    # Google Analytics
-    analytics_key = fields.Str(allow_none=True)
-
-    #
-    # Social links
-    #
-    google_url = fields.Str(allow_none=True)
-    github_url = fields.Str(allow_none=True)
-    twitter_url = fields.Str(allow_none=True)
-    support_url = fields.Str(allow_none=True)
-    facebook_url = fields.Str(allow_none=True)
-    youtube_url = fields.Str(allow_none=True)
-
-    #
-    # Generators
-    #
-    android_app_url = fields.Str(allow_none=True)
-    web_app_url = fields.Str(allow_none=True)
-
-    # Url of Frontend
-    frontend_url = fields.Url(allow_none=True)
-
-
-class SettingSchemaNonAdmin(Schema):
-    """
-    Non Admin Api schema for settings Model
-    """
-    class Meta:
-        """
-        Meta class for setting Api Schema
-        """
-        type_ = 'setting'
-        self_view = 'v1.setting_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-
-    # Name of the application. (Eg. Event Yay!, Open Event)
-    app_name = fields.Str(allow_none=True)
-    # Tagline for the application. (Eg. Event Management and Ticketing, Home)
-    tagline = fields.Str(allow_none=True)
-    # Google Analytics
-    analytics_key = fields.Str(allow_none=True)
-
-    stripe_publishable_key = fields.Str(allow_none=True)
-
-    #
-    # Social links
-    #
-    google_url = fields.Str(allow_none=True)
-    github_url = fields.Str(allow_none=True)
-    twitter_url = fields.Str(allow_none=True)
-    support_url = fields.Str(allow_none=True)
-    facebook_url = fields.Str(allow_none=True)
-    youtube_url = fields.Str(allow_none=True)
-
-    #
-    # Generators
-    #
-    android_app_url = fields.Str(allow_none=True)
-    web_app_url = fields.Str(allow_none=True)
-
-    # Url of Frontend
-    frontend_url = fields.Url(allow_none=True)
 
 
 class SettingDetail(ResourceDetail):

--- a/app/api/social_links.py
+++ b/app/api/social_links.py
@@ -1,38 +1,11 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
 
-from app.api.helpers.utilities import dasherize
+from app.api.bootstrap import api
+from app.api.helpers.query import event_query
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.social_links import SocialLinkSchema
 from app.models import db
 from app.models.social_link import SocialLink
-from app.api.bootstrap import api
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.query import event_query
-
-
-class SocialLinkSchema(Schema):
-    """
-    Social Link API Schema based on Social link model
-    """
-    class Meta:
-        """
-        Meta class for social link schema
-        """
-        type_ = 'social-link'
-        self_view = 'v1.social_link_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    link = fields.Url(required=True)
-    event = Relationship(attribute='event',
-                         self_view='v1.social_link_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'social_link_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
 
 
 class SocialLinkListPost(ResourceList):

--- a/app/api/speakers.py
+++ b/app/api/speakers.py
@@ -1,82 +1,18 @@
-from marshmallow_jsonapi import fields
-from marshmallow_jsonapi.flask import Schema, Relationship
+from flask import request
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
 from flask_rest_jsonapi.exceptions import ObjectNotFound
-from flask import request
 
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.models.speaker import Speaker
-from app.models.session import Session
-from app.models.user import User
-from app.models.event import Event
-from app.api.helpers.db import safe_query
 from app.api.bootstrap import api
-from app.api.helpers.utilities import require_relationship
+from app.api.helpers.db import safe_query
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.query import event_query
-
-
-class SpeakerSchema(Schema):
-    """
-    Speaker Schema based on Speaker Model
-    """
-
-    class Meta:
-        """
-        Meta class for speaker schema
-        """
-        type_ = 'speaker'
-        self_view = 'v1.speaker_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    email = fields.Str(required=True)
-    photo_url = fields.Url(allow_none=True)
-    thumbnail_image_url = fields.Url(allow_none=True)
-    small_image_url = fields.Url(allow_none=True)
-    icon_image_url = fields.Url(allow_none=True)
-    short_biography = fields.Str(allow_none=True)
-    long_biography = fields.Str(allow_none=True)
-    speaking_experience = fields.Str(allow_none=True)
-    mobile = fields.Str(allow_none=True)
-    website = fields.Url(allow_none=True)
-    twitter = fields.Url(allow_none=True)
-    facebook = fields.Url(allow_none=True)
-    github = fields.Url(allow_none=True)
-    linkedin = fields.Url(allow_none=True)
-    organisation = fields.Str(allow_none=True)
-    is_featured = fields.Boolean(default=False)
-    position = fields.Str(allow_none=True)
-    country = fields.Str(allow_none=True)
-    city = fields.Str(allow_none=True)
-    gender = fields.Str(allow_none=True)
-    heard_from = fields.Str(allow_none=True)
-    sponsorship_required = fields.Str(allow_none=True)
-    event = Relationship(attribute='event',
-                         self_view='v1.speaker_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'speaker_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
-    user = Relationship(attribute='user',
-                        self_view='v1.speaker_user',
-                        self_view_kwargs={'id': '<id>'},
-                        related_view='v1.user_detail',
-                        related_view_kwargs={'speaker_id': '<id>'},
-                        schema='UserSchema',
-                        type_='user')
-    sessions = Relationship(attribute='sessions',
-                            self_view='v1.speaker_session',
-                            self_view_kwargs={'id': '<id>'},
-                            related_view='v1.session_list',
-                            related_view_kwargs={'speaker_id': '<id>'},
-                            schema='SessionSchema',
-                            many=True,
-                            type_='session')
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.speakers import SpeakerSchema
+from app.models import db
+from app.models.event import Event
+from app.models.session import Session
+from app.models.speaker import Speaker
+from app.models.user import User
 
 
 class SpeakerListPost(ResourceList):

--- a/app/api/speakers_calls.py
+++ b/app/api/speakers_calls.py
@@ -1,62 +1,15 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-from marshmallow import validates_schema
-import marshmallow.validate as validate
-from sqlalchemy.orm.exc import NoResultFound
 from flask_rest_jsonapi.exceptions import ObjectNotFound
+from sqlalchemy.orm.exc import NoResultFound
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
+from app.api.helpers.exceptions import ForbiddenException
+from app.api.helpers.permission_manager import has_access
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.speakers_calls import SpeakersCallSchema
 from app.models import db
 from app.models.event import Event
-from app.api.helpers.exceptions import UnprocessableEntity
 from app.models.speakers_call import SpeakersCall
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.permission_manager import has_access
-from app.api.helpers.exceptions import ForbiddenException
-
-
-class SpeakersCallSchema(Schema):
-    """
-    Api Schema for Speakers Call model
-    """
-    class Meta:
-        """
-        Meta class for Speakers Call Api Schema
-        """
-        type_ = 'speakers-call'
-        self_view = 'v1.speakers_call_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    @validates_schema(pass_original=True)
-    def validate_date(self, data, original_data):
-        if 'id' in original_data['data']:
-            speakers_calls = SpeakersCall.query.filter_by(id=original_data['data']['id']).one()
-
-            if 'starts_at' not in data:
-                data['starts_at'] = speakers_calls.starts_at
-
-            if 'ends_at' not in data:
-                data['ends_at'] = speakers_calls.ends_at
-
-        if data['starts_at'] >= data['ends_at']:
-            raise UnprocessableEntity({'pointer': '/data/attributes/ends-at'}, "ends-at should be after starts-at")
-
-    id = fields.Str(dump_only=True)
-    announcement = fields.Str(required=True)
-    starts_at = fields.DateTime(required=True)
-    ends_at = fields.DateTime(required=True)
-    hash = fields.Str(allow_none=True)
-    privacy = fields.String(validate=validate.OneOf(choices=["private", "public"]), allow_none=True)
-    event = Relationship(attribute='event',
-                         self_view='v1.speakers_call_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'speakers_call_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
 
 
 class SpeakersCallList(ResourceList):

--- a/app/api/sponsors.py
+++ b/app/api/sponsors.py
@@ -1,45 +1,13 @@
-from marshmallow_jsonapi import fields
-from marshmallow_jsonapi.flask import Schema, Relationship
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
 
-from app.api.helpers.utilities import dasherize
+from app.api.bootstrap import api
+from app.api.helpers.exceptions import ForbiddenException
+from app.api.helpers.permission_manager import has_access
+from app.api.helpers.query import event_query
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.sponsors import SponsorSchema
 from app.models import db
 from app.models.sponsor import Sponsor
-from app.api.bootstrap import api
-from app.api.helpers.utilities import require_relationship
-from app.api.helpers.permission_manager import has_access
-from app.api.helpers.exceptions import ForbiddenException
-from app.api.helpers.query import event_query
-
-
-class SponsorSchema(Schema):
-    """
-    Sponsors API schema based on Sponsors model
-    """
-
-    class Meta:
-        """
-        Meta class for Sponsor schema
-        """
-        type_ = 'sponsor'
-        self_view = 'v1.sponsor_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    description = fields.Str(allow_none=True)
-    url = fields.Url(allow_none=True)
-    level = fields.Integer(allow_none=True)
-    logo_url = fields.Url(allow_none=True)
-    type = fields.Str(allow_none=True)
-    event = Relationship(attribute='event',
-                         self_view='v1.sponsor_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'sponsor_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
 
 
 class SponsorListPost(ResourceList):

--- a/app/api/stripe_authorization.py
+++ b/app/api/stripe_authorization.py
@@ -1,6 +1,4 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.api.bootstrap import api
@@ -8,39 +6,11 @@ from app.api.helpers.db import safe_query
 from app.api.helpers.exceptions import ForbiddenException, ConflictException
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.permissions import jwt_required
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.stripe_authorization import StripeAuthorizationSchema
 from app.models import db
 from app.models.event import Event
-from app.api.helpers.utilities import dasherize, require_relationship
 from app.models.stripe_authorization import StripeAuthorization
-
-
-class StripeAuthorizationSchema(Schema):
-    """
-        Stripe Authorization Schema
-    """
-
-    class Meta:
-        """
-        Meta class for StripeAuthorization Api Schema
-        """
-        type_ = 'stripe-authorization'
-        self_view = 'v1.stripe_authorization_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    stripe_secret_key = fields.Str(required=True)
-    stripe_refresh_token = fields.Str(required=True)
-    stripe_publishable_key = fields.Str(required=True)
-    stripe_user_id = fields.Str(required=True)
-    stripe_email = fields.Str(required=True)
-
-    event = Relationship(self_view='v1.stripe_authorization_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'id': '<id>'},
-                         schema="EventSchema",
-                         type_='event')
 
 
 class StripeAuthorizationListPost(ResourceList):

--- a/app/api/ticket_fees.py
+++ b/app/api/ticket_fees.py
@@ -1,32 +1,9 @@
-from app.api.bootstrap import api
 from flask_rest_jsonapi import ResourceDetail, ResourceList
-from marshmallow import validate
-from marshmallow_jsonapi.flask import Schema
-from marshmallow_jsonapi import fields
 
 from app import db
-from app.api.helpers.static import PAYMENT_CURRENCY_CHOICES
-from app.api.helpers.utilities import dasherize
+from app.api.bootstrap import api
+from app.api.schema.ticket_fees import TicketFeesSchema
 from app.models.ticket_fee import TicketFees
-
-
-class TicketFeesSchema(Schema):
-    """
-    Api schema for ticket_fee Model
-    """
-    class Meta:
-        """
-        Meta class for image_size Api Schema
-        """
-        type_ = 'ticket-fee'
-        self_view = 'v1.ticket_fee_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Integer(dump_only=True)
-    currency = fields.Str(validate=validate.OneOf(choices=PAYMENT_CURRENCY_CHOICES), allow_none=True)
-    service_fee = fields.Float(validate=lambda n: n >= 0, allow_none=True)
-    maximum_fee = fields.Float(validate=lambda n: n >= 0, allow_none=True)
 
 
 class TicketFeeList(ResourceList):

--- a/app/api/ticket_tags.py
+++ b/app/api/ticket_tags.py
@@ -1,49 +1,14 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.models.ticket import Ticket, TicketTag, ticket_tags_table
 from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import require_relationship
 from app.api.helpers.exceptions import ForbiddenException
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.query import event_query
-
-
-class TicketTagSchema(Schema):
-    """
-    Api schema for TicketTag Model
-    """
-
-    class Meta:
-        """
-        Meta class for TicketTag Api Schema
-        """
-        type_ = 'ticket-tag'
-        self_view = 'v1.ticket_tag_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(allow_none=True)
-    tickets = Relationship(attribute='tickets',
-                           self_view='v1.ticket_tag_ticket',
-                           self_view_kwargs={'id': '<id>'},
-                           related_view='v1.ticket_list',
-                           related_view_kwargs={'ticket_tag_id': '<id>'},
-                           schema='TicketSchema',
-                           many=True,
-                           type_='ticket')
-    event = Relationship(attribute='event',
-                         self_view='v1.ticket_tag_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'ticket_tag_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.ticket_tags import TicketTagSchema
+from app.models import db
+from app.models.ticket import Ticket, TicketTag, ticket_tags_table
 
 
 class TicketTagListPost(ResourceList):

--- a/app/api/tickets.py
+++ b/app/api/tickets.py
@@ -1,102 +1,17 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-from marshmallow import validates_schema
 from flask_rest_jsonapi.exceptions import ObjectNotFound
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.models.ticket import Ticket, TicketTag, ticket_tags_table
-from app.models.access_code import AccessCode
-from app.models.order import Order
-from app.api.helpers.exceptions import UnprocessableEntity
-from app.models.ticket_holder import TicketHolder
 from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import require_relationship
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.query import event_query
-
-
-class TicketSchema(Schema):
-    class Meta:
-        type_ = 'ticket'
-        self_view = 'v1.ticket_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    @validates_schema(pass_original=True)
-    def validate_date(self, data, original_data):
-        if 'id' in original_data['data']:
-            ticket = Ticket.query.filter_by(id=original_data['data']['id']).one()
-
-            if 'sales_starts_at' not in data:
-                data['sales_starts_at'] = ticket.sales_starts_at
-
-            if 'sales_ends_at' not in data:
-                data['sales_ends_at'] = ticket.sales_ends_at
-
-        if data['sales_starts_at'] >= data['sales_ends_at']:
-            raise UnprocessableEntity({'pointer': '/data/attributes/sales-ends-at'},
-                                      "sales-ends-at should be after sales-starts-at")
-
-    @validates_schema
-    def validate_quantity(self, data):
-        if 'max_order' in data and 'min_order' in data:
-            if data['max_order'] < data['min_order']:
-                raise UnprocessableEntity({'pointer': '/data/attributes/max-order'},
-                                          "max-order should be greater than min-order")
-
-        if 'quantity' in data and 'min_order' in data:
-            if data['quantity'] < data['min_order']:
-                raise UnprocessableEntity({'pointer': '/data/attributes/quantity'},
-                                          "quantity should be greater than min-order")
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    description = fields.Str(allow_none=True)
-    type = fields.Str(required=True)
-    price = fields.Float(validate=lambda n: n >= 0, allow_none=True)
-    quantity = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    is_description_visible = fields.Boolean(default=False)
-    position = fields.Integer(allow_none=True)
-    is_fee_absorbed = fields.Boolean()
-    sales_starts_at = fields.DateTime(required=True)
-    sales_ends_at = fields.DateTime(required=True)
-    is_hidden = fields.Boolean(default=False)
-    min_order = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    max_order = fields.Integer(validate=lambda n: n >= 0, allow_none=True)
-    event = Relationship(attribute='event',
-                         self_view='v1.ticket_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'ticket_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
-    ticket_tags = Relationship(attribute='tags',
-                               self_view='v1.ticket_ticket_tag',
-                               self_view_kwargs={'id': '<id>'},
-                               related_view='v1.ticket_tag_list',
-                               related_view_kwargs={'ticket_id': '<id>'},
-                               schema='TicketTagSchema',
-                               many=True,
-                               type_='ticket-tag')
-    access_codes = Relationship(attribute='access_codes',
-                                self_view='v1.ticket_access_code',
-                                self_view_kwargs={'id': '<id>'},
-                                related_view='v1.access_code_list',
-                                related_view_kwargs={'ticket_id': '<id>'},
-                                schema='AccessCodeSchema',
-                                many=True,
-                                type_='access-code')
-    attendees = Relationship(attribute='ticket_holders',
-                             self_view='v1.ticket_attendees',
-                             self_view_kwargs={'id': '<id>'},
-                             related_view='v1.attendee_list_post',
-                             related_view_kwargs={'ticket_id': '<id>'},
-                             schema='AttendeeSchema',
-                             many=True,
-                             type_='attendee')
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.tickets import TicketSchema
+from app.models import db
+from app.models.access_code import AccessCode
+from app.models.order import Order
+from app.models.ticket import Ticket, TicketTag, ticket_tags_table
+from app.models.ticket_holder import TicketHolder
 
 
 class TicketListPost(ResourceList):

--- a/app/api/tracks.py
+++ b/app/api/tracks.py
@@ -1,62 +1,15 @@
-import re
-
 from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-from marshmallow import pre_load, validates_schema
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
-from app.models import db
-from app.models.track import Track
-from app.models.session import Session
-from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.helpers.db import safe_query
-from app.api.helpers.utilities import require_relationship
 from app.api.helpers.exceptions import ForbiddenException
 from app.api.helpers.permission_manager import has_access
 from app.api.helpers.query import event_query
-
-
-class TrackSchema(Schema):
-    """
-    Api Schema for track model
-    """
-
-    class Meta:
-        """
-        Meta class for User Api Schema
-        """
-        type_ = 'track'
-        self_view = 'v1.track_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    @validates_schema
-    def valid_color(self, data):
-        if not re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', data['color']):
-            return UnprocessableEntity({'pointer': 'data/attributes/color'}, "Color should be proper HEX color code")
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    description = fields.Str(allow_none=True)
-    color = fields.Str(required=True)
-    font_color = fields.Str(allow_none=True, dump_only=True)
-    event = Relationship(attribute='event',
-                         self_view='v1.track_event',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.event_detail',
-                         related_view_kwargs={'track_id': '<id>'},
-                         schema='EventSchema',
-                         type_='event')
-    sessions = Relationship(attribute='sessions',
-                            self_view='v1.track_sessions',
-                            self_view_kwargs={'id': '<id>'},
-                            related_view='v1.session_list',
-                            related_view_kwargs={'track_id': '<id>'},
-                            schema='SessionSchema',
-                            many=True,
-                            type_='session')
+from app.api.helpers.utilities import require_relationship
+from app.api.schema.tracks import TrackSchema
+from app.models import db
+from app.models.session import Session
+from app.models.track import Track
 
 
 class TrackListPost(ResourceList):

--- a/app/api/user_permission.py
+++ b/app/api/user_permission.py
@@ -1,32 +1,9 @@
 from flask_rest_jsonapi import ResourceDetail, ResourceList
-from marshmallow_jsonapi.flask import Schema
-from marshmallow_jsonapi import fields
 
 from app.api.bootstrap import api
-from app.api.helpers.utilities import dasherize
+from app.api.schema.user_permission import UserPermissionSchema
 from app.models import db
 from app.models.user_permission import UserPermission
-
-
-class UserPermissionSchema(Schema):
-    """
-    Api schema for user permission Model
-    """
-    class Meta:
-        """
-        Meta class for user permission Api Schema
-        """
-        type_ = 'user-permission'
-        self_view = 'v1.user_permission_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    description = fields.Str(allow_none=True)
-
-    unverified_user = fields.Boolean(allow_none=True)
-    anonymous_user = fields.Boolean(allow_none=True)
 
 
 class UserPermissionList(ResourceList):

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -1,125 +1,27 @@
 import base64
+
+from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
+
 from app import get_settings
 from app.api.bootstrap import api
-from flask_rest_jsonapi import ResourceDetail, ResourceList, ResourceRelationship
-from marshmallow_jsonapi.flask import Schema, Relationship
-from marshmallow_jsonapi import fields
-
 from app.api.helpers.files import create_save_image_sizes, make_frontend_url
 from app.api.helpers.mail import send_email_confirmation, send_email_change_user_email, send_email_with_action
-from app.api.helpers.utilities import dasherize, get_serializer, str_generator
+from app.api.helpers.permissions import is_user_itself
+from app.api.helpers.utilities import get_serializer, str_generator
+from app.api.schema.users import UserSchema
 from app.models import db
-from app.models.mail import USER_REGISTER_WITH_PASSWORD
-from app.models.user import User
-from app.models.notification import Notification
-from app.models.users_events_role import UsersEventsRoles
-from app.models.email_notification import EmailNotification
-from app.models.event_invoice import EventInvoice
 from app.models.access_code import AccessCode
 from app.models.discount_code import DiscountCode
-from app.api.helpers.permissions import is_user_itself
+from app.models.email_notification import EmailNotification
+from app.models.event_invoice import EventInvoice
+from app.models.mail import USER_REGISTER_WITH_PASSWORD
+from app.models.notification import Notification
 from app.models.speaker import Speaker
 from app.models.session import Session
 from app.api.helpers.exceptions import ConflictException
 from app.api.helpers.db import safe_query
-
-
-class UserSchema(Schema):
-    """
-    Api schema for User Model
-    """
-    class Meta:
-        """
-        Meta class for User Api Schema
-        """
-        type_ = 'user'
-        self_view = 'v1.user_detail'
-        self_view_kwargs = {'id': '<id>'}
-        inflect = dasherize
-
-    id = fields.Str(dump_only=True)
-    email = fields.Email(required=True)
-    password = fields.Str(required=True, load_only=True)
-    avatar_url = fields.Url(allow_none=True)
-    is_super_admin = fields.Boolean(dump_only=True)
-    is_admin = fields.Boolean(dump_only=True)
-    is_verified = fields.Boolean(dump_only=True)
-    last_accessed_at = fields.DateTime(dump_only=True)
-    created_at = fields.DateTime(dump_only=True)
-    deleted_at = fields.DateTime(dump_only=True)
-    first_name = fields.Str(allow_none=True)
-    last_name = fields.Str(allow_none=True)
-    details = fields.Str(allow_none=True)
-    contact = fields.Str(allow_none=True)
-    facebook_url = fields.Url(allow_none=True)
-    twitter_url = fields.Url(allow_none=True)
-    instagram_url = fields.Url(allow_none=True)
-    google_plus_url = fields.Url(allow_none=True)
-    original_image_url = fields.Url(allow_none=True)
-    thumbnail_image_url = fields.Url(dump_only=True, allow_none=True)
-    small_image_url = fields.Url(dump_only=True, allow_none=True)
-    icon_image_url = fields.Url(dump_only=True, allow_none=True)
-    notifications = Relationship(
-        attribute='notifications',
-        self_view='v1.user_notification',
-        self_view_kwargs={'id': '<id>'},
-        related_view='v1.notification_list',
-        related_view_kwargs={'user_id': '<id>'},
-        schema='NotificationSchema',
-        many=True,
-        type_='notification')
-    event_invoice = Relationship(
-        attribute='event_invoice',
-        self_view='v1.user_event_invoice',
-        self_view_kwargs={'id': '<id>'},
-        related_view='v1.event_invoice_list',
-        related_view_kwargs={'user_id': '<id>'},
-        schema='EventInvoiceSchema',
-        many=True,
-        type_='event-invoice')
-    speakers = Relationship(
-        attribute='speaker',
-        self_view='v1.user_speaker',
-        self_view_kwargs={'id': '<id>'},
-        related_view='v1.speaker_list',
-        related_view_kwargs={'user_id': '<id>'},
-        schema='SpeakerSchema',
-        many=True,
-        type_='speaker')
-    sessions = Relationship(
-        attribute='session',
-        self_view='v1.user_session',
-        self_view_kwargs={'id': '<id>'},
-        related_view='v1.session_list',
-        related_view_kwargs={'user_id': '<id>'},
-        schema='SessionSchema',
-        many=True,
-        type_='session')
-    access_codes = Relationship(
-        attribute='access_codes',
-        self_view='v1.user_access_codes',
-        self_view_kwargs={'id': '<id>'},
-        related_view='v1.access_code_list',
-        related_view_kwargs={'user_id': '<id>'},
-        schema='AccessCodeSchema',
-        type_='access-codes')
-    discount_codes = Relationship(
-        attribute='discount_codes',
-        self_view='v1.user_discount_codes',
-        self_view_kwargs={'id': '<id>'},
-        related_view='v1.discount_code_list',
-        related_view_kwargs={'user_id': '<id>'},
-        schema='DiscountCodeSchema',
-        type_='discount-codes')
-    email_notifications = Relationship(
-        attribute='email_notifications',
-        self_view='v1.user_email_notifications',
-        self_view_kwargs={'id': '<id>'},
-        related_view='v1.email_notification_list',
-        related_view_kwargs={'id': '<id>'},
-        schema='EmailNotificationSchema',
-        many=True,
-        type_='email-notification')
+from app.models.user import User
+from app.models.users_events_role import UsersEventsRoles
 
 
 class UserList(ResourceList):

--- a/tests/unittests/api/validation/test_discount_codes.py
+++ b/tests/unittests/api/validation/test_discount_codes.py
@@ -2,7 +2,8 @@ import unittest
 
 from app import current_app as app
 from tests.unittests.utils import OpenEventTestCase
-from app.api.discount_codes import DiscountCodeSchemaTicket, UnprocessableEntity
+from app.api.discount_codes import UnprocessableEntity
+from app.api.schema.discount_codes import DiscountCodeSchemaTicket
 from app.factories.discount_code import DiscountCodeFactory
 from app.models import db
 from tests.unittests.setup_database import Setup

--- a/tests/unittests/api/validation/test_discount_codes.py
+++ b/tests/unittests/api/validation/test_discount_codes.py
@@ -2,7 +2,7 @@ import unittest
 
 from app import current_app as app
 from tests.unittests.utils import OpenEventTestCase
-from app.api.discount_codes import UnprocessableEntity
+from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.schema.discount_codes import DiscountCodeSchemaTicket
 from app.factories.discount_code import DiscountCodeFactory
 from app.models import db

--- a/tests/unittests/api/validation/test_events.py
+++ b/tests/unittests/api/validation/test_events.py
@@ -4,7 +4,8 @@ from pytz import timezone
 
 from app import current_app as app
 from tests.unittests.utils import OpenEventTestCase
-from app.api.events import EventSchema, UnprocessableEntity
+from app.api.events import UnprocessableEntity
+from app.api.schema.events import EventSchema
 from app.factories.event import EventFactoryBasic
 from app.models import db
 from tests.unittests.setup_database import Setup

--- a/tests/unittests/api/validation/test_events.py
+++ b/tests/unittests/api/validation/test_events.py
@@ -4,7 +4,7 @@ from pytz import timezone
 
 from app import current_app as app
 from tests.unittests.utils import OpenEventTestCase
-from app.api.events import UnprocessableEntity
+from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.schema.events import EventSchema
 from app.factories.event import EventFactoryBasic
 from app.models import db

--- a/tests/unittests/api/validation/test_sessions.py
+++ b/tests/unittests/api/validation/test_sessions.py
@@ -4,7 +4,8 @@ from pytz import timezone
 
 from app import current_app as app
 from tests.unittests.utils import OpenEventTestCase
-from app.api.sessions import SessionSchema, UnprocessableEntity
+from app.api.sessions import UnprocessableEntity
+from app.api.schema.sessions import SessionSchema
 from app.factories.session import SessionFactory
 from app.models import db
 from tests.unittests.setup_database import Setup

--- a/tests/unittests/api/validation/test_sessions.py
+++ b/tests/unittests/api/validation/test_sessions.py
@@ -4,7 +4,7 @@ from pytz import timezone
 
 from app import current_app as app
 from tests.unittests.utils import OpenEventTestCase
-from app.api.sessions import UnprocessableEntity
+from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.schema.sessions import SessionSchema
 from app.factories.session import SessionFactory
 from app.models import db

--- a/tests/unittests/api/validation/test_speakers_call.py
+++ b/tests/unittests/api/validation/test_speakers_call.py
@@ -4,7 +4,7 @@ from pytz import timezone
 
 from app import current_app as app
 from tests.unittests.utils import OpenEventTestCase
-from app.api.speakers_calls import UnprocessableEntity
+from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.schema.speakers_calls import SpeakersCallSchema
 from app.factories.speakers_call import SpeakersCallFactory
 from app.models import db

--- a/tests/unittests/api/validation/test_speakers_call.py
+++ b/tests/unittests/api/validation/test_speakers_call.py
@@ -4,7 +4,8 @@ from pytz import timezone
 
 from app import current_app as app
 from tests.unittests.utils import OpenEventTestCase
-from app.api.speakers_calls import SpeakersCallSchema, UnprocessableEntity
+from app.api.speakers_calls import UnprocessableEntity
+from app.api.schema.speakers_calls import SpeakersCallSchema
 from app.factories.speakers_call import SpeakersCallFactory
 from app.models import db
 from tests.unittests.setup_database import Setup

--- a/tests/unittests/api/validation/test_tickets.py
+++ b/tests/unittests/api/validation/test_tickets.py
@@ -4,7 +4,8 @@ from pytz import timezone
 
 from app import current_app as app
 from tests.unittests.utils import OpenEventTestCase
-from app.api.tickets import TicketSchema, UnprocessableEntity
+from app.api.tickets import UnprocessableEntity
+from app.api.schema.tickets import TicketSchema
 from app.factories.ticket import TicketFactory
 from app.models import db
 from tests.unittests.setup_database import Setup

--- a/tests/unittests/api/validation/test_tickets.py
+++ b/tests/unittests/api/validation/test_tickets.py
@@ -4,7 +4,7 @@ from pytz import timezone
 
 from app import current_app as app
 from tests.unittests.utils import OpenEventTestCase
-from app.api.tickets import UnprocessableEntity
+from app.api.helpers.exceptions import UnprocessableEntity
 from app.api.schema.tickets import TicketSchema
 from app.factories.ticket import TicketFactory
 from app.models import db


### PR DESCRIPTION
partially #4337 

Changes:
- Refactor: move API schemas to a different folder
- Separate public and coorganizer level schemas for events API

Refactor of all of the other APIs will be done in a seperate PR.
This is high priority so that the all the schema are moved to a different folder and any PRs adding new relationship don't cause a merge conflict

