### PR TITLE
`include` refactor: attendees API

### DIFF
--- a/app/api/attendees.py
+++ b/app/api/attendees.py
@@ -8,7 +8,7 @@ from app.api.helpers.permission_manager import has_access
 from app.api.helpers.permissions import jwt_required
 from app.api.helpers.query import event_query
 from app.api.helpers.utilities import require_relationship
-from app.api.schema.attendees import AttendeeSchema
+from app.api.schema.attendees import AttendeeSchema, AttendeeSchemaPublic
 from app.models import db
 from app.models.order import Order
 from app.models.ticket import Ticket
@@ -36,6 +36,10 @@ class AttendeeList(ResourceList):
     """
     List Attendees
     """
+    def before_get(self, args, kwargs):
+        if kwargs.get('user_id'):
+            self.schema = AttendeeSchemaPublic
+
     def query(self, view_kwargs):
         query_ = self.session.query(TicketHolder)
 

--- a/app/api/schema/attendees.py
+++ b/app/api/schema/attendees.py
@@ -4,7 +4,7 @@ from marshmallow_jsonapi.flask import Schema, Relationship
 from app.api.helpers.utilities import dasherize
 
 
-class AttendeeSchema(Schema):
+class AttendeeSchemaPublic(Schema):
     """
     Api schema for Ticket Holder Model
     """
@@ -29,13 +29,6 @@ class AttendeeSchema(Schema):
     ticket_id = fields.Str(allow_none=True)
     is_checked_in = fields.Boolean()
     pdf_url = fields.Url(required=True)
-    ticket = Relationship(attribute='ticket',
-                          self_view='v1.attendee_ticket',
-                          self_view_kwargs={'id': '<id>'},
-                          related_view='v1.ticket_detail',
-                          related_view_kwargs={'attendee_id': '<id>'},
-                          schema='TicketSchemaPublic',
-                          type_='ticket')
     event = Relationship(attribute='event',
                          self_view='v1.attendee_event',
                          self_view_kwargs={'id': '<id>'},
@@ -43,12 +36,6 @@ class AttendeeSchema(Schema):
                          related_view_kwargs={'attendee_id': '<id>'},
                          schema='EventSchema',
                          type_='event')
-    order = Relationship(self_view='v1.attendee_order',
-                         self_view_kwargs={'id': '<id>'},
-                         related_view='v1.order_detail',
-                         related_view_kwargs={'attendee_id': '<id>'},
-                         schema='OrderSchema',
-                         type_='order')
     user = Relationship(attribute='user',
                         self_view='v1.attendee_user',
                         self_view_kwargs={'id': '<id>'},
@@ -56,3 +43,32 @@ class AttendeeSchema(Schema):
                         related_view_kwargs={'attendee_id': '<id>'},
                         schema='UserSchemaPublic',
                         type_='user')
+
+
+class AttendeeSchema(AttendeeSchemaPublic):
+    """
+    Api schema for Ticket Holder Model
+    """
+
+    class Meta:
+        """
+        Meta class for Attendee API Schema
+        """
+        type_ = 'attendee'
+        self_view = 'v1.attendee_detail'
+        self_view_kwargs = {'id': '<id>'}
+        inflect = dasherize
+
+    ticket = Relationship(attribute='ticket',
+                          self_view='v1.attendee_ticket',
+                          self_view_kwargs={'id': '<id>'},
+                          related_view='v1.ticket_detail',
+                          related_view_kwargs={'attendee_id': '<id>'},
+                          schema='TicketSchemaPublic',
+                          type_='ticket')
+    order = Relationship(self_view='v1.attendee_order',
+                         self_view_kwargs={'id': '<id>'},
+                         related_view='v1.order_detail',
+                         related_view_kwargs={'attendee_id': '<id>'},
+                         schema='OrderSchema',
+                         type_='order')

--- a/app/api/schema/orders.py
+++ b/app/api/schema/orders.py
@@ -59,7 +59,7 @@ class OrderSchema(Schema):
                              self_view_kwargs={'order_identifier': '<identifier>'},
                              related_view='v1.attendee_list',
                              related_view_kwargs={'order_identifier': '<identifier>'},
-                             schema='AttendeeSchema',
+                             schema='AttendeeSchemaPublic',
                              many=True,
                              type_='attendee')
 

--- a/app/api/schema/users.py
+++ b/app/api/schema/users.py
@@ -156,7 +156,7 @@ class UserSchema(UserSchemaPublic):
         self_view_kwargs={'id': '<id>'},
         related_view='v1.attendee_list',
         related_view_kwargs={'user_id': '<id>'},
-        schema='AttendeeSchema',
+        schema='AttendeeSchemaPublic',
         many=True,
         type_='attendee')
     events = Relationship(


### PR DESCRIPTION
fixes #4338 .
After this, only orders API will remain, which will be addressed in a separate issue 