### PR TITLE
Changed default start date format from ddmmyy to mmddyy

### DIFF
--- a/app/static/js/events/wizard/sessions-speakers/vue-models.js
+++ b/app/static/js/events/wizard/sessions-speakers/vue-models.js
@@ -1,7 +1,7 @@
-Date.prototype.ddmmyyyy = function() {
+Date.prototype.mmddyyyy = function() {
   var mm = this.getMonth() + 1;
   var dd = this.getDate();
-  return [(dd>9 ? '' : '0') + dd, (mm>9 ? '' : '0') + mm, this.getFullYear()].join('/');
+  return [(mm>9 ? '' : '0') + mm, (dd>9 ? '' : '0') + dd, this.getFullYear()].join('/');
 };
 
 Date.prototype.hhmm = function() {
@@ -76,7 +76,7 @@ function getNewMicrolocation(name) {
 function getCallForSpeakers(event) {
     var callForSpeakers = _.clone(CALL_FOR_SPEAKERS);
     var currentDate = (new Date());
-    callForSpeakers.start_date = currentDate.ddmmyyyy();
+    callForSpeakers.start_date = currentDate.mmddyyyy();
     callForSpeakers.start_time = currentDate.hhmm();
     callForSpeakers.end_date = event.end_time_date;
     callForSpeakers.end_time = event.end_time_time;


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #4472 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->

#### Short description of what this resolves:
Everywhere in date parsing to javascript models the format of date used is mm/dd/yyyy. But the start date initializor in call for speaker section was in the format dd/mm/yyyy which was causing error for saving of start_date information. This has been fixed in this PR.
