### PR TITLE
Show Speaker Session Modal after Speaker Information is saved

### DIFF
--- a/app/templates/gentelella/guest/event/cfs.html
+++ b/app/templates/gentelella/guest/event/cfs.html
@@ -177,5 +177,8 @@
                 }
             }
         });
+        {% if show_speaker_modal == "True" %}
+            $('#speaker-session-modal').modal('show');
+        {% endif %}
 </script>
 {% endblock %}

--- a/app/views/public/event_detail.py
+++ b/app/views/public/event_detail.py
@@ -203,6 +203,7 @@ def display_event_schedule_xcal(identifier):
 
 @event_detail.route('/<identifier>/cfs/')
 def display_event_cfs(identifier, via_hash=False):
+    show_speaker_modal = request.args.get('show_speaker_modal', '')
     event = get_published_event_or_abort(identifier)
     placeholder_images = DataGetter.get_event_default_images()
     if login.current_user.is_authenticated:
@@ -270,7 +271,8 @@ def display_event_cfs(identifier, via_hash=False):
                            via_hash=via_hash,
                            custom_placeholder=custom_placeholder,
                            user_speaker=user_speaker,
-                           existing_sessions=existing_sessions)
+                           existing_sessions=existing_sessions,
+                           show_speaker_modal=show_speaker_modal)
 
 
 @event_detail.route('/cfs/<hash>/', methods=('GET', 'POST'))
@@ -503,7 +505,7 @@ def process_event_cfs_speaker(identifier, via_hash=False):
         DataManager.add_speaker_to_event(request, event.id)
         if login.current_user.is_authenticated:
             flash("You have been registered as Speaker", "success")
-            return redirect(url_for('event_detail.display_event_cfs', identifier=identifier))
+            return redirect(url_for('event_detail.display_event_cfs', identifier=identifier, show_speaker_modal=True))
         else:
             flash(Markup(
                 "You have been registered as Speaker. Please login/register with <strong><u>" + email + "</u></strong> to manage it."),

--- a/app/views/users/my_sessions.py
+++ b/app/views/users/my_sessions.py
@@ -123,9 +123,10 @@ def process_speaker_view(speaker_id):
 
     if request.method == 'POST':
         speaker = DataGetter.get_speaker(speaker_id)
+        event = DataGetter.get_event(speaker.event_id)
         DataManager.edit_speaker(request, speaker)
         flash("The speaker has been updated successfully", "success")
-        return redirect(url_for('.display_my_sessions_view', event_id=speaker.event_id))
+        return redirect(url_for('event_detail.display_event_cfs', identifier=event.identifier, show_speaker_modal=True))
 
 
 @my_sessions.route('/<int:event_id>/speakers/<int:speaker_id>/avatar', methods=('DELETE',))


### PR DESCRIPTION
Fixes #4491

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:

Show Speaker Session Modal after Speaker Information is saved

