### PR TITLE
Fixes TypeError: __init__() got an unexpected keyword argument 'created_at'

### DIFF
--- a/app/models/discount_code.py
+++ b/app/models/discount_code.py
@@ -40,6 +40,7 @@ class DiscountCode(db.Model):
                  valid_from=None,
                  valid_till=None,
                  is_active=True,
+                 created_at=None,
                  used_for=None,
                  event_id=None,
                  tickets=None,


### PR DESCRIPTION
Fixes #4464

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `nextgen` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Fixes : TypeError: __init__() got an unexpected keyword argument 'created_at'

#### Changes proposed in this pull request:

Add created_at field in DiscountCode model constructor


