### PR TITLE
[WIP] Adding code to accept rgba color code

### DIFF
--- a/app/models/track.py
+++ b/app/models/track.py
@@ -34,8 +34,13 @@ class Track(db.Model):
 
     @property
     def font_color(self):
-        h = self.color.lstrip('#')
-        a = 1 - (0.299 * int(h[0:2], 16) + 0.587 * int(h[2:4], 16) + 0.114 * int(h[4:6], 16))/255
+        if self.color.startswith('#'):
+            h = self.color.lstrip('#')
+            a = 1 - (0.299 * int(h[0:2], 16) + 0.587 * int(h[2:4], 16) + 0.114 * int(h[4:6], 16))/255
+        elif self.color.startswith('rgba'):
+            h = self.color.lstrip('rgba').replace('(', '', 1).replace(')', '', 1)
+            h = h.split(',')
+            a = 1 - (0.299 * int(int(h[0]), 16) + 0.587 * int(int(h[1]), 16) + 0.114 * int(int(h[2]), 16)) / 255
         return '#000000' if (a < 0.5) else '#ffffff'
 
     @property

--- a/docs/api/api_blueprint.apib
+++ b/docs/api/api_blueprint.apib
@@ -14835,7 +14835,7 @@ Data related to the various tracks (e.g, python, AI, etc.) associated with the v
 |:----------|-------------|------|----------|
 | `name`  | Name of the track | string | **yes** |
 | `description` | Description of the track | string | - |
-| `color` | Color code of the track | string | **yes** |
+| `color` | Color code of the track **(can be in hex notation(e.g, #a04b4b) or decimal notation from 0 to 255(e.g, rgba(160, 75, 75, 0.5)))** | string | **yes** |
 | `font-color` | Font Color of the track **(black/white: no user role - automatically updated)** | string | - |
 
 ## Tracks Collection [/v1/tracks{?page%5bsize%5d,page%5bnumber%5d,sort,filter}]


### PR DESCRIPTION
Fixes #4508 


#### Short description of what this resolves:

Previously when a color for a track was selected from the slider, it was giving an error due to the absence of the code to handle the `rgba` format

#### Changes proposed in this pull request:

- Added code for the same
 @niranjan94 I am not sure about the alpha channel in the rgba format which decides for the opacity, and to use it to decide the font color. Help.



